### PR TITLE
Use SSE for floating point math, no more x87.

### DIFF
--- a/SixTrack/crlibm/Makefile.template
+++ b/SixTrack/crlibm/Makefile.template
@@ -13,7 +13,8 @@ crlibm.a: $(OBJS)
 	ar -rv crlibm.a $(OBJS)
 AM1_CFLAGS = -fPIC -std=c99 -Wall -Wshadow -Wpointer-arith  -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline -pedantic -fno-strict-aliasing
 DEFS = -DLINUX_INLINE -DHAVE_CONFIG_H -I.
-CFLAGS = -g -O2 -m32
+CMATHFLAGS = -mfpmath=sse -msse2
+CFLAGS = -g -O2 -m32 $(CMATHFLAGS)
 COMPILE1 = $(CC) $(DEFS) $(AM1_CFLAGS) $(CFLAGS)
 csh_fast.o: csh_fast.c crlibm.h crlibm_private.h scs.h \
         scs_config.h scs_private.h crlibm_config.h \
@@ -74,11 +75,11 @@ disable_xp.o: disable_xp.c
 enable_xp.o: enable_xp.c
 	$(COMPILE1) -c enable_xp.c
 round_near.o: round_near.c
-	$(CC) -m32 -std=c99 -W -Wall -pedantic -c round_near.c
+	$(CC) -m32 -std=c99 -W -Wall -pedantic $(CMATHFLAGS) -c round_near.c
 dtoa_c.o: dtoa_c.c
-	$(CC) -m32 -std=c99 -W -Wall -pedantic -c dtoa_c.c
+	$(CC) -m32 -std=c99 -W -Wall -pedantic $(CMATHFLAGS) -c dtoa_c.c
 dtoaf.o: dtoaf.c
-	$(CC) -m32 -std=c99 -W -Wall -pedantic -c dtoaf.c
+	$(CC) -m32 -std=c99 -W -Wall -pedantic $(CMATHFLAGS) -c dtoaf.c
 
 AM2_CFLAGS = -Wall -Wshadow -Wpointer-arith -Wcast-align -Wconversion -Waggregate-return -Wstrict-prototypes -Wnested-externs -Wlong-long -Winline 
 COMPILE2 = $(CC) $(DEFS) $(AM2_CFLAGS) $(CFLAGS)

--- a/SixTrack/make_six
+++ b/SixTrack/make_six
@@ -542,7 +542,7 @@ then
   then
     myopt="O4"
   fi
-  export FCF=" -frecord-marker=4 -$myopt -m32 -g -fno-second-underscore -funroll-loops"
+  export FCF=" -frecord-marker=4 -$myopt -m32 -g -fno-second-underscore -funroll-loops -mfpmath=sse -msse2"
   export FCL="-static -m32"
   export FCLD="-m32"
 elif test "$lf95" = ""

--- a/SixTrack/makefile
+++ b/SixTrack/makefile
@@ -137,7 +137,7 @@ FCL_ifort  := -static -m32
 
 # gfortran configuration
 FC_gfortran   := gfortran -m32
-FCF_gfortran  := -frecord-marker=4 -g -fno-second-underscore -funroll-loops
+FCF_gfortran  := -frecord-marker=4 -g -fno-second-underscore -funroll-loops -mfpmath=sse -msse2
 ifneq ($(NOPT),)
   FCF_gfortran:=$(FCF_gfortran) -O$(NOPT)
 endif


### PR DESCRIPTION
This patch changes make_six, the crlibm makefile, and the sixtrack makefile to always use SSE math with gfortran. This makes the newer gfortran versions pass all the SixTrack checks, while having no effect on the results from earlier versions of gfortran.

This should probably be discussed with Eric etc.

I could not get the exact same results using the sixtrack makefile, but I suspect that this is rather due to the OPTIONS which I passed to it.

This patch fixes issue #12 .