### PR TITLE
bug fix to rbruce-morecollimator.

### DIFF
--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -29567,8 +29567,8 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 ! YIL11: Checking only the IR value for TCT's..
                elseif(bez(myix)(1:4).eq.'TCTH' .or.                     &
      &                bez(myix)(1:4).eq.'tcth' .or.
-     &                bez(myix)(1:4).eq.'TCTPH' .or.                    & 
-     &                bez(myix)(1:4).eq.'tctph') then                   &
+     &                bez(myix)(1:5).eq.'TCTPH' .or.                    & 
+     &                bez(myix)(1:5).eq.'tctph') then                   &
                   if(bez(myix)(8:8).eq.'1' .or.                         &                                                                                                                                       
      &                 bez(myix)(9:9).eq.'1' ) then
                      nsig = nsig_tcth1
@@ -29584,8 +29584,8 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
                   endif
                elseif(bez(myix)(1:4).eq.'TCTV' .or.                     &
      &                bez(myix)(1:4).eq.'tctv'.or.
-     &                bez(myix)(1:4).eq.'TCTPV' .or.                    &
-     &                bez(myix)(1:4).eq.'tctpv' ) then
+     &                bez(myix)(1:5).eq.'TCTPV' .or.                    &
+     &                bez(myix)(1:5).eq.'tctpv' ) then
                   if(bez(myix)(8:8).eq.'1' .or.                         &
      &                 bez(myix)(9:9).eq.'1' ) then
                      nsig = nsig_tctv1
@@ -30147,16 +30147,16 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
      &                bez(myix)(1:4).eq.'tcth' .or.
      &                bez(myix)(1:5).eq.'TCTPH' .or.                    & 
      &                bez(myix)(1:5).eq.'tctph') then                   &
-                  if(bez(myix)(8:8).eq.'1' .or.                         &                                                                                                                                       
+                  if(bez(myix)(8:8).eq.'1' .or.                         &
      &                 bez(myix)(9:9).eq.'1' ) then
                      nsig = nsig_tcth1
-                  elseif(bez(myix)(8:8).eq.'2' .or.                     &                                                                                                                                           
+                  elseif(bez(myix)(8:8).eq.'2' .or.                     &
      &                 bez(myix)(9:9).eq.'2' ) then
                      nsig = nsig_tcth2
                   elseif(bez(myix)(8:8).eq.'5'.or.                      &
      &                 bez(myix)(9:9).eq.'5' ) then
                      nsig = nsig_tcth5
-                  elseif(bez(myix)(8:8).eq.'8' .or.                     &                                                                                                                                           
+                  elseif(bez(myix)(8:8).eq.'8' .or.                     &
      &                 bez(myix)(9:9).eq.'8' ) then
                      nsig = nsig_tcth8
                   endif


### PR DESCRIPTION
When writing in sigmasettings.out/twisslike.out, tctps where not correctly identified, since string matching was truncating the bez() to 4 chars instead of 5.

Moreover, few extremely long lines (full of empty spaces) removed.