### PR TITLE
Add DYNK to SixDA

### DIFF
--- a/SixTrack/ast_mask/sixda.ast
+++ b/SixTrack/ast_mask/sixda.ast
@@ -6,4 +6,7 @@ e RUNDA,RUNCAV,UMSCHR
 e COR_ORD,COR_GLO,DALIESIX
 e beam6df,MYDAINF
 e dumps
+e dynktrack
+e dynkancil
+e close
 ex


### PR DESCRIPTION
Fix from Eric which makes the Differential Algebra version compile without complaining about linker error to COMNUL and various DYNK routines.