### PR TITLE
Correct typo in physics manual spotted by Adrian Oeftiger

### DIFF
--- a/Doc/physics_manual/sixphys.tex
+++ b/Doc/physics_manual/sixphys.tex
@@ -514,7 +514,7 @@ For instance, the map for a normal quadrupole, sextupole and octupole are :
   p_x & \to p_x - L \cdot \frac{k_2}{2}\cdot (x^2-y^2) &
   p_y & \to p_y + L \cdot k_2 \cdot xy,\\
   p_x & \to p_x - L \cdot \frac{k_3}{6}\cdot(x^3 - 3xy^2) &
-  p_y & \to p_y + L \cdot \frac{k_3}{6}\cdot(y^3 - 3x^2y) .
+  p_y & \to p_y + L \cdot \frac{k_3}{6}\cdot(3x^2y - y^3) .
 \end{align}
 
 \subsection{RF-cavity}


### PR DESCRIPTION
The octupole py-kick was wrong.