### PR TITLE
Simplify make_six

### DIFF
--- a/SixTrack/make_six
+++ b/SixTrack/make_six
@@ -989,14 +989,7 @@ then
                 fi
             elif [[ "$MACHTYPE" == *x86_64* ]]
             then
-                # YIL: for gfortran 4.4/4.5 don't say which directory to use...
-                if ( ${FC} --version | grep 4.4. > /dev/null ) || ( ${FC} --version | grep 4.5. > /dev/null )
-                then 
-                    export CERNLIB="-L../lib32 -lgraflib -lgrafX11 -lpacklib_noshift -lkernlib_noshift -lg2c -lX11 -lxcb -lXau -lXdmcp -ldl -lpthread -lgcc_eh"
-                else
-                    export CERNLIB="-L../lib32 -lgraflib -lgrafX11 -lpacklib_noshift -lkernlib_noshift -lg2c -lX11 -lxcb -lXau -lXdmcp -L/usr/lib/gcc/x86_64-redhat-linux/3.4.6/32 -ldl -lpthread -lgcc_eh"
-                fi
-                # YIL: add hdf5 libs
+		export CERNLIB="-L../lib32 -lgraflib -lgrafX11 -lpacklib_noshift -lkernlib_noshift -lg2c -lX11 -lxcb -lXau -lXdmcp -ldl -lpthread -lgcc_eh"
                 if test "$hdf5" = ""
                 then
                     export CERNLIB="-Wl,--start-group -I${H5ROOT}/include -L${H5ROOT}/lib -lszip -lhdf5 -lhdf5_hl -lhdf5_fortran -lhdf5_f90cstub -lhdf5_hl_fortran -lz -lm -Wl,--end-group  $CERNLIB"


### PR DESCRIPTION
Delete if statement hardcoding specific -L path for unrecognized gfortran versions (not 4.4 or 4.5) - the linker should figure it out itself. This was making problems for Frank Schmidt on Fedora23.

I tested the patch on CC7.2.1511 (gfortran 4.8.5), SLC6.7 (lxplus, gfortran 4.4.7), Fedora23 (5.3.1), Ubuntu 15.10 (gfortran 5.2.1) and it works without any problems. My workstation is quickly turning into a virtualbox zoo...

It may be a good idea to clean up the other compilers as well, but this should fix the issue for 99% of the developers.