### PR TITLE
BDEX: Beam Distribution EXchange

### DIFF
--- a/SixTrack/bdex_echo.py
+++ b/SixTrack/bdex_echo.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# ECHO particles for BDEX
+# This reads the particles from BDEX, and writes back the same particles.
+
+import sys
+
+if len(sys.argv) != 3:
+    print "Arguments: InPipe OutPipe"
+    exit(1)
+
+oPipeName = sys.argv[1] #/tmp/pip3
+iPipeName = sys.argv[2] #/tmp/pip4
+
+print "Opening", oPipeName, "for writing"
+oPipe = open(oPipeName,'w')
+print "Opening", iPipeName, "for reading"
+iPipe = open(iPipeName,'r')
+
+isConnected=False
+
+while True:
+    iData = iPipe.readline()
+    if len(iData)==0:
+        print "No more input!"
+        break
+    iData = iData.strip()
+    
+    if iData.startswith("BDEX-PIPE"):
+        print "SixTrack connected."
+        assert isConnected==False
+        isConnected=True
+    elif iData.startswith("BDEX TURN"):
+        ls = iData.split()
+        turn = int(ls[2])
+        bez  = ls[3][4:]
+        I    = int(ls[5])
+        NAPX = int(ls[7])
+        particles = []
+        for j in xrange(NAPX):
+            particles.append( iPipe.readline().strip() )
+            #print particles[-1]
+        
+        waiting=iPipe.readline().strip()
+        #print waiting
+        assert waiting=="BDEX WAITING..."
+        print "Got", NAPX, "particles"
+
+        oPipe.write(str(NAPX)+"\n")
+        for j in xrange(NAPX):
+            oPipe.write(particles[j]+"\n")
+        oPipe.flush()
+        print "Wrote them back!"
+        
+        tracking=iPipe.readline().strip()
+        #print tracking
+        assert tracking=="BDEX TRACKING..."
+        
+iPipe.close()
+oPipe.close()

--- a/SixTrack/make_six
+++ b/SixTrack/make_six
@@ -497,7 +497,7 @@ then
 fi
 if test "$collimat" = "" -a "$crlibm" = ""
 then
-    #Collimat is not really compatible with collimation
+    #Collimat is not really compatible with crlibm
     echo
     echo -e "\e[91m ***** WARNING ***** \e[39m"
     echo -e "\e[91mTrying to build SixTrack with both\e[39m"

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -18397,6 +18397,12 @@ cc2008
 
       if(ch(1:1).eq.'/') goto 2300 ! skip comment line
 
++if cr
+      write(lout,*) "BDEX not supported in CR version."
+      write(lout,*) "Sorry :("
+      call prror(-1)
++ei
+
       ! Which type of block? Look at start of string (no leading blanks allowed)
       if (ch(:4).eq."DEBU") then
          bdex_debug = .true.
@@ -18408,6 +18414,65 @@ cc2008
 +ei
      &        "BDEX> BDEX block debugging is ON"
          goto 2300 !loop BDEX
+
+      else if (ch(:4).eq."ELEM") then
+         call getfields_split( ch, getfields_fields, getfields_lfields,
+     &        getfields_nfields, getfields_lerr )
+         if ( getfields_lerr ) call prror(-1)
+         if (bdex_debug) then
++if cr
+            write (lout,'(1x,A,I4,A)')
++ei
++if .not.cr
+            write    (*,'(1x,A,I4,A)')
++ei
+     &           "BDEXDEBUG> Got a ELEM block, len=",
+     &           len(ch), ": '"// trim(ch)// "'"
+            do ii=1,getfields_nfields
++if cr
+               write (lout,*)
++ei
++if .not.cr
+               write (*,*)
++ei
+     &              "BDEXDEBUG> Field(",ii,") ='",
+     &              getfields_fields(ii)(1:getfields_lfields(ii)),"'"
+            enddo
+         endif
+         
+         !Parse ELEM
+         
+         goto 2300 !loop BDEX
+         
+      else if (ch(:4).eq."CHAN") then
+         call getfields_split( ch, getfields_fields, getfields_lfields,
+     &        getfields_nfields, getfields_lerr )
+         if ( getfields_lerr ) call prror(-1)
+         if (bdex_debug) then
++if cr
+            write (lout,'(1x,A,I4,A)')
++ei
++if .not.cr
+            write    (*,'(1x,A,I4,A)')
++ei
+     &           "BDEXDEBUG> Got a CHAN block, len=",
+     &           len(ch), ": '"// trim(ch)// "'"
+            do ii=1,getfields_nfields
++if cr
+               write (lout,*)
++ei
++if .not.cr
+               write (*,*)
++ei
+     &              "BDEXDEBUG> Field(",ii,") ='",
+     &              getfields_fields(ii)(1:getfields_lfields(ii)),"'"
+            enddo
+         endif
+
+         !Parse CHAN
+
+         goto 2300 !Loop BDEX
+         
       else if (ch(:4).eq.next) then
          if (bdex_debug) then
 +if cr
@@ -18473,7 +18538,7 @@ cc2008
       write (*,*)    "*LOGIC ERROR IN PARSING BDEX*"
       write (*,*)    "*****************************"
 +ei
-
+      call prror(-1)
 
 !-----------------------------------------------------------------------
   771 if(napx.ge.1) then

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -30605,8 +30605,10 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
                 if (bdex_channels(bdex_elementChannel(ix),1).eq.1) then !PIPE channel
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX TURN=",n,"BEZ=",bez(ix),"I=",i,"NAPX=",napx
+                   !TODO: CRLIBM!
+                   
+                   !Write out particles
                    do j=1,napx
-                     !TODO: CRLIBM!
                      write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                     xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
      &                     ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
@@ -30614,7 +30616,25 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
                    enddo
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX WAITING..."
-                   !Todo: Read back particles
+                   
+                   !Read back particles
+                   read(bdex_channels(bdex_elementChannel(ix),4),*) napx
+                   if (bdex_debug) then
++if cr
+                      write(lout,*)
++ei
++if .not.cr
+                      write(*,*)
++ei
+     &                "BDEXDEBUG> Reading",napx, "particles back..."
+                   endif
+                   do j=1,napx
+                      read(bdex_channels(bdex_elementChannel(ix),4),*)
+     &                     xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
+     &                     ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
+     &                     dpsv1(j),nlostp(j)
+                   enddo
+                   
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX TRACKING..."
 

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -29386,7 +29386,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 
           if (bdex_enable) then
 +if cr
-             write(*,lout) "BDEX> BDEX only available for thin6d"
+             write(lout,*) "BDEX> BDEX only available for thin6d"
 +ei
 +if .not.cr
              write(*,*)    "BDEX> BDEX only available for thin6d"
@@ -34162,7 +34162,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
           if (bdex_enable) then
              !TODO - if you have a test case, please contact developers!
 +if cr
-             write(*,lout) "BDEX> BDEX only available for thin6d"
+             write(lout,*) "BDEX> BDEX only available for thin6d"
 +ei
 +if .not.cr
              write(*,*)    "BDEX> BDEX only available for thin6d"
@@ -36022,7 +36022,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
             if (bdex_enable) then
                !TODO - if you have a test case, please contact developers!
 +if cr
-               write(*,lout) "BDEX> BDEX only available for thin6d"
+               write(lout,*) "BDEX> BDEX only available for thin6d"
 +ei
 +if .not.cr
                write(*,*)    "BDEX> BDEX only available for thin6d"
@@ -36608,7 +36608,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
             if (bdex_enable) then
                !TODO - if you have a test case, please contact developers!
 +if cr
-               write(*,lout) "BDEX> BDEX only available for thin6d"
+               write(lout,*) "BDEX> BDEX only available for thin6d"
 +ei
 +if .not.cr
                write(*,*)    "BDEX> BDEX only available for thin6d"
@@ -37290,7 +37290,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
             if (bdex_enable) then
                !TODO - if you have a test case, please contact developers!
 +if cr
-               write(*,lout) "BDEX> BDEX only available for thin6d"
+               write(lout,*) "BDEX> BDEX only available for thin6d"
 +ei
 +if .not.cr
                write(*,*)    "BDEX> BDEX only available for thin6d"

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -29303,6 +29303,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca dbdump
 +ca comdynk
 +ca dbdcum
++ca combdex
 +ca save
 !-----------------------------------------------------------------------
       nthinerr=0
@@ -29382,6 +29383,17 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +if time
 +ca timefct
 +ei
+
+          if (bdex_enable) then
++if cr
+             write(*,lout) "BDEX> BDEX only available for thin6d"
++ei
++if .not.cr
+             write(*,*)    "BDEX> BDEX only available for thin6d"
++ei
+             call prror(-1)
+          endif
+          
           goto(10,  630,  740, 630, 630, 630, 630, 630, 630, 630, !10
      &         30,  50,   70,   90, 110, 130, 150, 170, 190, 210, !20
      &         420, 440, 460,  480, 500, 520, 540, 560, 580, 600, !30
@@ -34012,6 +34024,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca dbdump
 +ca comdynk
 +ca dbdcum
++ca combdex
 +ca save
 !-----------------------------------------------------------------------
 +if fast
@@ -34090,13 +34103,25 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca bpmdata
 +ei bpm
       
-      if (ldumpfront) then
+          if (ldumpfront) then
 +ca dumplines
-      endif
+          endif
       
 +if time
 +ca timefct
 +ei
+
+          if (bdex_enable) then
+             !TODO - if you have a test case, please contact developers!
++if cr
+             write(*,lout) "BDEX> BDEX only available for thin6d"
++ei
++if .not.cr
+             write(*,*)    "BDEX> BDEX only available for thin6d"
++ei
+             call prror(-1)
+          endif
+
 !--------count44
           goto(10,30,740,650,650,650,650,650,650,650,50,70,90,110,130,  &
      &150,170,190,210,230,440,460,480,500,520,540,560,580,600,620,      &
@@ -35854,6 +35879,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca comgetfields
 +ca dbdump
 +ca comdynk
++ca combdex
 +ca save
 !-----------------------------------------------------------------------
       nthinerr=0
@@ -35943,6 +35969,17 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +if time
 +ca timefct
 +ei
+            endif
+
+            if (bdex_enable) then
+               !TODO - if you have a test case, please contact developers!
++if cr
+               write(*,lout) "BDEX> BDEX only available for thin6d"
++ei
++if .not.cr
+               write(*,*)    "BDEX> BDEX only available for thin6d"
++ei
+               call prror(-1)
             endif
 
 !----------count=43
@@ -36400,6 +36437,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca comgetfields
 +ca dbdump
 +ca comdynk
++ca combdex
 +ca save
 +if debug
 !-----------------------------------------------------------------------
@@ -36518,6 +36556,18 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 !     endif
 !     if (i.eq.676) stop
 +ei
+
+            if (bdex_enable) then
+               !TODO - if you have a test case, please contact developers!
++if cr
+               write(*,lout) "BDEX> BDEX only available for thin6d"
++ei
++if .not.cr
+               write(*,*)    "BDEX> BDEX only available for thin6d"
++ei
+               call prror(-1)
+            endif
+
 !----------count 44
 !----------count 54! Eric
             goto(20,40,740,500,500,500,500,500,500,500,60,80,100,120,   &
@@ -37093,6 +37143,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca comgetfields
 +ca dbdump
 +ca comdynk
++ca combdex
 +ca save
 !-----------------------------------------------------------------------
       nthinerr=0
@@ -37187,7 +37238,17 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca timefct
 +ei
             endif
-
+            
+            if (bdex_enable) then
+               !TODO - if you have a test case, please contact developers!
++if cr
+               write(*,lout) "BDEX> BDEX only available for thin6d"
++ei
++if .not.cr
+               write(*,*)    "BDEX> BDEX only available for thin6d"
++ei
+               call prror(-1)
+            endif
 !----------count 56
             goto(20,40,740,500,500,500,500,500,500,500,60,80,100,120,   &
      &140,160,180,200,220,240,290,310,330,350,370,390,410,430,          &

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -18432,6 +18432,11 @@ cc2008
       write(lout,*) "Sorry :("
       call prror(-1)
 +ei
++if collimat
+      write(*,*) "BDEX not supported in COLLIMAT version."
+      write(*,*) "Sorry :("
+      call prror(-1)
++ei
 
       ! Which type of block? Look at start of string (no leading blanks allowed)
       if (ch(:4).eq."DEBU") then
@@ -18485,7 +18490,7 @@ cc2008
          
          jj = -1
          do ii=1,il !match the single element
-            if ( bez(j) .eq.
+            if ( bez(ii) .eq.
      &           getfields_fields(3)(1:getfields_lfields(3)) ) then
                jj=ii
                exit !breaks the loop
@@ -18501,6 +18506,18 @@ cc2008
      &"BDEX> ERROR: The element '"//
      &getfields_fields(3)(1:getfields_lfields(3)) //"' was not found "//
      &"in the single element list."
+            call prror(-1)
+         endif
+
+         if (kz(jj).ne.0) then
++if cr
+            write(lout,*) "BDEX> Error: The element",bez(jj),
+     & "is not a marker."
++ei
++if .not.cr
+            write(*,*)    "BDEX> Error: The element",bez(jj),
+     & "is not a marker."
++ei
             call prror(-1)
          endif
 
@@ -18772,10 +18789,41 @@ cc2008
             bdex_enable = .true.
          endif
          
-         !While debugging BDEX parser:
-         call closeUnits
-         write(*,*) "Stopping here."
-         stop
+         if (bdex_debug) then
++if cr
+            ! TODO - no CR support in BDEX, so I'll try to avoid the double-writes here...
++ei
++if .not.cr
+            write(*,*) "BDEXDEBUG> Done parsing block, data dump:"
+            write(*,*) "BDEXDEBUG> bdex_enable = ", bdex_enable
+            write(*,*) "BDEXDEBUG> bdex_debug  = ", bdex_debug
+            do ii=1,il
+               if ( bdex_elementStatus(ii).ne.0) then
+                  write(*,*) "BDEXDEBUG> Single element number", ii,
+     &"named ",bez(ii), "bdex_elementStatus(#)=",bdex_elementStatus(ii),
+     &"bdex_elementChannel(#)=",bdex_elementChannel(ii)
+               endif
+            enddo
+            write(*,*) "BDEXDEBUG> bdex_nchannels=",bdex_nchannels,
+     &           ">=",bdex_maxchannels
+            do ii=1,bdex_nchannels
+               write(*,*) "BDEXDEBUG> Channel #",ii,
+     &"bdex_channelNames(#)='"//
+     &trim(dynk_stringzerotrim(bdex_channelNames(ii)))//"'",
+     &"bdex_channels(#,:)=",bdex_channels(ii,1),bdex_channels(ii,2),
+     &bdex_channels(ii,3),bdex_channels(ii,4)
+            enddo
+            write(*,*) "BDEXDEBUG> bdex_nstringStorage=",
+     &bdex_nstringStorage,">=",bdex_maxStore
+            do ii=1,bdex_nstringStorage
+               write(*,*) "BDEXDEBUG> #",ii,"= '"//
+     &trim(dynk_stringzerotrim(bdex_stringStorage(ii)))//"'"
+            enddo
+            write(*,*) "BDEXDEBUG> Dump completed."
++ei
+         endif
+!         stop
+         goto 110 ! loop BLOCK
       else
 +if cr
          write (lout,*)
@@ -29799,6 +29847,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca dbdump
 +ca comdynk
 +ca dbdcum
++ca combdex
 +ca save
 !-----------------------------------------------------------------------
 +if fast
@@ -30538,6 +30587,37 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 !           backspace (93,iostat=ierro)
 !         endif
 +ei
+
+          if ( bdex_enable .and. kz(ix).eq.0 .and.
+     &         bdex_elementStatus(ix).ne.0 ) then
+             if (bdex_elementStatus(ix).eq.1) then
+                !Particle exchange
+                if (bdex_debug) then
++if cr
+                   write(lout,*) "BDEXDEBUG> "//
++ei
++if .not.cr
+                   write(*,*)    "BDEXDEBUG> "//
++ei
+     &"Doing particle exchange in bez=",bez(ix),
+     &"elementStatus=",bdex_elementStatus(ix)
+                endif
+                
+                !TODO...
+                
+             else
++if cr
+                write(lout,*) "BDEX> elementStatus=",
+     &bdex_elementStatus(i), "not understood."
++ei
++if .not.cr
+                write(*,*)    "BDEX> elementStatus=",
+     &bdex_elementStatus(i), "not understood."
++ei
+                call prror(-1)
+             endif
+          endif
+
 ! JBG RF CC Multipoles
 ! JBG adding CC multipoles elements in tracking. ONLY in thin6d!!!
 ! JBG 755 -RF quad, 756 RF Sext, 757 RF Oct

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -18482,6 +18482,48 @@ cc2008
 +ei
             call prror(-1)
          endif
+         
+         jj = -1
+         do ii=1,il !match the single element
+            if ( bez(j) .eq.
+     &           getfields_fields(3)(1:getfields_lfields(3)) ) then
+               jj=ii
+               exit !breaks the loop
+            endif
+         enddo
+         if (jj.eq.-1) then
++if cr
+            write(lout,*)
++ei
++if .not.cr
+            write(*,*)
++ei
+     &"BDEX> ERROR: The element '"//
+     &getfields_fields(3)(1:getfields_lfields(3)) //"' was not found "//
+     &"in the single element list."
+            call prror(-1)
+         endif
+
+         bdex_elementStatus(jj)=1 !Particle exchange at this element
+         
+         bdex_elementChannel(jj) = -1
+         do ii=1,bdex_nchannels !Match channel name
+            if ( bdex_channelNames(ii)(1:getfields_lfields(2)) .eq.
+     &             getfields_fields(2)(1:getfields_lfields(2)) ) then
+               bdex_elementChannel(jj)=ii
+            endif
+         enddo
+         if ( bdex_elementChannel(jj).eq.-1 ) then
++if cr
+            write(lout,*) "BDEX> ERROR: The channel '"//
+     &getfields_fields(2)(1:getfields_lfields(2)) //"' was not found"
++ei
++if .not.cr
+            write(*,*)    "BDEX> ERROR: The channel '"//
+     &getfields_fields(2)(1:getfields_lfields(2)) //"' was not found"
++ei
+            call prror(-1)
+         endif
 
          goto 2300 !loop BDEX
          
@@ -18511,7 +18553,7 @@ cc2008
          endif
 
          !Parse CHAN
-         select case( trim(dynk_stringzerotrim( getfields_fields(3) )) )
+         select case( trim(dynk_stringzerotrim( getfields_fields(3) )) ) !Could I rather just use the length of the field?
          case ("PIPE")
             !PIPE: Use a pair of pipes to communicate the particle distributions
             !Arguments: InFileName OutFileName format fileUnit
@@ -18576,7 +18618,7 @@ cc2008
             inquire( unit=bdex_channels(bdex_nchannels,4),opened=lopen )
             if (lopen) then
 +if cr
-               write(lout,*)"BDEX> ERROR in daten():PIPE "
+               write(lout,*)"BDEX> ERROR in daten():BDEX:CHAN:PIPE"
                write(lout,*)"BDEX> unit=",
      &              bdex_channels(bdex_nchannels,4),
      &              "for file '"//bdex_stringStorage(
@@ -18584,7 +18626,7 @@ cc2008
      &              //"' was already taken"
 +ei
 +if .not.cr
-               write(*,*)   "BDEX> ERROR in daten():PIPE "
+               write(*,*)   "BDEX> ERROR in daten():BDEX:CHAN:PIPE"
                write(*,*)   "BDEX> unit =",
      &              bdex_channels(bdex_nchannels,4),
      &              "for file '"//bdex_stringStorage(

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -29811,7 +29811,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
        INTEGER hdfturn,hdfpid,hdftyp
        DOUBLE PRECISION hdfx,hdfxp,hdfy,hdfyp,hdfdee,hdfs
 +ei
-      integer i,irrtr,ix,j,k,kpz,n,nmz,nthinerr
+      integer i,irrtr,ix,j,k,kpz,n,nmz,nthinerr,ii
       double precision c5m4,cbxb,cbzb,cccc,cikve,cikveb,crkve,crkveb,   &
      &crkveuk,crxb,crzb,dpsv3,pux,r0,r2b,rb,rho2b,rkb,stracki,tkb,xbb,  &
      &xlvj,xrb,yv1j,yv2j,zbb,zlvj,zrb
@@ -29860,6 +29860,11 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +ca comdynk
 +ca dbdcum
 +ca combdex
++if crlibm
+!Needed for string conversions for BDEX
+      character*8192 ch
+      integer dtostr
++ei
 +ca save
 !-----------------------------------------------------------------------
 +if fast
@@ -30617,15 +30622,46 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
                 if (bdex_channels(bdex_elementChannel(ix),1).eq.1) then !PIPE channel
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX TURN=",n,"BEZ=",bez(ix),"I=",i,"NAPX=",napx
-                   !TODO: CRLIBM!
                    
                    !Write out particles
++if crlibm
+                   do j=1,napx
+                     do k=1,8192
+                        ch(k:k)=' '
+                     enddo
+                     ii=1
+                     ii=dtostr(xv(1,j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(yv(1,j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(xv(2,j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(yv(2,j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(sigmv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(ejv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(ejfv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(rvv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(dpsv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(oidpsv(j),ch(ii:ii+24))+1+ii
+                     ii=dtostr(dpsv1(j),ch(ii:ii+24))+1+ii
+                     
+                     if (ii .ne. 1+(24+1)*11) then !Also check if too big?
+                        write(*,*) "ERRORRRRR! ii=",ii
+                        write(*,*) "ch=",ch
+                     endif
+                     
+                     write(ch(ii:ii+24),'(i24)') nlostp(j)
+                     
+                     write(
+     &     bdex_channels(bdex_elementChannel(ix),4)+1,'(a)') ch(1:ii+24)
+
+                   enddo
++ei
++if .not.crlibm
                    do j=1,napx
                      write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
-     &                     xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
+     &                     xv(1,j),yv(1,j),xv(2,j),yv(2,j),sigmv(j),
      &                     ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
      &                     dpsv1(j),nlostp(j)
                    enddo
++ei
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX WAITING..."
                    
@@ -30654,7 +30690,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
                      endif
                      do j=1,napx
                        read(bdex_channels(bdex_elementChannel(ix),4),*)
-     &                       xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
+     &                       xv(1,j),yv(1,j),xv(2,j),yv(2,j),sigmv(j),
      &                       ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
      &                       dpsv1(j),nlostp(j)
                      enddo

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -30602,8 +30602,8 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 
           if ( bdex_enable .and. kz(ix).eq.0 .and.
      &         bdex_elementStatus(ix).ne.0 ) then
-             if (bdex_elementStatus(ix).eq.1) then
-                !Particle exchange
+
+             if (bdex_elementStatus(ix).eq.1) then !Particle exchange
                 if (bdex_debug) then
 +if cr
                    write(lout,*) "BDEXDEBUG> "//
@@ -30630,26 +30630,38 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
      &                 "BDEX WAITING..."
                    
                    !Read back particles
-                   read(bdex_channels(bdex_elementChannel(ix),4),*) napx
-                   if (bdex_debug) then
+                   read(bdex_channels(bdex_elementChannel(ix),4),*) j
+                   if ( j .eq. -1) then !Don't change the distribution at all
+                     if (bdex_debug) then
 +if cr
-                      write(lout,*)
+                       write(lout,*)
 +ei
 +if .not.cr
-                      write(*,*)
+                       write(*,*)
 +ei
-     &                "BDEXDEBUG> Reading",napx, "particles back..."
+     &                  "BDEXDEBUG> No change in distribution."
+                     endif
+                   else
+                     napx=j
+                     if (bdex_debug) then
++if cr
+                       write(lout,*)
++ei
++if .not.cr
+                       write(*,*)
++ei
+     &                   "BDEXDEBUG> Reading",napx, "particles back..."
+                     endif
+                     do j=1,napx
+                       read(bdex_channels(bdex_elementChannel(ix),4),*)
+     &                       xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
+     &                       ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
+     &                       dpsv1(j),nlostp(j)
+                     enddo
                    endif
-                   do j=1,napx
-                      read(bdex_channels(bdex_elementChannel(ix),4),*)
-     &                     xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
-     &                     ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
-     &                     dpsv1(j),nlostp(j)
-                   enddo
                    
                    write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
      &                 "BDEX TRACKING..."
-
                 endif
                 
              else

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -30599,11 +30599,26 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 +if .not.cr
                    write(*,*)    "BDEXDEBUG> "//
 +ei
-     &"Doing particle exchange in bez=",bez(ix),
-     &"elementStatus=",bdex_elementStatus(ix)
+     &"Doing particle exchange in bez=",bez(ix)
                 endif
                 
-                !TODO...
+                if (bdex_channels(bdex_elementChannel(ix),1).eq.1) then !PIPE channel
+                   write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
+     &                 "BDEX TURN=",n,"BEZ=",bez(ix),"I=",i,"NAPX=",napx
+                   do j=1,napx
+                     !TODO: CRLIBM!
+                     write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
+     &                     xv(1,j),yv(1,j),xv(2,j),xv(2,j),sigmv(j),
+     &                     ejv(j),ejfv(j),rvv(j),dpsv(j),oidpsv(j),
+     &                     dpsv1(j),nlostp(j)
+                   enddo
+                   write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
+     &                 "BDEX WAITING..."
+                   !Todo: Read back particles
+                   write(bdex_channels(bdex_elementChannel(ix),4)+1,*)
+     &                 "BDEX TRACKING..."
+
+                endif
                 
              else
 +if cr


### PR DESCRIPTION
As described in issue #59 , this patch allows exchanging the particle distribution at some element.

TODO:
- Binary format in order to avoid roundoff errors, or at least CRLIBM (if not already there?)
- Documentation
- More than just thin6d tracking (this could also be implemented in a later patch)?
- Testing...

Related development: DYNK-PIPEFUN, pull request #66 .