### PR TITLE
Replace calls to DFLOAT with DBLE.

### DIFF
--- a/SixTrack/make_six
+++ b/SixTrack/make_six
@@ -628,8 +628,8 @@ then
   ####export FCF="-$myopt -float-store -$myopt -C=undefined -abi=32 -dusty -maxcontin=60 -dcfuns -ieee=full -g90"
 # export FCF="-$myopt -C=all -abi=32 -dusty -maxcontin=60 -dcfuns -ieee=full -g90"
 # export FCF="-float-store -$myopt -abi=32 -dusty -maxcontin=60 -dcfuns -ieee=full -g90"
-  export FCF="-$myopt -abi=32 -dusty -maxcontin=60 -dcfuns -ieee=full -g90"
-  export FCF="-$myopt -abi=32 -dusty -maxcontin=60 -ieee=full -g90"
+  export FCF="-$myopt -abi=32 -dusty -dcfuns -ieee=full -g90"
+#  export FCF="-$myopt -abi=32 -dusty -maxcontin=60 -ieee=full -g90" ## Former default, could not build plato
 # The ieee=nonstd is INCOMPATIBLE with abi=32!!!
 # export FCF="-$myopt -abi=32 -dusty -maxcontin=60 -dcfuns -ieee=nonstd -g90"
   export FCL="-Bstatic -abi=32"
@@ -800,7 +800,11 @@ if test "$MACHTYPE" = "i586"
 then
     export FCLMAP="$FCL"
 else
-    export FCLMAP="-Wl,--print-map $FCL"
+    if "$nagfor" != ""; then
+	export FCLMAP="-Wl,--print-map $FCL"
+    else
+	export FCLMAP="$FCL"
+    fi
 fi
 
 if test "$OSTYPE" = "Darwin"

--- a/SixTrack/plato_seq.s
+++ b/SixTrack/plato_seq.s
@@ -144,7 +144,7 @@ C.............................REJECTS FREQUENCIES NEAR 0 OR 1
           NFTMAX=NFT
         END IF
       ENDDO
-      TUNEFOU=DFLOAT(NFTMAX-1)/DFLOAT(NPOINT)
+      TUNEFOU=DBLE(NFTMAX-1)/DBLE(NPOINT)
       DELTAT=1D0/NPOINT
       TUNE1=TUNEFOU-DELTAT
       CALL ZFUN(TUNE,Z,MAXN,TUNE1,DELTAT)
@@ -195,7 +195,7 @@ C............................................................
       DUEPI=8*DATAN(1D0)
 +ei
 C.............................................................
-      C=DFLOAT(MAX)/2D0-DFLOAT(INT(MAX/2D0))
+      C=DBLE(MAX)/2D0-DBLE(INT(MAX/2D0))
       MAX1=MAX
       IF(C.GT.1D-1) MAX1=MAX-1
       MAX2=MAX1/2
@@ -227,7 +227,7 @@ C.............................................................
         TUNEAPA=PA/DUEPI
         SUMAPM=SUMAPM+TUNEAPA
         IF (N.GE.MAX2) THEN
-          TUNE(N-MAX2+1)=((SUMAPM/DFLOAT(N))/DFLOAT(N+1))*2.D0
+          TUNE(N-MAX2+1)=((SUMAPM/DBLE(N))/DBLE(N+1))*2.D0
           U(N-MAX2+1)=1.D0/N
         ENDIF
 C.............................................................
@@ -357,23 +357,23 @@ C................................................INTERPOLATION
       CF3=ABS(ZSING(NFTMAX+1))
 +if crlibm
       IF (CF3.GT.CF1) THEN      
-        ASSK=DFLOAT(NFTMAX)+(NPOINT/PI)*
+        ASSK=DBLE(NFTMAX)+(NPOINT/PI)*
      .       ATAN2_RN(CF3*SIN_RN(PI/NPOINT),CF2+CF3*COS_RN(PI/NPOINT))
       ELSEIF (CF3.LE.CF1) THEN                   
-        ASSK=DFLOAT(NFTMAX-1)+(NPOINT/PI)*
+        ASSK=DBLE(NFTMAX-1)+(NPOINT/PI)*
      .       ATAN2_RN(CF2*SIN_RN(PI/NPOINT),CF1+CF2*COS_RN(PI/NPOINT))
       ENDIF
 +ei
 +if .not.crlibm
       IF (CF3.GT.CF1) THEN      
-        ASSK=DFLOAT(NFTMAX)+(NPOINT/PI)*
+        ASSK=DBLE(NFTMAX)+(NPOINT/PI)*
      .       ATAN2(CF3*SIN(PI/NPOINT),CF2+CF3*COS(PI/NPOINT))
       ELSEIF (CF3.LE.CF1) THEN                   
-        ASSK=DFLOAT(NFTMAX-1)+(NPOINT/PI)*
+        ASSK=DBLE(NFTMAX-1)+(NPOINT/PI)*
      .       ATAN2(CF2*SIN(PI/NPOINT),CF1+CF2*COS(PI/NPOINT))
       ENDIF
 +ei
-      TUNEABT=1D+0-(ASSK-1D+0)/DFLOAT(NPOINT) !1D+0 = 1D0, i.e. double precision 1.0?
+      TUNEABT=1D+0-(ASSK-1D+0)/DBLE(NPOINT) !1D+0 = 1D0, i.e. double precision 1.0?
 C............................................................  
       RETURN 
 C............................................................  
@@ -457,24 +457,24 @@ C.............................................................
       ENDIF
 C..........................................INTERPOLATION
 +if crlibm
-      CO=COS_RN((2*PI)/DFLOAT(NPOINT))
-      SI=SIN_RN((2*PI)/DFLOAT(NPOINT))
+      CO=COS_RN((2*PI)/DBLE(NPOINT))
+      SI=SIN_RN((2*PI)/DBLE(NPOINT))
 +ei
 +if .not.crlibm
-      CO=COS((2*PI)/DFLOAT(NPOINT))
-      SI=SIN((2*PI)/DFLOAT(NPOINT))
+      CO=COS((2*PI)/DBLE(NPOINT))
+      SI=SIN((2*PI)/DBLE(NPOINT))
 +ei
       SCRA1=CO**2*(P1+P2)**2-((2*P1)*P2)*((2*CO**2-CO)-1)
       SCRA2=(P1+P2*CO)*(P1-P2)
       SCRA3=(P1**2+P2**2)+((2*P1)*P2)*CO
       SCRA4=(-SCRA2+P2*SQRT(SCRA1))/SCRA3
 +if crlibm
-      ASSK=DFLOAT(NN)+((NPOINT/2)/PI)*ASIN_RN(SI*SCRA4)
+      ASSK=DBLE(NN)+((NPOINT/2)/PI)*ASIN_RN(SI*SCRA4)
 +ei
 +if .not.crlibm
-      ASSK=DFLOAT(NN)+((NPOINT/2)/PI)*ASIN(SI*SCRA4)
+      ASSK=DBLE(NN)+((NPOINT/2)/PI)*ASIN(SI*SCRA4)
 +ei
-      TUNEABT2=1D+0-(ASSK-1D+0)/DFLOAT(NPOINT)
+      TUNEABT2=1D+0-(ASSK-1D+0)/DBLE(NPOINT)
 C............................................................  
       RETURN 
 C............................................................  
@@ -724,7 +724,7 @@ C.............................REJECTS FREQUENCIES NEAR 0 OR 1
           NFTMAX=NFT
         END IF
       ENDDO
-      TUNEFOU=DFLOAT(NFTMAX-1)/DFLOAT(NPOINT)
+      TUNEFOU=DBLE(NFTMAX-1)/DBLE(NPOINT)
       DELTAT=1D0/NPOINT
       TUNE1=TUNEFOU-DELTAT
       CALL ZFUN(TUNE,Z,MAXN,TUNE1,DELTAT)
@@ -1273,7 +1273,7 @@ C..COMPUTATION OF SCALAR PRODUCT WITH ITERATED BODE ALGORITHM
             FOME=FOME+((7D0*(Z(1+K)+Z(5+K))+32D0*(Z(2+K)+Z(4+K)))
      .               +12D0*Z(3+K))
           ENDDO
-          FOME=((.5D0*FOME)/45D0)/DFLOAT(MBODE+1)
+          FOME=((.5D0*FOME)/45D0)/DBLE(MBODE+1)
 C..........SEARCH FOR MAXIMUM OF SCALAR PRODUCT AND DEFINITION
 C..........OF THE NEW INTERVAL (OMEMIN,OMEMAX) WHERE TO
 C........................................RESTART THE PROCEDURE

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -3,7 +3,7 @@
       character*10 moddate
       integer itot,ttot
       data version /'4.5.40'/
-      data moddate /'29.11.2016'/
+      data moddate /'06.12.2016'/
 +cd license
 !!SixTrack
 !!

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -8817,6 +8817,18 @@ cc2008
 
 +dk nocode
       !Dummy deck to satisfy astuce in case of no decks in the fortran file...
++if .not.datamods
+      subroutine nodatamods
++if cr
+      write(lout,*)
++ei
++if .not.cr
+      write(*,*)
++ei
+     &     "Dummy routine in bigmats.f if beamgas module is off."
+      end subroutine
++ei
+
 +dk datamods
       module bigmats
 !     Module defining some very large matrices, which doesn't fit in BSS with common blocks.


### PR DESCRIPTION
It seems DFLOAT is a language extension that converts an integer to a double.

This does not seem to be supported by nagfor any more.

The standard way seems to be to call DBLE instead.

This just replaces calls to DFLOAT with calls to DBLE.