### PR TITLE
Fix test check tools to not print out random memory contents.

### DIFF
--- a/SixTest/bin/checkf10.f
+++ b/SixTest/bin/checkf10.f
@@ -1,10 +1,14 @@
       program checkf10
       implicit none
       double precision prob(60),prob1(60)
-      integer line,word
+      integer line,word,i
       logical diff,diffs
 ! Now compare the closed orbit in 53-58 as well
-! and NMAC in 59 (60 is used for CPU for Massimo) 
+! and NMAC in 59 (60 is used for CPU for Massimo)
+      do i=1,60
+        prob(i) = 0
+        prob1(i) = 0
+      enddo
       line=0
       diff=.false.
     1 read (20,*,end=100,err=98) prob

--- a/SixTest/bin/checkf1014.f
+++ b/SixTest/bin/checkf1014.f
@@ -5,6 +5,12 @@
       logical diff,diffs
       character*80 buffer
 ! Now compare the closed orbit in 53-60 as well
+      do i=1,60
+        prob(i) = 0
+        prob1(i) = 0
+        lprob(i) = 0
+        lprob1(i) = 0
+      enddo
       line=0
       diff=.false.
       diffs=.false.

--- a/SixTest/bin/checkf110.f
+++ b/SixTest/bin/checkf110.f
@@ -1,9 +1,13 @@
       program checkf110
       implicit none
       double precision prob(60),prob1(60)
-      integer line,word
+      integer line,word,i
       logical diff,diffs
 ! Now compare the closed orbit in 53-60 as well
+      do i=1,60
+        prob(i) = 0
+        prob1(i) = 0
+      enddo
       line=0
       diff=.false.
       diffs=.false.

--- a/SixTest/bin/compf10.f
+++ b/SixTest/bin/compf10.f
@@ -1,9 +1,14 @@
       program compf10
       implicit none
       double precision prob(60),prob1(60),eps(60)
-      integer line,word
+      integer line,word,i
       logical diff,diffs
 ! Now compare the closed orbit in 53-58 as well
+      do i=1,60
+        prob(i) = 0
+        prob1(i) = 0
+        eps(i) = 0
+      enddo
       line=0
       diff=.false.
       diffs=.false.

--- a/SixTest/bin/verify10.f
+++ b/SixTest/bin/verify10.f
@@ -4,6 +4,8 @@
       integer line,word,i
       logical diff,diffs
 ! Now checks the closed orbit as well as Total Turns
+      probv = 0
+      probv1 = 0
       do i=1,60
         prob(i) = 0
         prob1(i) = 0

--- a/SixTest/bin/verify10.f
+++ b/SixTest/bin/verify10.f
@@ -1,9 +1,13 @@
       program verify10
       implicit none
       double precision prob(60),prob1(60),probv,probv1
-      integer line,word
+      integer line,word,i
       logical diff,diffs
 ! Now checks the closed orbit as well as Total Turns
+      do i=1,60
+        prob(i) = 0
+        prob1(i) = 0
+      enddo
       line=0
       diff=.false.
     1 read (20,*,end=100,err=99) prob


### PR DESCRIPTION
As the title says....

Now it prints out the same output each time (when you run without an input file).