### PR TITLE
Fix runtime warning in test programs with Nagfor.

### DIFF
--- a/SixTest/bin/checkf10.f
+++ b/SixTest/bin/checkf10.f
@@ -28,8 +28,8 @@
          stop 2
       endif
       
-      open(20,status='OLD')
-      open(21,status='OLD')
+      open(20,status='OLD',file="fort.20")
+      open(21,status='OLD',file="fort.21")
       
     1 read (20,*,end=100,err=98) prob
       line=line+1

--- a/SixTest/bin/checkf1014.f
+++ b/SixTest/bin/checkf1014.f
@@ -31,8 +31,8 @@
          stop 2
       endif
       
-      open(20,status='OLD')
-      open(21,status='OLD')
+      open(20,status='OLD', file="fort.20")
+      open(21,status='OLD', file="fort.21")
       
     1 read (20,*,end=100,err=98) lprob
       do i=1,60

--- a/SixTest/bin/checkf110.f
+++ b/SixTest/bin/checkf110.f
@@ -28,8 +28,8 @@
          stop 2
       endif
       
-      open(20,status='OLD')
-      open(21,status='OLD')
+      open(20,status='OLD', file="fort.20")
+      open(21,status='OLD', file="fort.21")
       
     1 read (20,end=100,err=98) prob
       line=line+1

--- a/SixTest/bin/compf10.f
+++ b/SixTest/bin/compf10.f
@@ -29,8 +29,8 @@
          stop 2
       endif
       
-      open(20,status='OLD')
-      open(21,status='OLD')
+      open(20,status='OLD', file="fort.20")
+      open(21,status='OLD', file="fort.21")
       
     1 read (20,*,end=100,err=98) prob
       line=line+1

--- a/SixTest/bin/verify10.f
+++ b/SixTest/bin/verify10.f
@@ -29,8 +29,8 @@
          stop 2
       endif
       
-      open(20,status='OLD')
-      open(21,status='OLD')
+      open(20,status='OLD', file="fort.20")
+      open(21,status='OLD', file="fort.21")
       
     1 read (20,*,end=100,err=99) prob
       line=line+1


### PR DESCRIPTION
Nagfor was giving errors
```
checkf10.f, line 31: Unit 20 is not connected on OPEN with STATUS='OLD' and no FILE= specifier
Program terminated by fatal I/O error
```