### PR TITLE
Building/testing on aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,7 @@ get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 #lots of games to play here.... start with fortran flags
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
 	# gfortran
-	SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops")
+	SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops -ffp-contract=off")
 	SET(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 	SET(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g3 -ffpe-trap=invalid,zero,overflow,underflow -fcheck=all")
 
@@ -661,6 +661,7 @@ endif ()
 #${CMAKE_C_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU")
 
+	set (CMAKE_C_FLAGS "-ffp-contract=off ${CMAKE_C_FLAGS}")
 	set (CMAKE_C_FLAGS_RELEASE "-O2")
 	set (CMAKE_C_FLAGS_DEBUG   "-O0 -g3")
 
@@ -728,6 +729,7 @@ endif()
 #${CMAKE_CXX_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 
+	set (CMAKE_CXX_FLAGS "-ffp-contract=off ${CMAKE_CXX_FLAGS}")
 	set (CMAKE_CXX_FLAGS_RELEASE "-O3")
 	set (CMAKE_CXX_FLAGS_DEBUG   "-O0 -g")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,7 +534,12 @@ get_filename_component (Fortran_COMPILER_NAME ${CMAKE_Fortran_COMPILER} NAME)
 #lots of games to play here.... start with fortran flags
 if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
 	# gfortran
-	SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops -ffp-contract=off")
+	SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops")
+
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+		set (CMAKE_Fortran_FLAGS "-ffp-contract=off ${CMAKE_Fortran_FLAGS}")
+	endif()
+
 	SET(CMAKE_Fortran_FLAGS_RELEASE "-O3")
 	SET(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g3 -ffpe-trap=invalid,zero,overflow,underflow -fcheck=all")
 
@@ -661,7 +666,9 @@ endif ()
 #${CMAKE_C_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU")
 
-	set (CMAKE_C_FLAGS "-ffp-contract=off ${CMAKE_C_FLAGS}")
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+		set (CMAKE_C_FLAGS "-ffp-contract=off ${CMAKE_C_FLAGS}")
+	endif()
 	set (CMAKE_C_FLAGS_RELEASE "-O2")
 	set (CMAKE_C_FLAGS_DEBUG   "-O0 -g3")
 
@@ -729,7 +736,9 @@ endif()
 #${CMAKE_CXX_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 
-	set (CMAKE_CXX_FLAGS "-ffp-contract=off ${CMAKE_CXX_FLAGS}")
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+		set (CMAKE_CXX_FLAGS "-ffp-contract=off ${CMAKE_CXX_FLAGS}")
+	endif()
 	set (CMAKE_CXX_FLAGS_RELEASE "-O3")
 	set (CMAKE_CXX_FLAGS_DEBUG   "-O0 -g")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -536,7 +536,7 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
 	# gfortran
 	SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops")
 
-	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64 )
 		set (CMAKE_Fortran_FLAGS "-ffp-contract=off ${CMAKE_Fortran_FLAGS}")
 	endif()
 
@@ -666,7 +666,7 @@ endif ()
 #${CMAKE_C_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_C_COMPILER_ID} MATCHES "GNU")
 
-	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64 )
 		set (CMAKE_C_FLAGS "-ffp-contract=off ${CMAKE_C_FLAGS}")
 	endif()
 	set (CMAKE_C_FLAGS_RELEASE "-O2")
@@ -736,7 +736,7 @@ endif()
 #${CMAKE_CXX_COMPILER_ID} : From the docs: "one of "Clang", "GNU", "Intel", or "MSVC". This works even if a compiler wrapper like ccache is used."
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 
-	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AARCH64 )
+	if(${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64 )
 		set (CMAKE_CXX_FLAGS "-ffp-contract=off ${CMAKE_CXX_FLAGS}")
 	endif()
 	set (CMAKE_CXX_FLAGS_RELEASE "-O3")


### PR DESCRIPTION
By default gcc seems to create fma instructions on armv8/aarch64. This disables them. Without this the tests will fail.