### PR TITLE
Force static linking of libstdc++ if a static build is requested.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,7 +764,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 	endif()
 
 	if(STATIC)
-		SET(CMAKE_CXX_LINKER_FLAGS "-static ${CMAKE_CXX_LINKER_FLAGS}")
+		SET(CMAKE_CXX_LINKER_FLAGS "-static -static-libstdc++ ${CMAKE_CXX_LINKER_FLAGS}")
 	endif(STATIC)
 
 endif()


### PR DESCRIPTION
This fixes some issues I had with different g++ versions on aarch64.

I also checked it doesn't cause issues on default lxplus.