### PR TITLE
Error output

### DIFF
--- a/SixTrack/libArchive_wrapper.c
+++ b/SixTrack/libArchive_wrapper.c
@@ -48,7 +48,7 @@ void write_archive(const char* const outname, char** filename, int nFiles) {
 			      FILE_ATTRIBUTE_NORMAL, NULL);
     if (hFile == INVALID_HANDLE_VALUE) continue;
     if(!GetFileSizeEx(hFile, &filesize_union)) {
-      printf("CRITICAL ERROR in write_archive(): GetFileSizeEx failed.");
+      fprintf(stderr, "CRITICAL ERROR in write_archive(): GetFileSizeEx failed.");
       exit(EXIT_FAILURE);
     }
     CloseHandle(hFile);
@@ -75,8 +75,8 @@ void write_archive(const char* const outname, char** filename, int nFiles) {
     while ( len > 0 ) {
       err=archive_write_data(a, buff, len);
       if (err < 0){
-	printf("CRITICAL ERROR in write_archive(): When writing file, got err=%i\n",err);
-	printf("CRITICAL ERROR in write_archive(): %s\n",archive_error_string(a));
+	fprintf(stderr, "CRITICAL ERROR in write_archive(): When writing file, got err=%i\n",err);
+	fprintf(stderr, "CRITICAL ERROR in write_archive(): %s\n",archive_error_string(a));
 	exit(EXIT_FAILURE);
       }
       len = fread(buff, 1,sizeof(buff), fd);
@@ -87,7 +87,7 @@ void write_archive(const char* const outname, char** filename, int nFiles) {
     
     //printf("Wrote file '%s', len_total = %i, filesize = %i\n", filename[i], len_total, filesize);
     if (len_total != filesize) {
-      printf("CRITICAL ERROR in write_archive(): When writing file '%s', got len_total = %i but filesize = %i\n", filename[i], len_total, filesize);
+      fprintf(stderr, "CRITICAL ERROR in write_archive(): When writing file '%s', got len_total = %i but filesize = %i\n", filename[i], len_total, filesize);
     }
   }
   archive_entry_free(entry);
@@ -104,14 +104,14 @@ void list_archive(const char* const infile) {
   // TODO: Write a function which *returns* the list of files
   //       (by writing it into a char** supplied by the caller)
   
-  printf("Opening archive '%s' for listing...\n",infile);
+  fprintf(stderr, "Opening archive '%s' for listing...\n",infile);
   
   struct archive* a = archive_read_new();
   archive_read_support_format_zip(a);
   int err = archive_read_open_filename(a, infile,10240);//Note: Blocksize isn't neccessarilly adhered to
   if (err != ARCHIVE_OK) {
-    printf("CRITICAL ERROR in list_archive(): When opening archive '%s', err=%i\n",infile,err);
-    printf("CRITICAL ERROR in list_archive(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in list_archive(): When opening archive '%s', err=%i\n",infile,err);
+    fprintf(stderr, "CRITICAL ERROR in list_archive(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
   
@@ -124,8 +124,8 @@ void list_archive(const char* const infile) {
   archive_read_close(a);
   err = archive_read_free(a);
   if (err != ARCHIVE_OK){
-    printf("CRITICAL ERROR in list_archive(): Error when calling archive_read_free(), '%s', err=%i\n",infile,err);
-    printf("CRITICAL ERROR in list_archive(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in list_archive(): Error when calling archive_read_free(), '%s', err=%i\n",infile,err);
+    fprintf(stderr, "CRITICAL ERROR in list_archive(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
 }
@@ -138,8 +138,8 @@ void list_archive_get(const char* const infile, char** filenames, int* nfiles, c
   archive_read_support_format_zip(a);
   int err = archive_read_open_filename(a, infile,10240);//Note: Blocksize isn't neccessarilly adhered to
   if (err != ARCHIVE_OK) {
-    printf("CRITICAL ERROR in list_archive_get(): When opening archive '%s', err=%i\n",infile,err);
-    printf("CRITICAL ERROR in list_archive_get(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in list_archive_get(): When opening archive '%s', err=%i\n",infile,err);
+    fprintf(stderr, "CRITICAL ERROR in list_archive_get(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
   
@@ -153,20 +153,20 @@ void list_archive_get(const char* const infile, char** filenames, int* nfiles, c
     int buff_used = 0;
     buff_used = snprintf(filenames[*nfiles],buffsize,"%s",archive_entry_pathname(entry));
     if (buff_used >= buffsize) {
-      printf("CRITICAL ERROR in list_archive_get(): When reading file '%s' from archive '%s':\n",filenames[*nfiles],infile);
-      printf("CRITICAL ERROR in list_archive_get(): Buffer too small by %i characters\n",buff_used-buffsize+1);
+      fprintf(stderr, "CRITICAL ERROR in list_archive_get(): When reading file '%s' from archive '%s':\n",filenames[*nfiles],infile);
+      fprintf(stderr, "CRITICAL ERROR in list_archive_get(): Buffer too small by %i characters\n",buff_used-buffsize+1);
       exit(EXIT_FAILURE);
     }
     else if (buff_used < 0) {
-      printf("CRITICAL ERROR in list_archive_get(): When reading file '%s' from archive '%s':\n",filenames[*nfiles],infile);
-      printf("CRITICAL ERROR in list_archive_get(): Error in snprintf.\n");
+      fprintf(stderr, "CRITICAL ERROR in list_archive_get(): When reading file '%s' from archive '%s':\n",filenames[*nfiles],infile);
+      fprintf(stderr, "CRITICAL ERROR in list_archive_get(): Error in snprintf.\n");
       exit(EXIT_FAILURE);
     }
     
     archive_read_data_skip(a);
     
     if(++(*nfiles) >= nfiles_max) {
-      printf("CRITICAL ERROR in list_archive_get(): Number of files greater than nfiles_max=%i",nfiles_max);
+      fprintf(stderr, "CRITICAL ERROR in list_archive_get(): Number of files greater than nfiles_max=%i",nfiles_max);
       exit(EXIT_FAILURE);
     }
   }
@@ -174,8 +174,8 @@ void list_archive_get(const char* const infile, char** filenames, int* nfiles, c
   archive_read_close(a);
   err = archive_read_free(a);
   if (err != ARCHIVE_OK){
-    printf("CRITICAL ERROR in list_archive_get(): Error when calling archive_read_free(), '%s', err=%i\n",infile,err);
-    printf("CRITICAL ERROR in list_archive_get(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in list_archive_get(): Error when calling archive_read_free(), '%s', err=%i\n",infile,err);
+    fprintf(stderr, "CRITICAL ERROR in list_archive_get(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
 }
@@ -200,8 +200,8 @@ void read_archive(const char* const infile, const char* const extractFolder){
   int err;
   err = archive_read_open_filename(a, infile, 10240);
   if (err != ARCHIVE_OK) {
-    printf("CRITICAL ERROR in read_archive(): When opening archive '%s', err=%i\n",infile,err);
-    printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): When opening archive '%s', err=%i\n",infile,err);
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
 
@@ -216,8 +216,8 @@ void read_archive(const char* const infile, const char* const extractFolder){
       break;
     }
     else if (err != ARCHIVE_OK){
-      printf("CRITICAL ERROR in read_archive(): When reading archive, err=%i\n",err);
-      printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): When reading archive, err=%i\n",err);
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
       exit(EXIT_FAILURE);
     }
     //printf("Found file: '%s'\n",archive_entry_pathname(entry));
@@ -227,16 +227,16 @@ void read_archive(const char* const infile, const char* const extractFolder){
     char newPath[PATH_MAX];
     int buff_used = snprintf(newPath, PATH_MAX, "%s/%s",extractFolder,archive_entry_pathname(entry));
     if (buff_used >= PATH_MAX || buff_used < 0){
-      printf("CRITICAL ERROR in read_archive(): Buffer overflow or other error when creating the path.\n");
-      printf("CRITICAL ERROR in read_archive(): buff_used=%i\n",buff_used);
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): Buffer overflow or other error when creating the path.\n");
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): buff_used=%i\n",buff_used);
       exit(EXIT_FAILURE);
     }
     archive_entry_set_pathname(entry,newPath);
     
     err = archive_write_header(ext, entry);
     if (err != ARCHIVE_OK){
-      printf("CRITICAL ERROR in read_archive(): when extracting archive (creating new file), err=%i\n",err);
-      printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(ext));
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): when extracting archive (creating new file), err=%i\n",err);
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(ext));
       exit(EXIT_FAILURE);
     }
 
@@ -254,27 +254,27 @@ void read_archive(const char* const infile, const char* const extractFolder){
 	break;
       }
       else if (err != ARCHIVE_OK){
-	printf("CRITICAL ERROR in read_archive(): When extracting archive (reading data), err=%i\n",err);
-	printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+	fprintf(stderr, "CRITICAL ERROR in read_archive(): When extracting archive (reading data), err=%i\n",err);
+	fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
 	exit(EXIT_FAILURE);
       }
 
       err = archive_write_data_block(ext,buff,size,offset);
       if (err != ARCHIVE_OK){
-	printf("CRITICAL ERROR in read_archive(): When extracting archive (writing data), err=%i\n",err);
-	printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+	fprintf(stderr, "CRITICAL ERROR in read_archive(): When extracting archive (writing data), err=%i\n",err);
+	fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
 	exit(EXIT_FAILURE);
       }
     }
     if (!bcompleted){
-      printf("CRITICAL ERROR in read_archive(): The file writing block loop was aborted by the infinite loop guard\n");
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): The file writing block loop was aborted by the infinite loop guard\n");
       exit(EXIT_FAILURE);
     }
     
     err=archive_write_finish_entry(ext);
     if (err != ARCHIVE_OK) {
-      printf("CRITICAL ERROR in read_archive(): When extracting archive (closing new file), err=%i\n",err);
-      printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(ext));
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): When extracting archive (closing new file), err=%i\n",err);
+      fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(ext));
       exit(EXIT_FAILURE);
     }
   }
@@ -282,20 +282,20 @@ void read_archive(const char* const infile, const char* const extractFolder){
   archive_read_close(a);
   err=archive_read_free(a);
   if (err != ARCHIVE_OK){
-    printf("CRITICAL ERROR in read_archive(): When calling archive_read_free(a), err=%i\n",err);
-    printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): When calling archive_read_free(a), err=%i\n",err);
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
   archive_write_close(ext);
   err = archive_write_free(ext);
   if (err != ARCHIVE_OK){
-    printf("CRITICAL ERROR in read_archive(): When calling archive_read_free(ext), err=%i\n",err);
-    printf("CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): When calling archive_read_free(ext), err=%i\n",err);
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): %s\n",archive_error_string(a));
     exit(EXIT_FAILURE);
   }
   
   if (!fcompleted) {
-    printf("CRITICAL ERROR in read_archive(): The file header loop was aborted by the infinite loop guard\n");
+    fprintf(stderr, "CRITICAL ERROR in read_archive(): The file header loop was aborted by the infinite loop guard\n");
     exit(EXIT_FAILURE);
   }
 }

--- a/SixTrack/lielib.s
+++ b/SixTrack/lielib.s
@@ -100,12 +100,7 @@
               ndt=nd2
               if(ndpt.ne.nd2-1) then
                 write(lout,*) ' LETHAL ERROR IN LIEINIT'
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-                stop 
-+ei
+                call prror(-1)
               endif
             endif
        endif
@@ -3503,12 +3498,8 @@
       read(iref,*) nres
       if(nres.ge.nreso) then
        write(lout,*) ' NRESO IN LIELIB TOO SMALL '
-+if cr
-      call abend('999                                               ')
-+ei
-+if .not.cr
-       stop 999
-+ei
+       write(lout,'(a)') "ERROR 999 in initpert"
+       call prror(-1)
       endif
       elseif(iref.eq.0) then
       nres=0

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -2,8 +2,8 @@
       character*8 version  !Keep data type in sync with 'cr_version'
       character*10 moddate !Keep data type in sync with 'cr_moddate'
       integer itot,ttot
-      data version /'4.6.22'/
-      data moddate /'01.06.2017'/
+      data version /'4.6.23'/
+      data moddate /'04.06.2017'/
 +cd license
 !!SixTrack
 !!

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -63618,8 +63618,8 @@ c$$$         backspace (93,iostat=ierro)
 !+ei
 !     call boinc_zipitall()
 !     call boinc_finish_graphics()
-      close(93)
       if(errout_status.ne.0) then
+         close(93)
          call boincrf('fort.93',filename)
          call print_lastlines_to_stderr(93,filename)
          
@@ -63653,8 +63653,8 @@ c$$$         backspace (93,iostat=ierro)
  31   continue
 !     call boinc_zipitall()
 !     call boinc_finish_graphics()
-      close(93)
       if(errout_status.ne.0) then
+         close(93)
          call boincrf('fort.93',filename)
          call print_lastlines_to_stderr(93,filename)
          

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -9448,13 +9448,7 @@ cc2008
         if(ifail.ne.0.and.ifail.ne.5) then
 !-----------------------------------------------------------------------
           write(lout,10040) ifail
-          call closeUnits
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-          stop
-+ei
+          call prror(-1)
         end if
 !-----------------------------------------------------------------------
         do 200 jsex=1,jeltot
@@ -9667,13 +9661,8 @@ cc2008
    20   continue
         if(point.gt.4000) then
           write(lout,10000)
-          call closeUnits
-+if cr
-      call abend('Problem with data in fort.23')
-+ei
-+if .not.cr
-          stop
-+ei
+          write(lout,'(a)') "Problem with data in fort.23"
+          call prror(-1)
         end if
 !-----------------------------------------------------------------------
 !---- DATA PROCESSING
@@ -10363,13 +10352,7 @@ cc2008
         if(ifail.ne.0.and.ifail.ne.5) then
 !-----------------------------------------------------------------------
           write(lout,10040) ifail
-          call closeUnits
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-          stop
-+ei
+          call prror(-1)
         end if
 !-----------------------------------------------------------------------
         do 170 jsex=1,jeltot
@@ -10579,13 +10562,7 @@ cc2008
    20   continue
         if(point.gt.8000) then
           write(lout,10000)
-          call closeUnits
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-          stop
-+ei
+          call prror(-1)
         end if
 !-----------------------------------------------------------------------
 !---- DATA PROCESSING
@@ -10601,13 +10578,7 @@ cc2008
    30   continue
         if(point.gt.8000) then
           write(lout,10000)
-          call closeUnits
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-          stop
-+ei
+          call prror(-1)
         end if
 !-----------------------------------------------------------------------
 !---- DATA PROCESSING
@@ -25529,7 +25500,7 @@ C Should get me a NaN
       call abend('                                                  ')
 +ei
 +if .not.cr
-      stop 0 ! We're done :)
+      stop 0 ! We're done in maincr:)
 +ei
 10000 format(/t10,'TRACKING ENDED ABNORMALLY'/t10, 'PARTICLE ',i7,      &
      &' RANDOM SEED ',i8,/ t10,' MOMENTUM DEVIATION ',g12.5,            &
@@ -26100,7 +26071,7 @@ C Should get me a NaN
             write(lout,*)
             write(lout,*) "ERROR"
             write(lout,*) "thin6dua not supported by collimation"
-            STOP
+            call prror(-1)
           endif
 +ei
           call thin6dua(nthinerr)
@@ -26428,12 +26399,7 @@ C Should get me a NaN
      &           enerror, bunchlength )
          else
             write(lout,*) 'INFO> review your distribution parameters !!'
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-            stop
-+ei
+            call prror(-1)
          endif
 !
        endif
@@ -29248,7 +29214,7 @@ C Should get me a NaN
      &               "attempting to use a halo not purely in the "//
      &               "horizontal or vertical plane with pencil_dist=3"//
      &               " - abort."
-                stop
+               call prror(-1)
              endif
              
 !     calculate offset from tilt of positive and negative jaws, at start and end
@@ -29380,7 +29346,7 @@ C Should get me a NaN
                 endif
               else
                 Write(lout,*) "ERROR: Non-zero length collimator!"
-                STOP
+                call prror(-1)
               endif
 !
               flukaname(j) = ipart(j)+100*samplenumber
@@ -30207,12 +30173,7 @@ C Should get me a NaN
      &                  part_impact(j)
                   write(outlun,*) 'ERR>  Invalid impact parameter!',    &
      &                  part_impact(j)
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-      stop
-+ei
+                  call prror(-1)
                 endif
                 n_impact = n_impact + 1
                 sum = sum + part_impact(j)
@@ -33359,7 +33320,7 @@ C Should get me a NaN
       if (do_coll) then
          write(lout,*) "Error: in trauthck and do_coll is TRUE"
          write(lout,*) "Collimation is not supported for thick tracking"
-         STOP
+         call prror(-1)
       endif
 +ei
 
@@ -33867,7 +33828,7 @@ C Should get me a NaN
          write (lout,*) 
      & "DUMP/FRONT not yet supported on thick elements "//
      & "due to lack of test cases. Please contact developers!"
-      stop
+         call prror(-1)
 !+ca dumplines
       endif
       
@@ -34435,7 +34396,7 @@ C Should get me a NaN
          write (lout,*) 
      & "DUMP/FRONT not yet supported on thick elements "//
      & "due to lack of test cases. Please contact developers!"
-      stop
+         call prror(-1)
 !+ca dumplines
       endif
 
@@ -35116,7 +35077,7 @@ C Should get me a NaN
          write (lout,*) 
      & "DUMP/FRONT not yet supported on thick elements "//
      & "due to lack of test cases. Please contact developers!"
-      stop
+         call prror(-1)
 !+ca dumplines
       endif
 
@@ -37119,7 +37080,7 @@ C Should get me a NaN
       call abend('                                                  ')
 +ei
 +if .not.cr
-      stop
+      stop 0 ! We're done in mainda :)
 +ei
 +if .not.tilt
 10000 format(/t10,'SIXTRACK DA VERSION ',A8,                            &
@@ -46025,13 +45986,8 @@ c$$$            endif
             write(lout,*) 'DIVISION BY ZERO EXPECTED.'
             write(lout,*) 'PROBABLY TWO CORRECTORS TOO CLOSE.'
             write(lout,10000) ' SUSPECTED CORRECTOR: ',j
-            call closeUnits
-+if cr
-      call abend('777                                               ')
-+ei
-+if .not.cr
-            stop 777
-+ei
+            write(lout,'(a)') "Error '777' in subroutine htls"
+            call prror(-1)
           endif
 
           rho(j)=h
@@ -55232,13 +55188,7 @@ c$$$            endif
       return
  900  write(lout,910) p0
  910  format(' (FUNC.GAUINV) INVALID INPUT ARGUMENT ',1pd20.13)
-      call closeUnits
-+if cr
-      call abend('                                                  ')
-+ei
-+if .not.cr
-      stop
-+ei
+      call prror(-1)
       end
 +dk myrinv
       subroutine kerset(ercode,lgfile,limitm,limitr)
@@ -56336,7 +56286,7 @@ c$$$            endif
          write(lout,*) 'ERR>  In subroutine collimate2:'
          write(lout,*) 'ERR>  Material "', c_material, '" not found.'
          write(lout,*) 'ERR>  Check your CollDB! Stopping now.'
-         STOP
+         call prror(-1)
       endif
 !
         length  = c_length
@@ -56641,7 +56591,7 @@ c$$$            endif
             s = (-1d0*x) / xp
             if (s.le.0) then
               write(lout,*) 'S.LE.0 -> This should not happen'
-              stop
+              call prror(-1)
             endif
 !
             if (s .lt. length) then
@@ -57118,7 +57068,7 @@ c$$$          endif
          mat = 12
       else
          write(lout,*) 'ERR>  Material not found. STOP', c_material
-!        STOP
+         call prror(-1)
       endif
 !
         length  = c_length
@@ -57379,7 +57329,7 @@ c$$$          endif
             s = (-1.0d0*x) / xp
             if (s.le.0d0) then
               write(lout,*) 'S.LE.0 -> This should not happen (1)'
-              stop
+              call prror(-1)
             endif
 !
             if (s .lt. length) then
@@ -57400,7 +57350,7 @@ c$$$          endif
             s = (-1.0d0*z) / zp
             if (s.le.0) then
               write(lout,*) 'S.LE.0 -> This should not happen (2)'
-              stop
+              call prror(-1)
             endif
 !
             if (s .lt. length) then
@@ -57429,7 +57379,7 @@ c$$$          endif
 !
             if (s.le.0d0) then
               write(lout,*) 'S.LE.0 -> This should not happen (3)'
-              stop
+              call prror(-1)
             endif
 !
             if (s .lt. length) then
@@ -58127,7 +58077,7 @@ c$$$          endif
          elseif ( mynex.eq.0d0.and.myney.eq.0d0 ) then  ! nominal bunches centered in the aperture - can't apply rejection sampling. return with error
             write(lout,*) "Stop in makedis_coll. attempting to use halo type 
      &3 with Gaussian dist. "
-            stop
+            call prror(-1)
 c$$$            phix = (2d0*pi)*dble(rndm4())                                 
 c$$$            iix = (-1d0*myemitx0) * log( dble(rndm4()) )                  
 c$$$            myx(j) = sqrt((2d0*iix)*mybetax) * cos(phix)                  
@@ -61134,12 +61084,8 @@ c      write(*,*)cs_tail,prob_tail,ranc,EnLo*DZ
         write(lout,*) '!!!!! WARNING !!!!!'
         write(lout,*)'beambeamdist.dat is either missing or too small'
         write(lout,*)
-+if cr
-        call abend('bnlelens input file error                         ')
-+ei      
-+if .not.cr
-        stop
-+ei
+        write(lout,'(a)') 'bnlelens input file error'
+        call prror(-1)
       else
         write(lout,*) "Number of samples in the bunch = ",mynp
       endif
@@ -65824,7 +65770,7 @@ c$$$         backspace (93,iostat=ierro)
       enddo
       if (pressID.eq.0) then
        write(lout,*) 'Couldnt find pressure marker at',totals
-       stop
+       call prror(-1)
       endif
       
       doLorentz=0
@@ -65916,7 +65862,7 @@ c$$$         backspace (93,iostat=ierro)
            write(lout,*) "ERROR> there is something wrong",             &
      &      " with your dpmjet event", bgiddb(choice),totMomentum,      &
      &      new4MomCoord
-           stop
+            call prror(-1)
           else
 !           boosted xp event
            bgxpdb(choice) = z(1)
@@ -66072,7 +66018,7 @@ c$$$         backspace (93,iostat=ierro)
       j=j+1
        if (j>bgmaxx) then
          write(lout,*) 'ERROR> Too many pressure markers!'
-         stop
+         call prror(-1)
        endif
       else if (filereaderror.lt.0) then
 !       means that end of file is reached
@@ -66115,7 +66061,7 @@ c$$$         backspace (93,iostat=ierro)
          if (previousEvent.gt.dpmjetevents) exit
          if (numberOfEvents.gt.(bgmaxx-1)) then
          write(lout,*) 'ERROR> Too many dpmjet events!'
-         stop
+         call prror(-1)
       endif
       enddo
 !       number of lines in dpmjet - 1
@@ -66128,7 +66074,7 @@ c$$$         backspace (93,iostat=ierro)
          write(lout,*) 'ERROR> Maximum for this sixtrack run is: ',mynp
          write(lout,*) 'ERROR> You generated ',numberOfEvents,' trackable  &
      &events'
-         stop
+         call prror(-1)
       endif
       write(lout,*) 'INFO> This is job number: ', njobthis
       write(lout,*) 'INFO> Total number of jobs is: ', njobs

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -80,6 +80,11 @@
 !     Otherwise write directly to "*" aka iso_fortran_env::output_unit (usually unit 6)
       integer lout
       common /crflags/lout
++cd errout
+!     Set the exit status in case of an error.
+      integer errout_status
+      common /errout/ errout_status
+      
 +cd commtim
       real r1,timestart,timenow
       common /mytimes/timestart
@@ -23385,6 +23390,7 @@ C Should get me a NaN
 +if crlibm
 +ca crlibco
 +ei
++ca errout
 !-----------------------------------------------------------------------
 !
 !  SIXTRACK
@@ -23509,6 +23515,10 @@ C Should get me a NaN
      &' September',' October  ',' November ',' December '/
 +ca version
 !-----------------------------------------------------------------------
+      
+      errout_status = 0         ! Set to nonzero before calling abend in case of error.
+                                ! If prror is called, it will be set internally.
+      
 +if crlibm
 ! Removed the call to disable_xp for Laurent
 ! but re-instated it
@@ -25519,7 +25529,7 @@ C Should get me a NaN
       call abend('                                                  ')
 +ei
 +if .not.cr
-      stop
+      stop 0 ! We're done :)
 +ei
 10000 format(/t10,'TRACKING ENDED ABNORMALLY'/t10, 'PARTICLE ',i7,      &
      &' RANDOM SEED ',i8,/ t10,' MOMENTUM DEVIATION ',g12.5,            &
@@ -36685,6 +36695,7 @@ C Should get me a NaN
 +ca commonta
 +ca commonl
 +ca commonc
++ca errout      
 !-----------------------------------------------------------------------
       character*10 cmonth
       character*80 day,runtim
@@ -36714,6 +36725,9 @@ C Should get me a NaN
 +ei
 +ca version
 
+      errout_status = 0         ! Set to nonzero before calling abend in case of error.
+                                ! If prror is called, it will be set internally.
+      
 +if .not.cr
       lout=output_unit
 +ei
@@ -40243,8 +40257,12 @@ C Should get me a NaN
 +if bnlelens
 +ca rhicelens
 +ei
++ca errout
       save
 !-----------------------------------------------------------------------
+
+      errout_status = ier
+      
       write(lout,10000)
       goto(10  ,20  ,30  ,40  ,50  ,60  ,70  ,80  ,90  ,100 , !1-10  
      &     110 ,120 ,130 ,140 ,150 ,160 ,170 ,180 ,190 ,200 , !11-20 
@@ -40475,7 +40493,7 @@ C Should get me a NaN
       call abend('                                                  ')
 +ei
 +if .not.cr
-      stop
+      stop errout_status
 +ei
 10000 format(5x///t10,'++++++++++++++++++++++++'/ t10,                  &
      &'+++++ERROR DETECTED+++++'/ t10,'++++++++++++++++++++++++'/ t10,  &
@@ -63464,6 +63482,7 @@ c$$$         backspace (93,iostat=ierro)
 +ca commonxz
 +ca crco
 +ca version
++ca errout
       integer i,lstring,j
       character*(*) cstring
       character*256 filename
@@ -63616,7 +63635,7 @@ c$$$         backspace (93,iostat=ierro)
     7 continue
       if (lout.eq.92) then
         write(93,*)                                                     &
-     &'SIXTRACR STOP/ABEND copying fort.92'
+     &'SIXTRACR STOP/ABEND copying fort.92 to fort.6'
         endfile (93,iostat=ierro)
         backspace (93,iostat=ierro)
         rewind 92
@@ -63652,9 +63671,10 @@ c$$$         backspace (93,iostat=ierro)
 !+ei
 !     call boinc_zipitall()
 !     call boinc_finish_graphics()
-      call boinc_finish(0)
+      call boinc_finish(errout_status)
 +ei
-      stop
+      stop errout_status
+      
     8 write(93,*)                                                       &
      &'SIXTRACR CR ABEND *** ERROR *** reading fort.92, iostat=',ierro
       close(93)
@@ -63672,9 +63692,9 @@ c$$$         backspace (93,iostat=ierro)
  31   continue
 !     call boinc_zipitall()
 !     call boinc_finish_graphics()
-      call boinc_finish(0)
+      call boinc_finish(errout_status)
 +ei
-      stop
+      stop errout_status
 +ei
 +if .not.cr
       !This one should probably remain as write(*,*) or use output_unit
@@ -63683,9 +63703,10 @@ c$$$         backspace (93,iostat=ierro)
 +if debug
                    !call system('../crend   >> crlog')
 +ei
-      stop
+      stop errout_status
 +ei
       end
+      
 +dk plotdumy
       subroutine hbook2(i1,c1,i2,r1,r2,i3,r3,r4,r5)
       implicit none

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -63699,6 +63699,7 @@ c$$$         backspace (93,iostat=ierro)
       character(1024) fileBuff (nlines)
       integer fileBuff_idx
       integer i,j
+      integer printLines
 
       logical lopen
       integer ierro
@@ -63726,17 +63727,16 @@ c$$$         backspace (93,iostat=ierro)
          return
       endif
       
-      write(error_unit,'(a,1x,i5,1x,a,a,a)')
-     &     "******* Last",nlines,"lines of file '",file_name,"' *******"
-      
 !     Read into fileBuff as a ring buffer.
       fileBuff_idx = 1
+      j = 0
       
  1    read(file_unit,'(a1024)',end=3,err=2,iostat=ierro)
      &     fileBuff(fileBuff_idx)
     ! write(error_unit,*) fileBuff_idx,":",trim(fileBuff(fileBuff_idx))
       fileBuff_idx = fileBuff_idx+1
       if (fileBuff_idx.ge.nlines) fileBuff_idx = 1
+      j = j+1
       goto 1
       
  2    continue                  !An error occured
@@ -63748,6 +63748,16 @@ c$$$         backspace (93,iostat=ierro)
       close(file_unit)
 
 !     Print stuff back out from the buffer
+      if (j .lt. nlines) then
+         printLines = j
+         fileBuff_idx=1
+      else
+         printLines = nlines
+      endif
+      write(error_unit,'(a,1x,i5,1x,a,a,a)')
+     &     "******* Last",printLines,"lines of file '",
+     &     file_name,"': *******"
+      
       i = fileBuff_idx          !Position in buffer (we have already incremented i)
       j = 0                     !How many have we printed
       
@@ -63755,13 +63765,13 @@ c$$$         backspace (93,iostat=ierro)
       write(error_unit,'(a)') trim(fileBuff(i))
       i = i+1
       j = j+1                   ! j just counts
-      if (j.lt.nlines) goto 10
+      if (j.lt.printLines) goto 10
 
       write(error_unit,'(a,a,a)')
      &     "******* Done writing tail of file '",file_name,
      &     "' to stderr *******"
       
-      end subroutine
+      end subroutine print_lastlines_to_stderr
       
 +dk plotdumy
       subroutine hbook2(i1,c1,i2,r1,r2,i3,r3,r4,r5)


### PR DESCRIPTION
Debugging failed BOINC runs tends to be quite difficult; this patch should make it easier:
* It puts the error messages in stderr, which is returned by the client
* When something fails, it sets another return code than 0; zero is reserved for successful runs ONLY.
* All failure exits in SixTrack now call prror, nowhere except the bottom of program `maincr` and `mainda` calls STOP/ABEND/etc. directly.

This part is therefore in principle done. I would however want to look for a problem in SixTestWrapper - for quick / failed runs, it seems to always restart the process over and over; it should probably also look at the exit code of SixTrack.