### PR TITLE
Safe and correct repositioning of files

### DIFF
--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -43076,7 +43076,7 @@ C      write(*,*) "DBGDBG c:", funName, len(funName)
                enddo
             endif
             
-         enddo
+         enddo !END "do ii=1, nfuncs_dynk"
 
          !Open dynksets.dat
 +if collimat
@@ -43120,11 +43120,11 @@ C      write(*,*) "DBGDBG c:", funName, len(funName)
             endfile (665,iostat=ierro)
             backspace (665,iostat=ierro)
 +ei
-+if collimat
-         endif
-+ei
 +if cr
-         endif
+         endif !END if(dynkfilepos.eq.-1)
++ei
++if collimat
+         endif !END if(samplenumber.eq.1)
 +ei
  
 +if collimat
@@ -43148,9 +43148,9 @@ C      write(*,*) "DBGDBG c:", funName, len(funName)
      &                            csets_unique_dynk(ii,2),
      &                            newValue )
             enddo
-         endif
-+ei
-      endif
+         endif !END "if (samplenumber.gt.1) then"
++ei !END +if collimat
+      endif ! END "if (turn .eq. 1) then"
       
       !Apply the sets
       do ii=1,nsets_dynk
@@ -53016,6 +53016,12 @@ c$$$            endif
 +ei
 ! We should really write fort.10 in BINARY!
       write(110,iostat=ierro) (sumda(i),i=1,60)
+      if(ierro.ne.0) then
+        write(lout,*)
+        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 110'
+        write(lout,*) 'ERROR CODE : ',ierro
+        write(lout,*)
+      endif
 +if debug
 +if .not.nagfor
       write(210,'(60Z21)') (sumda(i),i=1,60)
@@ -53041,7 +53047,7 @@ c$$$            endif
 +ei
       if(ierro.ne.0) then
         write(lout,*)
-        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 10 or 110' 
+        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 10'
         write(lout,*) 'ERROR CODE : ',ierro
         write(lout,*)
       endif
@@ -53427,6 +53433,12 @@ c$$$            endif
 +ei
 ! We should really write fort.10 in BINARY!
       write(110,iostat=ierro) (sumda(i),i=1,60)
+      if(ierro.ne.0) then
+        write(lout,*)
+        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 110'
+        write(lout,*) 'ERROR CODE : ',ierro
+        write(lout,*)
+      endif
 +if debug
 +if .not.nagfor
       write(210,'(60Z21)') (sumda(i),i=1,60)
@@ -53452,7 +53464,7 @@ c$$$            endif
 +ei
       if(ierro.ne.0) then
         write(lout,*)
-        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 10 or 110' 
+        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 10'
         write(lout,*) 'ERROR CODE : ',ierro
         write(lout,*)
       endif
@@ -61764,10 +61776,12 @@ c$$$         backspace (93,iostat=ierro)
      &(crbinrecs(j),j=1,(crnapxo+1)/2)
         endfile (93,iostat=ierro)
         backspace (93,iostat=ierro)
+        
 !--   First we position fort.6 to last checkpoint
-  603   read(6,'(a1024)',end=604,err=106,iostat=ierro) arecord
-        sixrecs=sixrecs+1
-        if (sixrecs.lt.crsixrecs) goto 603
+        do j=1,crsixrecs
+           read(6,'(a1024)',end=604,err=106,iostat=ierro) arecord
+           sixrecs=sixrecs+1
+        end do
         endfile (6,iostat=ierro)
   604   backspace (6,iostat=ierro)
 +if debug
@@ -61783,6 +61797,7 @@ c$$$         backspace (93,iostat=ierro)
         if (lhc.eq.9) then
 !--   Now re-position beambeam-output.dat and lostID.dat
 !--   or only fort.10 if boinc
+!     TODO: Fix positioning in +if bnlelens so that it works when number of cr records = 0
 +if .not.boinc
   610     read(52,'(a1024)',end=608,err=108,iostat=ierro) arecord
           bnlrec=bnlrec+1
@@ -61817,7 +61832,8 @@ c$$$         backspace (93,iostat=ierro)
         endif
 !GRDRHIC
 !GRD-042008
-+ei
++ei !END +if bnlelens
+
 !--   We may be re-running with a DIFFERENT number of turns (numl)
 ! Eric fix this later by reading numl for fort.90
         if (numl.ne.crnuml) then
@@ -61855,7 +61871,7 @@ c$$$         backspace (93,iostat=ierro)
           open(94,file='fort.94',form='unformatted',status='unknown')
 +ei
 +if .not.stf
-          do 13 ia=1,crnapxo/2,1
+          do ia=1,crnapxo/2,1
             ! First, copy crbinrecs(ia) records of data from fort.91-ia to fort.94
             mybinrecs=0
             binrecs94=0
@@ -61866,7 +61882,7 @@ c$$$         backspace (93,iostat=ierro)
             hbuff(51)=numl ! Reset the number of turns (not very elegant)
             write(94,err=105,iostat=ierro) hbuff
             ! Copy particle tracking data
-            do 14 j=2,crbinrecs(ia)
+            do j=2,crbinrecs(ia)
               if(ntwin.ne.2) then
                 read(91-ia,err=105,end=105,iostat=ierro)                &
      &(tbuff(k),k=1,17)
@@ -61876,7 +61892,7 @@ c$$$         backspace (93,iostat=ierro)
                 write(94,err=105,iostat=ierro) tbuff
               endif
               mybinrecs=mybinrecs+1
- 14         continue
+            end do ! END "do j=2,crbinrecs(ia)"
             
             ! Second, copy crbinrecs(ia) records of data from fort.94 to fort.91-ia
             rewind 94
@@ -61886,7 +61902,7 @@ c$$$         backspace (93,iostat=ierro)
             binrecs94=binrecs94+1
             write(91-ia,err=105,iostat=ierro) hbuff
             ! Copy particle tracking data
-            do 15 j=2,crbinrecs(ia)
+            do j=2,crbinrecs(ia)
               if(ntwin.ne.2) then
                 read(94,err=105,end=105,iostat=ierro)                   &
      &(tbuff(k),k=1,17)
@@ -61896,11 +61912,11 @@ c$$$         backspace (93,iostat=ierro)
                 write(91-ia,err=105,iostat=ierro) tbuff
               endif
               binrecs94=binrecs94+1
-   15       continue
-   17       endfile (91-ia,iostat=ierro)
+            end do ! END "j=2,crbinrecs(ia)"
+            endfile (91-ia,iostat=ierro)
             backspace (91-ia,iostat=ierro)
             rewind 94
-   13     continue ! END "do 13 ia=1,crnapxo/2,1"
+         end do ! END "do ia=1,crnapxo/2,1"
 +ei ! END +if .not.stf
 +if stf
           ! First, copy crbinrecs(ia)*(crnapx/2) records of data from singletrackfile.dat to fort.94
@@ -61977,7 +61993,7 @@ c$$$         backspace (93,iostat=ierro)
           ! Binary files have been rewritten; now re-position
           write(93,*)                                                   &
      &'SIXTRACR CRCHECK re-positioning binary files'
-          do 10 ia=1,crnapxo/2,1
+          do ia=1,crnapxo/2,1
             myia=91-ia
             if (crbinrecs(ia).ge.crbinrec) then
               mybinrecs=0
@@ -61998,7 +62014,7 @@ c$$$         backspace (93,iostat=ierro)
               write(93,*)                                               &
      &'SIXTRACR CRCHECK ignoring IA ',ia,' Unit ',myia
             endif
-   10     continue
+         end do ! END "do ia=1,crnapxo/2,1"
 +ei ! END +if .not.stf
 +if stf
       mybinrecs=0
@@ -62054,40 +62070,50 @@ c$$$         backspace (93,iostat=ierro)
             call abend
      &('SIXTRACR CRCHECK failure positioning dynksets.dat ')
          end if
+         if (dynkfilepos_cr .ne. -1) then
 +if boinc
-         call boincrf("dynksets.dat",filename)
-         open(unit=665,file=filename,status="old",
-     &        action="readwrite", err=110)
+            call boincrf("dynksets.dat",filename)
+            open(unit=665,file=filename,status="old",
+     &           action="readwrite", err=110)
 +ei
 +if .not.boinc
-         open(unit=665,file='dynksets.dat',status="old",
-     &        action="readwrite", err=110)
+            open(unit=665,file='dynksets.dat',status="old",
+     &           action="readwrite", err=110)
 +ei
-         dynkfilepos = 0 ! Start counting lines at 0, not -1
-         
- 701     read(665,'(a1024)',end=110,err=110,iostat=ierro) arecord
-         dynkfilepos=dynkfilepos+1
-         if (dynkfilepos.lt.dynkfilepos_cr) goto 701
+            dynkfilepos = 0     ! Start counting lines at 0, not -1
+            do j=1,dynkfilepos_cr
+               read(665,'(a1024)',end=110,err=110,iostat=ierro) arecord
+               dynkfilepos=dynkfilepos+1
+            end do
 
-         endfile (665,iostat=ierro)
-!         backspace (665,iostat=ierro)
-         close(665)
+            endfile (665,iostat=ierro)
+            close(665)
 +if boinc
-         call boincrf("dynksets.dat",filename)
-         open(unit=665, file=filename, status="old",
-     &        position='append', action="write")
+            call boincrf("dynksets.dat",filename)
+            open(unit=665, file=filename, status="old",
+     &           position='append', action="write")
 +ei
 +if .not.boinc
-         open(unit=665, file="dynksets.dat", status="old",
-     &        position='append', action="write")
+            open(unit=665, file="dynksets.dat", status="old",
+     &           position='append', action="write")
 +ei
          
-         write(93,*)                                                     &
+            write(93,*)
      &'SIXTRACR CRCHECK sucessfully repositioned dynksets.dat, '//
-     &'dynkfilepos=',dynkfilepos
-        endfile (93,iostat=ierro)
-        backspace (93,iostat=ierro)
-      endif
+     &'dynkfilepos=',dynkfilepos, "dynkfilepos_cr=",dynkfilepos_cr
+            endfile (93,iostat=ierro)
+            backspace (93,iostat=ierro)
+         else
+            write(93,*)
+     &           'SIXTRACR CRCHECK did not attempt repositioning '//
+     &           'of dynksets.dat, dynkfilepos_cr=',dynkfilepos_cr
+            write(93,*) "If anything has been written to the file, "//
+     &           "it will be correctly truncated in dynk_apply "//
+     &           "on the first turn."
+            endfile (93,iostat=ierro)
+            backspace (93,iostat=ierro)
+         endif !END "if (dynkfilepos_cr .ne. -1)"
+      endif !END if (ldynk .and.(.not.ldynkfiledisable) )
       
       !Reposition files for DUMP
       write(93,*) "SIXTRACR CRCHECK REPOSITIONING DUMP files"
@@ -62121,10 +62147,12 @@ c$$$         backspace (93,iostat=ierro)
                endif
 
                dumpfilepos(i) = 0
- 702           read(dumpunit(i),'(a1024)',end=111,err=111,iostat=ierro)
-     &              arecord
-               dumpfilepos(i) = dumpfilepos(i) + 1
-               if (dumpfilepos(i).lt.dumpfilepos_cr(i)) goto 702
+               do j=1,dumpfilepos_cr(i)
+ 702              read(dumpunit(i),'(a1024)',
+     &                 end=111,err=111,iostat=ierro)
+     &                 arecord
+                  dumpfilepos(i) = dumpfilepos(i) + 1
+               end do
 
             else                         ! BINARY (format = 3)
                if ( .not. lopen ) then
@@ -62139,12 +62167,13 @@ c$$$         backspace (93,iostat=ierro)
 +ei
                endif
                dumpfilepos(i) = 0
- 703           read(dumpunit(i),end=111,err=111,iostat=ierro)
-     &              tmp_ID,tmp_nturn,tmp_dcum,
-     &              tmp_x,tmp_xp,tmp_y,tmp_yp,tmp_sigma,tmp_dEE,
-     &              tmp_ktrack
-               dumpfilepos(i) = dumpfilepos(i) + 1
-               if (dumpfilepos(i).lt.dumpfilepos_cr(i)) goto 703
+               do j=1,dumpfilepos_cr(i)
+ 703              read(dumpunit(i),end=111,err=111,iostat=ierro)
+     &                 tmp_ID,tmp_nturn,tmp_dcum,
+     &                 tmp_x,tmp_xp,tmp_y,tmp_yp,tmp_sigma,tmp_dEE,
+     &                 tmp_ktrack
+                  dumpfilepos(i) = dumpfilepos(i) + 1
+               end do
             endif
 
          endif
@@ -62154,7 +62183,7 @@ c$$$         backspace (93,iostat=ierro)
       do i=0, il
          if (ldump(i)) then
             endfile (dumpunit(i),iostat=ierro)
-C            backspace (dumpunit(i),iostat=ierro)
+            
             ! Change from 'readwrite' to 'write'
             close(dumpunit(i))
             if (dumpfmt(i).ne.3) then ! ASCII
@@ -62196,7 +62225,10 @@ C            backspace (dumpunit(i),iostat=ierro)
         backspace (93,iostat=ierro)
         return
       endif
-      goto 605
+      
+      goto 605                  !Should not end up here -> checkpoint failed.
+                                ! Start simulation over!
+
 !--   Just abort if we cannot re-position/copy the binary files,
 +if .not.stf
   102 write(lout,*)
@@ -63722,7 +63754,7 @@ c$$$         backspace (93,iostat=ierro)
         if(ierro.ne.0) then
           write(lout,*)
           write(lout,*)                                                 &
-     &'*** ERROR ***,PROBLEMS WRITING TO FILE 10 or 110' 
+     &'*** ERROR ***,PROBLEMS WRITING TO FILE 10 FROM ABEND'
           write(lout,*) 'ERROR CODE : ',ierro
           write(lout,*)
         endif

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -2,8 +2,8 @@
       character*8 version  !Keep data type in sync with 'cr_version'
       character*10 moddate !Keep data type in sync with 'cr_moddate'
       integer itot,ttot
-      data version /'4.6.25'/
-      data moddate /'06.06.2017'/
+      data version /'4.6.26'/
+      data moddate /'07.06.2017'/
 +cd license
 !!SixTrack
 !!


### PR DESCRIPTION
Previously, the DUMP, dynksets, and (theoretically fort.6) files were repositioned in a way that was unsafe. This could lead to incorrect results in the output, with doubled- or missing lines, or crashes.

This patch fixes #281 .