### PR TITLE
Fixed some code formatting that broke syntax highlighting

### DIFF
--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -27134,12 +27134,11 @@ C Should get me a NaN
             if(abs(dppoff).gt.pieni) sigmv(j)=sigmv(j)-sigmoff(i)
             if(kz(ix).eq.12) then
 +if crlibm
-              ejv(j)=ejv(j)+ed(ix)*sin_rn(hsyc(ix)*sigmv(j)+
+              ejv(j)=ejv(j)+ed(ix)*sin_rn(hsyc(ix)*sigmv(j)+phasc(ix))
 +ei
 +if .not.crlibm
-              ejv(j)=ejv(j)+ed(ix)*sin(hsyc(ix)*sigmv(j)+               &
+              ejv(j)=ejv(j)+ed(ix)*sin(hsyc(ix)*sigmv(j)+phasc(ix))
 +ei
-     &phasc(ix))
             else
 +if crlibm
               ejv(j)=ejv(j)+hsy(1)*sin_rn(hsy(3)*sigmv(j))
@@ -27792,11 +27791,11 @@ C Should get me a NaN
             if(kz(ix).eq.12) then
 +if crlibm
               ejv(j)=ejv(j)+ed(ix)*sin_rn((hsyc(ix)*sigmv(j)+phas)+     &!hr01
-     &phasc(ix))                                                         !hr01
+     &                                    phasc(ix))                     !hr01
 +ei
 +if .not.crlibm
               ejv(j)=ejv(j)+ed(ix)*sin((hsyc(ix)*sigmv(j)+phas)+        &
-     &phasc(ix))                                                         !hr01
+     &                                 phasc(ix))                        !hr01
 +ei
             else
 +if crlibm
@@ -30394,12 +30393,11 @@ C Should get me a NaN
               if(abs(dppoff).gt.pieni) sigmv(j)=sigmv(j)-sigmoff(i)
               if(kz(ix).eq.12) then
 +if crlibm
-                ejv(j)=ejv(j)+ed(ix)*sin_rn(hsyc(ix)*sigmv(j)+
+                ejv(j)=ejv(j)+ed(ix)*sin_rn(hsyc(ix)*sigmv(j)+phasc(ix))
 +ei
 +if .not.crlibm
-                ejv(j)=ejv(j)+ed(ix)*sin(hsyc(ix)*sigmv(j)+             &
+                ejv(j)=ejv(j)+ed(ix)*sin(hsyc(ix)*sigmv(j)+phasc(ix))
 +ei
-     &phasc(ix))
               else
 +if crlibm
                 ejv(j)=ejv(j)+hsy(1)*sin_rn(hsy(3)*sigmv(j))
@@ -31064,11 +31062,12 @@ C Should get me a NaN
               if(kz(ix).eq.12) then
 +if crlibm
                 ejv(j)=ejv(j)+ed(ix)*sin_rn((hsyc(ix)*sigmv(j)+phas)+   &!hr01
+     &                                      phasc(ix))
 +ei
 +if .not.crlibm
                 ejv(j)=ejv(j)+ed(ix)*sin((hsyc(ix)*sigmv(j)+phas)+      &!hr01
+     &                                   phasc(ix))
 +ei
-     &phasc(ix))
               else
 +if crlibm
                 ejv(j)=ejv(j)+hsy(1)*sin_rn(hsy(3)*sigmv(j)+phas)


### PR DESCRIPTION
Beginning a parenthesis twice in a +if block broke syntax highlighting. These repeated code lines were also inconsistent in the source. Parentheses are now closed properly in all four blocks.