### PR TITLE
Fix building testing on some systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1393,7 +1393,7 @@ IF(BUILD_TESTING)
 	if(${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
 		target_link_libraries(SixTestWrapper stdc++)
 	endif()
-	#set_property(TARGET SixTestWrapper PROPERTY CXX_STANDARD 11)
+	set_property(TARGET SixTestWrapper PROPERTY CXX_STANDARD 11)
 
 	#just a work around to build on MSYS2 for now
 	if(MSYS AND STATIC)


### PR DESCRIPTION
Some systems, e.g. ubuntu. still have a compiler that does not enable c++11 by default.

The test tool needs c++11, therefore the build explodes.

This change fixes this...