### PR TITLE
Mark SCATTERed particles as dirty for collimation

### DIFF
--- a/SixTrack/collimation.s90
+++ b/SixTrack/collimation.s90
@@ -812,6 +812,7 @@ subroutine collimate_start_sample(nsample)
     tertiary(j)       = 0
     secondary(j)      = 0
     other(j)          = 0
+    scatterhit(j)     = 0
     nabs_type(j)      = 0
     ipart(j)          = j
     flukaname(j)      = 0
@@ -1131,12 +1132,13 @@ subroutine collimate_start_sample(nsample)
   call rluxgo(rnd_lux, rnd_seed, rnd_k1, rnd_k2)
 ! TW - 01/2007
 
-!GRD INITIALIZE LOCAL ADDITIVE PARAMETERS, ie THE ONE WE DON'T WANT
+!GRD INITIALIZE LOCAL ADDITIVE PARAMETERS, I.E. THE ONE WE DON'T WANT
 !GRD TO KEEP OVER EACH LOOP
   do j=1,napx
     tertiary(j)=0
     secondary(j)=0
     other(j)=0
+    scatterhit(j)=0
     nabs_type(j) = 0
   end do
 
@@ -1485,7 +1487,7 @@ subroutine collimate_do_collimator(stracki)
 !     &'#  1=x 2=y 3=xp 4=yp 5=E 6=s'
     do j = 1, napx
       write(45,'(1X,I8,6(1X,E15.7),3(1X,I4,1X,I4))') ipart(j)+100*samplenumber,xv(1,j), xv(2,j), yv(1,j), yv(2,j),     &
-     &        ejv(j), mys(j),iturn,secondary(j)+tertiary(j)+other(j),nabs_type(j)
+     &        ejv(j), mys(j),iturn,secondary(j)+tertiary(j)+other(j)+scatterhit(j),nabs_type(j)
     end do
   end if
 
@@ -2405,7 +2407,7 @@ subroutine collimate_end_collimator()
         hdfy    = (rcy0(j)*c1e3+torby(ie))-half*c_length*(rcyp0(j)*c1e3+torbyp(ie))
         hdfyp   = rcyp0(j)*c1e3+torbyp(ie)
         hdfdee  = (ejv(j)-myenom)/myenom
-        hdftyp  = secondary(j)+tertiary(j)+other(j)
+        hdftyp  = secondary(j)+tertiary(j)+other(j)+scatterhit(j)
         CALL APPENDREADING(hdfpid,hdfturn,hdfs,hdfx,hdfxp,hdfy,hdfyp,hdfdee,hdftyp)
 +ei
 +if .not.hdf5
@@ -2415,7 +2417,7 @@ subroutine collimate_end_collimator()
        &rcxp0(j)*c1e3+torbxp(ie),                                          &
        &(rcy0(j)*c1e3+torby(ie))-half*c_length*(rcyp0(j)*c1e3+torbyp(ie)), &
        &rcyp0(j)*c1e3+torbyp(ie),                                          &
-       &(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)
+       &(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)+scatterhit(j)
 +ei
 
       !Here we've found a newly hit particle
@@ -2423,14 +2425,22 @@ subroutine collimate_end_collimator()
         xkick = rcxp(j) - rcxp0(j)
         ykick = rcyp(j) - rcyp0(j)
 
-        if(db_name1(icoll)(1:3).eq.'TCP'.or. db_name1(icoll)(1:4).eq.'COLM'.or. &
-           db_name1(icoll)(1:5).eq.'COLH0'.or. db_name1(icoll)(1:5).eq.'COLV0') then
+        ! Indicate wether this is a secondary / tertiary / other particle;
+        !  note that 'scatterhit' (equals 8 when set) is set in SCATTER.
+        if(db_name1(icoll)(1:3).eq.'TCP'   .or. &
+           db_name1(icoll)(1:4).eq.'COLM'  .or. &
+           db_name1(icoll)(1:5).eq.'COLH0' .or. &
+           db_name1(icoll)(1:5).eq.'COLV0'       ) then
           secondary(j) = 1
-        else if(db_name1(icoll)(1:3).eq.'TCS'.or.&
- &              db_name1(icoll)(1:4).eq.'COLH1'.or. db_name1(icoll)(1:4).eq.'COLV1'.or.db_name1(icoll)(1:4).eq.'COLH2') then
+        else if(db_name1(icoll)(1:3).eq.'TCS'   .or. &
+                db_name1(icoll)(1:4).eq.'COLH1' .or. &
+                db_name1(icoll)(1:4).eq.'COLV1' .or. &
+                db_name1(icoll)(1:4).eq.'COLH2'       ) then
           tertiary(j)  = 2
-        else if((db_name1(icoll)(1:3).eq.'TCL').or.(db_name1(icoll)(1:3).eq.'TCT').or. &
- &              (db_name1(icoll)(1:3).eq.'TCD').or.(db_name1(icoll)(1:3).eq.'TDI')) then
+       else if((db_name1(icoll)(1:3).eq.'TCL') .or. &
+               (db_name1(icoll)(1:3).eq.'TCT') .or. &
+               (db_name1(icoll)(1:3).eq.'TCD') .or. &
+               (db_name1(icoll)(1:3).eq.'TDI')       ) then
           other(j)     = 4
         end if
       else
@@ -2443,11 +2453,17 @@ subroutine collimate_end_collimator()
 !GRD THIS LOOP MUST NOT BE WRITTEN INTO THE "IF(FIRSTRUN)" LOOP !!!!!
       if(dowritetracks) then
         if(part_abs_pos(j).eq.0 .and. part_abs_turn(j).eq.0) then
-          if((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j).eq.4) .and.(xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec).and.&
+          if((secondary(j) .eq. 1 .or. &
+              tertiary(j)  .eq. 2 .or. &
+              other(j)     .eq. 4 .or. &
+              scatterhit(j).eq.8         ) .and. &
+             (xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec).and.&
 !GRD HERE WE APPLY THE SAME KIND OF CUT THAN THE SIGSECUT PARAMETER
- &((((xv(1,j)*c1m3)**2 / (tbetax(ie)*myemitx0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(2,j)*c1m3)**2 / (tbetay(ie)*myemity0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(1,j)*c1m3)**2 / (tbetax(ie)*myemitx0_collgap))+((xv(2,j)*c1m3)**2/(tbetay(ie)*myemity0_collgap)).ge.sigsecut3)) ) then
+             ((((xv(1,j)*c1m3)**2 / (tbetax(ie)*myemitx0_collgap)) .ge. real(sigsecut2,fPrec)) .or. &
+             (((xv(2,j)*c1m3)**2  / (tbetay(ie)*myemity0_collgap)) .ge. real(sigsecut2,fPrec)) .or. &
+             (((xv(1,j)*c1m3)**2  / (tbetax(ie)*myemitx0_collgap)) + &
+             ((xv(2,j)*c1m3)**2   / (tbetay(ie)*myemity0_collgap)) .ge. sigsecut3)) ) &
+             then
 
             xj  = (xv(1,j)-torbx(ie))  /c1e3
             xpj = (yv(1,j)-torbxp(ie)) /c1e3
@@ -2464,7 +2480,7 @@ subroutine collimate_end_collimator()
             hdfy    = (rcy0(j)*c1e3+torby(ie)) - half*c_length*(rcyp0(j)*c1e3+torbyp(ie))
             hdfyp   = rcyp0(j)*c1e3+torbyp(ie)
             hdfdee  = (ejv(j)-myenom)/myenom
-            hdftyp  = secondary(j)+tertiary(j)+other(j)
+            hdftyp  = secondary(j)+tertiary(j)+other(j)+scatterhit(j)
             call APPENDREADING(hdfpid,hdfturn,hdfs,hdfx,hdfxp,hdfy,hdfyp,hdfdee,hdftyp)
 
             hdfs  = sampl(ie)+half*c_length
@@ -2482,13 +2498,13 @@ subroutine collimate_end_collimator()
            &rcxp0(j)*c1e3+torbxp(ie),                                          &
            &(rcy0(j)*c1e3+torby(ie))-half*c_length*(rcyp0(j)*c1e3+torbyp(ie)), &
            &rcyp0(j)*c1e3+torbyp(ie),                                          &
-           &(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)
+           &(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)+scatterhit(j)
 
             write(38,'(1x,i8,1x,i4,1x,f10.2,4(1x,e11.5),1x,e11.3,1x,i4)')      &
            &ipart(j)+100*samplenumber,iturn,sampl(ie)+half*c_length,           &
            &xv(1,j)+half*c_length*yv(1,j),yv(1,j),                             &
            &xv(2,j)+half*c_length*yv(2,j),yv(2,j),(ejv(j)-myenom)/myenom,      &
-           &secondary(j)+tertiary(j)+other(j)
+           &secondary(j)+tertiary(j)+other(j)+scatterhit(j)
 +ei
           end if ! if((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j).eq.4) .and.(xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec) .and.
         end if !if(part_abs_pos(j).eq.0 .and. part_abs_turn(j).eq.0) then
@@ -3094,6 +3110,7 @@ subroutine collimate_start_element(i)
       secondary(j) = 0
       tertiary(j)  = 0
       other(j)     = 0
+      scatterhit(j)= 0
       nabs_type(j) = 0
     end if
   end do
@@ -3267,10 +3284,17 @@ subroutine collimate_end_element
       if(part_abs_pos(j).eq.0 .and. part_abs_turn(j).eq.0) then
 
 !GRD HERE WE APPLY THE SAME KIND OF CUT THAN THE SIGSECUT PARAMETER
-        if((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j).eq.4) .and.(xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec) .and.&
- &((((xv(1,j)*c1m3)**2/(tbetax(ie)*myemitx0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(2,j)*c1m3)**2/(tbetay(ie)*myemity0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(1,j)*c1m3)**2/(tbetax(ie)*myemitx0_collgap))+((xv(2,j)*c1m3)**2/(tbetay(ie)*myemity0_collgap)).ge.sigsecut3)) ) then
+         if((secondary(j) .eq. 1 .or. &
+             tertiary(j)  .eq. 2 .or. &
+             other(j)     .eq. 4 .or. &
+             scatterhit(j).eq. 8       ) .and. &
+             (xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec) .and. &
+             ((((xv(1,j)*c1m3)**2 / (tbetax(ie)*myemitx0_collgap)) .ge. real(sigsecut2,fPrec)).or. &
+             (((xv(2,j)*c1m3)**2  / (tbetay(ie)*myemity0_collgap)) .ge. real(sigsecut2,fPrec)).or. &
+             (((xv(1,j)*c1m3)**2  / (tbetax(ie)*myemitx0_collgap)) + &
+             ((xv(2,j)*c1m3)**2  /  (tbetay(ie)*myemity0_collgap)) .ge. sigsecut3)) ) &
+             then
+            
           xj  = (xv(1,j)-torbx(ie)) /c1e3
           xpj = (yv(1,j)-torbxp(ie))/c1e3
           yj  = (xv(2,j)-torby(ie)) /c1e3
@@ -3284,12 +3308,12 @@ subroutine collimate_end_element
           hdfy=xv(2,j)
           hdfyp=yv(2,j)
           hdfdee=(ejv(j)-myenom)/myenom
-          hdftyp=secondary(j)+tertiary(j)+other(j)
+          hdftyp=secondary(j)+tertiary(j)+other(j)+scatterhit(j)
           call APPENDREADING(hdfpid,hdfturn,hdfs,hdfx,hdfxp,hdfy,hdfyp,hdfdee,hdftyp)
 +ei
 +if .not.hdf5
           write(38,'(1x,i8,1x,i4,1x,f10.2,4(1x,e11.5),1x,e11.3,1x,i4)') ipart(j)+100*samplenumber, iturn, sampl(ie), &
- &              xv(1,j), yv(1,j), xv(2,j), yv(2,j), (ejv(j)-myenom)/myenom, secondary(j)+tertiary(j)+other(j)
+ &              xv(1,j), yv(1,j), xv(2,j), yv(2,j), (ejv(j)-myenom)/myenom, secondary(j)+tertiary(j)+other(j)+scatterhit(j)
 +ei
         end if
       end if
@@ -3578,6 +3602,7 @@ subroutine collimate_end_turn
         secondary(imov) = secondary(j)
         tertiary(imov) = tertiary(j)
         other(imov) = other(j)
+        scatterhit(imov) = scatterhit(j)
         nabs_type(imov) = nabs_type(j)
 !GRD HERE WE ADD A MARKER FOR THE PARTICLE FORMER NAME
         ipart(imov) = ipart(j)
@@ -3696,10 +3721,17 @@ subroutine collimate_end_turn
 
       if(part_abs_pos(j).eq.0 .and. part_abs_turn(j).eq.0) then
 !GRD HERE WE APPLY THE SAME KIND OF CUT THAN THE SIGSECUT PARAMETER
-        if((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j).eq.4).and.(xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec) .and. &
- &((((xv(1,j)*c1m3)**2/(tbetax(ie)*myemitx0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(2,j)*c1m3)**2/(tbetay(ie)*myemity0_collgap)).ge.real(sigsecut2,fPrec)).or. &
- & (((xv(1,j)*c1m3)**2/(tbetax(ie)*myemitx0_collgap))+((xv(2,j)*c1m3)**2/(tbetay(ie)*myemity0_collgap)).ge.sigsecut3)) ) then
+        if((secondary(j) .eq. 1 .or. &
+            tertiary(j)  .eq. 2 .or. &
+            other(j)     .eq. 4 .or. &
+            scatterhit(j).eq. 8        ) .and. &
+            (xv(1,j).lt.99.0_fPrec .and. xv(2,j).lt.99.0_fPrec) .and. &
+            ((((xv(1,j)*c1m3)**2 / (tbetax(ie)*myemitx0_collgap)) .ge. real(sigsecut2,fPrec)).or. &
+            (((xv(2,j)*c1m3)**2  / (tbetay(ie)*myemity0_collgap)) .ge. real(sigsecut2,fPrec)).or. &
+            (((xv(1,j)*c1m3)**2  / (tbetax(ie)*myemitx0_collgap)) + &
+            ((xv(2,j)*c1m3)**2  / (tbetay(ie)*myemity0_collgap)) .ge. sigsecut3)) ) &
+            then
+           
            xj     = (xv(1,j)-torbx(ie))/c1e3
            xpj    = (yv(1,j)-torbxp(ie))/c1e3
            yj     = (xv(2,j)-torby(ie))/c1e3
@@ -3713,15 +3745,15 @@ subroutine collimate_end_turn
            hdfy=xv(2,j)
            hdfyp=yv(2,j)
            hdfdee=(ejv(j)-myenom)/myenom
-           hdftyp=secondary(j)+tertiary(j)+other(j)
+           hdftyp=secondary(j)+tertiary(j)+other(j)+scatterhit(j)
            call APPENDREADING(hdfpid,hdfturn,hdfs,hdfx,hdfxp,hdfy,hdfyp,hdfdee,hdftyp)
 +ei
 
 +if .not.hdf5
            write(38,'(1x,i8,1x,i4,1x,f10.2,4(1x,e11.5),1x,e11.3,1x,i4)') ipart(j)+100*samplenumber,iturn,sampl(ie), &
-&          xv(1,j),yv(1,j),xv(2,j),yv(2,j),(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)
+&          xv(1,j),yv(1,j),xv(2,j),yv(2,j),(ejv(j)-myenom)/myenom,secondary(j)+tertiary(j)+other(j)+scatterhit(j)
 +ei
-        end if !if ((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j)
+        end if !if ((secondary(j).eq.1.or.tertiary(j).eq.2.or.other(j).eq.4.or.scatterhit(j).eq.8
       end if !if(part_abs_pos(j).eq.0 .and. part_abs_turn(j).eq.0) then
     end do ! do j = 1, napx
   end if !if(dowritetracks) then

--- a/SixTrack/scatter.s90
+++ b/SixTrack/scatter.s90
@@ -1000,15 +1000,20 @@ end subroutine scatter_parseSeed
 !  K. Sjobak, V.K. Berglyd Olsen, BE-ABP-HSS
 !  Last modified: 02-11-2017
 ! =================================================================================================
-subroutine scatter_thin(ix, turn)
+subroutine scatter_thin(i_elem, ix, turn)
     
-      use crcoall
+    use crcoall
     use mod_common
     use mod_commonmn
     implicit none
     
 
 +ca stringzerotrim
+
++if collimat
++ca collpara ! Needed to define array sizes
++ca dbcommon ! Get the arrays that we need to set to mark the particle as "dirty" for collimation
++ei
 
     ! Temp variables
     integer          ELEMidx, PROidx, GENidx
@@ -1019,7 +1024,7 @@ subroutine scatter_thin(ix, turn)
     real(kind=fPrec) rndPhi(npart), rndP(npart)
     real(kind=fPrec) scaling
 
-    integer, intent(in) :: ix, turn
+    integer, intent(in) :: i_elem, ix, turn
 
     ELEMidx = scatter_elemPointer(ix)
     PROidx  = scatter_ELEM(ELEMidx,2)
@@ -1085,7 +1090,13 @@ subroutine scatter_thin(ix, turn)
 +if cr
             scatter_filepos = scatter_filepos+1
 +ei
-        end do
+
++if collimat
+            scatterhit(j) = 8
+            part_hit_pos = i_elem
+            part_hit_turn = turn
++ei
+        end do ! END loop over particles (j)
     end do
 
 +if cr

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -642,7 +642,7 @@
       common /cut/ cut_input
 
       real(kind=fPrec) xbob(nblz),ybob(nblz),xpbob(nblz),ypbob(nblz),   &
-     &xineff(npart),yineff(npart),xpineff(npart),ypineff(npart)
+           xineff(npart),yineff(npart),xpineff(npart),ypineff(npart)
 
       common /xcheck/ xbob,ybob,xpbob,ypbob,xineff,yineff,xpineff,      &
      &ypineff
@@ -699,8 +699,8 @@
       common /efficiency/ neffx,neffy
 
 
-      integer secondary(npart),tertiary(npart),other(npart),            &
-     &part_hit_before_pos(npart), part_hit_before_turn(npart)
+      integer secondary(npart),tertiary(npart),other(npart),scatterhit(npart), &
+           part_hit_before_pos(npart), part_hit_before_turn(npart)
       real(kind=fPrec) part_indiv(npart),part_linteract(npart)
 
       integer part_hit_pos(npart),part_hit_turn(npart),                 &
@@ -713,7 +713,7 @@
      &     part_hit_before_pos, part_hit_before_turn,                   &
      &     part_abs_pos,part_abs_turn,                                  &
      &     nabs_type,part_indiv,                                        &
-     &     part_linteract,secondary,tertiary,other
+     &     part_linteract,secondary,tertiary,other,scatterhit
       common /n_tot_absorbed/ n_tot_absorbed,n_absorbed
       common /part_select/ part_select
 !
@@ -1821,7 +1821,7 @@
 +cd scat_thi
       !Thin scattering
       ! It is already checked that scatter_elemPointer != 0
-      call scatter_thin(ix,n)
+      call scatter_thin(i, ix,n)
       
 +cd kickv01v
 +if .not.tilt


### PR DESCRIPTION
Here are the proposed changes to mark the particles as "dirty" for collimation, which should result in them being written to tracks2.dat etc.

I added one more parameter to scatter_thin (the structure element ID); it may be a good idea to also write this and/or the element s-position (`dcum` array AFAIK) to the SCATTER output file.