### PR TITLE
Collimation and aperture updates

### DIFF
--- a/SixTrack/aperture.s90
+++ b/SixTrack/aperture.s90
@@ -10,7 +10,7 @@ module aperture
   use end_sixtrack
   use mathlib_bouncer
   use numerical_constants
-  
+
   use parpro !For nele, npart
 
   !contains pstop(npart) etc
@@ -18,9 +18,10 @@ module aperture
   use crcoall
   use mod_common
   use mod_commons
-  
+
   use mod_hions
-  
+  use mod_alloc
+
   implicit none
   
   ! A.Mereghetti, P.Garcia Ortega and D.Sinuela Pastor, for the FLUKA Team
@@ -40,7 +41,7 @@ module aperture
   ! ape(7,:): tilt angle of marker (all) [rad]
   ! ape(8,:): hor offset of marker (all) [mm]
   ! ape(9,:): ver offset of marker (all) [mm]
-  real(kind=fPrec), allocatable, save ::  ape(:,:)
+  real(kind=fPrec), allocatable, save ::  ape(:,:) !(9,nele)
   logical, allocatable, save :: lapeofftlt(:)      ! aperture is tilted/offcentred (nele)
 
   ! save (i.e. do not kill) lost particles
@@ -86,8 +87,7 @@ module aperture
   ! octagon         -- 5
   ! racetrack       -- 6
   ! transition      -- 7
-  character(len=2), parameter, dimension(-1:6) ::  &
- &               apeName=(/'TR','NA','CR','RE','EL','RL','OC','RT'/)
+  character(len=2), parameter, dimension(-1:6) :: apeName=(/'TR','NA','CR','RE','EL','RL','OC','RT'/)
 
   ! precision parameters:
   real(kind=fPrec), parameter :: aPrec=c1m6 ! identify two ap. markers as identical [mm]
@@ -133,10 +133,10 @@ subroutine aperture_comnul
 
   ldmpaper      = .false.
   aperunit      = 0
-  aper_filename = ' '
+  aper_filename = char(0)
   ldmpaperMem   = .false.
   loadunit      = 3 ! default: read aperture markers in fort.3
-  load_file     = ' '
+  load_file     = char(0)
 
   lbacktracking = .false. ! backtracking off by default
   do ii=1,npart
@@ -155,7 +155,7 @@ subroutine aperture_comnul
   mxsec = 0
   do ii=1,nxsec
      xsecunit(ii)=0
-     xsec_filename(ii)=' '
+     xsec_filename(ii)=char(0)
      sLocMin(ii)=zero
      sLocMax(ii)=zero
      sLocDel(ii)=zero

--- a/SixTrack/collimation.s90
+++ b/SixTrack/collimation.s90
@@ -1042,7 +1042,8 @@ subroutine collimate_start_sample(nsample)
 
       do i = 1, db_ncoll
 ! start searching minimum gap
-        if((db_name1(i)(1:11).eq.bez(myix)(1:11)).or.(db_name2(i)(1:11).eq.bez(myix)(1:11))) then
+        if((db_name1(i)(1:max_name_len).eq.bez(myix)(1:max_name_len)).or. &
+           (db_name2(i)(1:max_name_len).eq.bez(myix)(1:max_name_len))) then
           if( db_length(i) .gt. zero ) then
             nsig_err = nsig + gap_rms_error(i)
 
@@ -1371,7 +1372,8 @@ subroutine collimate_start_collimator(stracki)
 
 !     SR, 01-09-2005: to set found = .TRUE., add the condition L>0!!
   do j = 1, db_ncoll
-    if((db_name1(j)(1:11).eq.bez(myix)(1:11)) .or. (db_name2(j)(1:11).eq.bez(myix)(1:11))) then
+    if((db_name1(j)(1:max_name_len).eq.bez(myix)(1:max_name_len)) .or. &
+       (db_name2(j)(1:max_name_len).eq.bez(myix)(1:max_name_len))) then
       if( db_length(j) .gt. zero ) then
         found = .true.
         icoll = j
@@ -1470,7 +1472,8 @@ subroutine collimate_do_collimator(stracki)
 
 !++  Write beam ellipse at selected collimator
 ! ---- changed name_sel(1:11) name_sel(1:12) to be checked if feasible!!
-  if (((db_name1(icoll).eq.name_sel(1:12)) .or.(db_name2(icoll).eq.name_sel(1:12))) .and. dowrite_dist) then
+  if (((db_name1(icoll).eq.name_sel(1:max_name_len)) .or.&
+       (db_name2(icoll).eq.name_sel(1:max_name_len))) .and. dowrite_dist) then
 !          if (firstrun .and.                                            &
 !     &         ((db_name1(icoll).eq.name_sel(1:11))                     &
 !     &         .or.(db_name2(icoll).eq.name_sel(1:11)))                 &
@@ -1492,7 +1495,7 @@ subroutine collimate_do_collimator(stracki)
 !++  Output to temporary database and screen
   if(iturn.eq.1.and.firstrun) then
     write(40,*) '# '
-    write(40,*) db_name1(icoll)(1:11)
+    write(40,*) db_name1(icoll)!(1:11)
     write(40,*) db_material(icoll)
     write(40,*) db_length(icoll)
     write(40,*) db_rotation(icoll)
@@ -1503,7 +1506,7 @@ subroutine collimate_do_collimator(stracki)
     write(outlun,*) ' '
     write(outlun,*)   'Collimator information: '
     write(outlun,*) ' '
-    write(outlun,*) 'Name:                ', db_name1(icoll)(1:11)
+    write(outlun,*) 'Name:                ', db_name1(icoll)!(1:11)
     write(outlun,*) 'Material:            ', db_material(icoll)
     write(outlun,*) 'Length [m]:          ', db_length(icoll)
     write(outlun,*) 'Rotation [rad]:      ', db_rotation(icoll)
@@ -2566,7 +2569,8 @@ subroutine collimate_end_collimator()
 
 ! should name_sel(1:11) extended to allow longer names as done for
 ! coll the coll_ellipse.dat file !!!!!!!!
-  if(((db_name1(icoll).eq.name_sel(1:11)).or.(db_name2(icoll).eq.name_sel(1:11))) .and. iturn.eq.1  ) then
+  if(((db_name1(icoll).eq.name_sel(1:max_name_len)).or.&
+      (db_name2(icoll).eq.name_sel(1:max_name_len))) .and. iturn.eq.1  ) then
     num_selhit = 0
     num_surhit = 0
     num_selabs = 0

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -13544,8 +13544,7 @@ subroutine daten
 !         A.Mereghetti and P.Garcia Ortega, 12-06-2014
 !         echo precision for back-tracking
           if (lbacktracking) then
-            write(lout,*)' --> back-tracking at aperture LIMIs is on,'//&
-     &' with precision [m]:',bktpre
+            write(lout,*)' --> back-tracking at aperture LIMIs is on, with precision [m]:',bktpre
           else
             write(lout,*)' --> no back-tracking, only checks at aperture LIMIs'
           endif
@@ -13562,11 +13561,9 @@ subroutine daten
 
       else
 
-        call getfields_split( ch, getfields_fields, getfields_lfields,  &
-     &        getfields_nfields, getfields_lerr )
+        call getfields_split( ch, getfields_fields, getfields_lfields,getfields_nfields, getfields_lerr )
         if ( getfields_lerr ) then
-          write(lout,*)'ERROR in LIMI block: getfields_lerr=', getfields_lerr, &
-     &    ' at line: ',ch
+          write(lout,*)'ERROR in LIMI block: getfields_lerr=', getfields_lerr, ' at line: ',ch
           call prror(-1)
         endif
 
@@ -13582,8 +13579,7 @@ subroutine daten
           read (getfields_fields(3)(1:getfields_lfields(3)),*) load_file
           inquire( file=load_file, exist=lexist )
           if (.not.lexist ) then
-             write(lout,*) "APERTURE LOAD FILE ",load_file," NOT FOUND ",&
-     &       "IN THE RUNNING FOLDER"
+             write(lout,*) "APERTURE LOAD FILE ",load_file," NOT FOUND IN THE RUNNING FOLDER"
              call prror(-1)
           endif
           open(loadunit,file=load_file,form='formatted') 
@@ -13867,7 +13863,7 @@ subroutine daten
                   endif
                 end do
               end if
-              call aperture_initroffpos( j, tmpflts(1), tmpflts(2), tmpflts(3) )
+              call aperture_initroffpos( j, tmpflts(7), tmpflts(8), tmpflts(9) )
               limifound=.true.
               exit
             end if

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -367,7 +367,7 @@
      &driftsx,driftsy,pencil_offset,pencil_rmsx,pencil_rmsy,            &
      &sigsecut3,sigsecut2,enerror,bunchlength
 
-      character(len=24) name_sel
+      character(len=max_name_len) name_sel
       character(len=80) coll_db
       character(len=16) castordir
       character(len=80) filename_dis


### PR DESCRIPTION
- Check for the full element names when searching for collimators instead of (1:11) - this was finding aperture markers instead.

- @amereghe  - I changed the call in daten to call aperture_initroffpos() so you may want to merge this into your branch.