### PR TITLE
Strings module and mod_alloc index fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,11 +303,11 @@ LIST(APPEND PREPRO_FLAGS_LIB CRLIBM CERNLIB NAGLIB CR DEBUG HDF5 FIO LIBARCHIVE 
 ###################################################################################################
 
 if(DA)
-	list(APPEND FORS_FREEFORM end_sixtrack close scatter dynk floatprecision bouncy_castle plato_seq lielib dabnew fma physical_constants postprocessing sixsc sixda sixscfox dump zipf mainarrays parpro_scale bdex aperture ranecu wire elens hions mod_alloc)
-	list(APPEND FORS_F90 core_tools strings string_tools file_units)
+	list(APPEND FORS_FREEFORM end_sixtrack close scatter dynk floatprecision bouncy_castle plato_seq lielib dabnew fma physical_constants postprocessing sixsc sixda sixscfox dump zipf mainarrays parpro_scale bdex aperture ranecu wire elens hions)
+	list(APPEND FORS_F90 core_tools strings string_tools file_units mod_alloc)
 else()
-	list(APPEND FORS_FREEFORM end_sixtrack close scatter dynk floatprecision bouncy_castle plato_seq lielib dabnews fma physical_constants postprocessing track sixve sixvefox dump zipf mainarrays parpro_scale bdex aperture ranecu wire elens hions mod_alloc)
-	list(APPEND FORS_F90 core_tools strings string_tools file_units)
+	list(APPEND FORS_FREEFORM end_sixtrack close scatter dynk floatprecision bouncy_castle plato_seq lielib dabnews fma physical_constants postprocessing track sixve sixvefox dump zipf mainarrays parpro_scale bdex aperture ranecu wire elens hions)
+	list(APPEND FORS_F90 core_tools strings string_tools file_units mod_alloc)
 endif()
 
 if(COLLIMAT)

--- a/SixTrack/ast_mask/mod_alloc.ast
+++ b/SixTrack/ast_mask/mod_alloc.ast
@@ -1,5 +1,0 @@
-mod_alloc.s90
-mod_allocn.f
-df debug,spammy
-e mod_alloc
-ex

--- a/SixTrack/dump.s90
+++ b/SixTrack/dump.s90
@@ -1199,7 +1199,6 @@ subroutine dump_comnul
     dumplast(i)  = 0
     dumpunit(i) = 0
     dumpfmt(i)  = 0
-    dump_fname(i) = repeat(char(0),str_maxLen)
 +if cr
     dumpfilepos(i) = -1
 +ei

--- a/SixTrack/mod_alloc.f90
+++ b/SixTrack/mod_alloc.f90
@@ -1,4 +1,10 @@
-+dk mod_alloc
+! ================================================================================================ !
+!  SixTrack Array Alloc Module
+! ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!  J. Molson, K.N. Sjobak, V.K. Berglyd Olsen, BE-ABP-HSS
+!  Last Modified: 2018-04-26
+! ================================================================================================ !
+
 module mod_alloc
 
   use, intrinsic :: iso_fortran_env
@@ -154,7 +160,7 @@ subroutine print_alloc(ename, requested_bits)
   character(len=*), intent(in) :: ename
   integer(kind=int64) :: requested_bits
   
-+if spammy
+#ifdef spammy
   
   write(lout,*) 'Memory allocation for array ', ename
 
@@ -179,7 +185,7 @@ subroutine print_alloc(ename, requested_bits)
     maximum_bits = allocated_bits
   end if
 
-+ei
+#endif
 
 end subroutine print_alloc
 
@@ -2987,7 +2993,7 @@ subroutine resize1dc(input, strlen, newsize, initial, ename, f_index_in)
   end do
 
   !Set the initial values of the buffer
-  do i=oldsize+1,newsize
+  do i=oldsize+f_index,newsize
     buffer(i) = initial
   end do
 

--- a/SixTrack/strings.f90
+++ b/SixTrack/strings.f90
@@ -38,10 +38,10 @@ module strings
     
     procedure, public,  pass(this)  :: get     => getStr
     procedure, public,  pass(this)  :: set     => setStr
-    procedure, public,  pass(this)  :: len     => lenStr
-    procedure, public,  pass(this)  :: trim    => trimStr
-    procedure, public,  pass(this)  :: adjustl => adjLStr
-    procedure, public,  pass(this)  :: adjustr => adjRStr
+  ! procedure, public,  pass(this)  :: len     => lenStr
+  ! procedure, public,  pass(this)  :: trim    => trimStr
+  ! procedure, public,  pass(this)  :: adjustl => adjLStr
+  ! procedure, public,  pass(this)  :: adjustr => adjRStr
     procedure, public,  pass(this)  :: strip   => stripStr
     procedure, public,  pass(this)  :: upper   => upperStr
     procedure, public,  pass(this)  :: lower   => lowerStr

--- a/SixTrack/strings.f90
+++ b/SixTrack/strings.f90
@@ -20,7 +20,7 @@
 !  Strip:         aString%strip()                 => Returns a string without lead/trail spaces
 !  Strip Zero:    aString%strip(zero=.true.)      => As above, but first cuts at first \0 character
 !  Upper Case:    aString%upper()                 => Returns a string, replacing [a-z] with [A-Z]
-!  Lower Case:    aString%upper()                 => Returns a string, replacing [A-Z] with [a-z]
+!  Lower Case:    aString%lower()                 => Returns a string, replacing [A-Z] with [a-z]
 !
 !  Note: gfortran 6.3 shows some unexpected behaviour when comparing char arrays and strings. This
 !        error is not reproducible in gfortran 7, and can be avoided by comparing

--- a/SixTrack/strings.f90
+++ b/SixTrack/strings.f90
@@ -2,7 +2,7 @@
 !  SixTrack String Module
 ! ~~~~~~~~~~~~~~~~~~~~~~~~
 !  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Last Modified: 2018-04-25
+!  Last Modified: 2018-04-26
 !
 !  Usage
 ! ~~~~~~~
@@ -22,8 +22,8 @@
 !  Upper Case:    aString%upper()                 => Returns a string, replacing [a-z] with [A-Z]
 !  Lower Case:    aString%lower()                 => Returns a string, replacing [A-Z] with [a-z]
 !
-!  Note: gfortran 6.3 shows some unexpected behaviour when comparing char arrays and strings. This
-!        error is not reproducible in gfortran 7, and can be avoided by comparing
+!  Note: gfortran 6.x shows some unexpected behaviour when comparing char arrays and string arrays.
+!        This error is not reproducible in gfortran 7, and can be avoided by comparing
 !        (aString%get() == "Something") instead of (aString == "Something").
 ! ================================================================================================ !
 module strings


### PR DESCRIPTION
Added three new routines to strings:
* aString%upper() : Replaces [a-z] with [A-Z]
* aString%lower() : Replaces [A-Z] with [a-z]
* aString%strip() : Removes leading and trailing spaces
* aString%strip(zero=.true.) : Also cuts at first char(0)

mod_alloc
* Fixed the indexing of alloc and resize in mod_alloc for all with an optional first index not equal to 1
* Added 1D string array support