### PR TITLE
Revert "Fixed cmake_six after file rename"

### DIFF
--- a/SixTrack/cmake_six
+++ b/SixTrack/cmake_six
@@ -47,7 +47,7 @@ if [ -x "$(command -v gawk)" ]; then
     astuce_linter dynk.s90
     astuce_linter fluka.s90
     astuce_linter fma.s90
-#   astuce_linter hdf5_sixtrack.s90
+    astuce_linter hdf5_sixtrack.s90
     astuce_linter postprocessing.s90
     astuce_linter scatter.s90
     astuce_linter dump.s90


### PR DESCRIPTION
Reverts SixTrack/SixTrack#470