### PR TITLE
Fix DYNK GLOBALVARS energy update to work with THICK and SIGMAV

### DIFF
--- a/SixTrack/cmake_six
+++ b/SixTrack/cmake_six
@@ -38,16 +38,16 @@ if [ -x "$(command -v gawk)" ]; then
     fi
     }
     astuce_linter sixtrack.s90
-#    astuce_linter plato_seq.s90
+    # astuce_linter plato_seq.s90
     astuce_linter lielib.s90
     astuce_linter dabnew.s90
     astuce_linter beamgas.s90
-#    astuce_linter bouncy_castle.s90
+    # astuce_linter bouncy_castle.s90
     astuce_linter collimation.s90
     astuce_linter dynk.s90
     astuce_linter fluka.s90
     astuce_linter fma.s90
-    astuce_linter hdf5_sixtrack.s90
+    # astuce_linter hdf5_sixtrack.s90
     astuce_linter postprocessing.s90
     astuce_linter scatter.s90
     astuce_linter dump.s90

--- a/SixTrack/dynk.s90
+++ b/SixTrack/dynk.s90
@@ -3024,6 +3024,9 @@ subroutine dynk_setvalue(element_name, att_name, newValue)
     character(maxstrlen_dynk) element_name_stripped
     character(maxstrlen_dynk) att_name_stripped
 
+    !Original energies before energy update
+    real(kind=fPrec) e0fo, e0o
+
     ! For sanity check
     logical ldoubleElement
     ldoubleElement = .false.
@@ -3043,6 +3046,10 @@ subroutine dynk_setvalue(element_name, att_name, newValue)
     if (element_name_stripped .eq. "GLOBAL-VARS") then
         if (att_name_stripped .eq. "E0" ) then
             ! Modify the reference particle
+
+            e0o  = e0
+            e0fo = e0f
+
             e0     = newValue
             e0f    = sqrt(e0**2 - nucm0**2)
             gammar = nucm0/e0
@@ -3056,7 +3063,13 @@ subroutine dynk_setvalue(element_name, att_name, newValue)
                 oidpsv(j) = one/(one + dpsv(j))
                 moidpsv(j) = mtc(j)/(one + dpsv(j))
                 rvv(j) = (ejv(j)*e0f)/(e0*ejfv(j))
-            end do
+
+                !Also update sigmv with the new beta0 = e0f/e0
+                sigmv(j)=((e0f*e0o)/(e0fo*e0))*sigmv(j)
+              end do
+
+              if(ithick.eq.1) call synuthck
+
         end if
         ldoubleElement = .true.
     end if


### PR DESCRIPTION
Changes that I think should fix the remaining bugs in ENVARSV, after carefully reading the energy update code in `thck6dua` and `thin6dua`.

Note: In the old code, the algorithm was as follows:
* Store original e0 and e0f
* Update e0 and e0f
* For each particle:
  * if (sigma < 0): sigma = (beta0 / beta0_old) * sigma
  * Energy kick from the cavity && update of variables
  * if (sigma > 0): sigma = (beta0 / beta0_old) * sigma
* In thick only: Call `synuthck`

I'm a bit confused about why it does the sigma update the way it is done...

Things still to be done:
* Delete the now superfluous and commented-out code from `sixtrack.s`
* Delete variables `phas0`, `e0o`, `e0fo`, `xv1j`, `xv2j`
* Make variables `nde(1)` and `nde(2)` -- the number of turns at flat bottom and for energy ramping -- invalid in `daten`
* Review `nwr(1)`, `nwr(2)`, `nwr(3)`, `nwr(4)` in for marking invalid.
* Review and delete calls to the old code...

Once this tiny bit of diff is reviewed, I'll do the rest of the changes and update the test. Then we can merge.

-- Kyrre & Veronica