### PR TITLE
End of vvector

### DIFF
--- a/SixTrack/ast_mask/bdex.ast
+++ b/SixTrack/ast_mask/bdex.ast
@@ -1,5 +1,5 @@
 bdex.s90 common_modules.s90 sixtrack.s90
 bdexn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,libarchive,g4collimat,naff
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,libarchive,g4collimat,naff
 e bdex
 ex

--- a/SixTrack/ast_mask/beamgas.ast
+++ b/SixTrack/ast_mask/beamgas.ast
@@ -1,5 +1,5 @@
 beamgas.s90 sixtrack.s90
 beamgasn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,fio,lf95,hugenblz,bignpart,hugenpart,datamods
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,fio,lf95,hugenblz,bignpart,hugenpart,datamods
 e beamGasK
 ex

--- a/SixTrack/ast_mask/collimation.ast
+++ b/SixTrack/ast_mask/collimation.ast
@@ -1,5 +1,5 @@
 sixtrack.s90 collimation.s90
 collimationn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,g4collimat,root
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,g4collimat,root
 e nwrtcoll
 ex

--- a/SixTrack/ast_mask/fluka.ast
+++ b/SixTrack/ast_mask/fluka.ast
@@ -1,5 +1,5 @@
 fluka.s90 sixtrack.s90
 flukan.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,fluka
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,fluka
 e flukadeck
 ex

--- a/SixTrack/ast_mask/hions.ast
+++ b/SixTrack/ast_mask/hions.ast
@@ -1,5 +1,5 @@
 common_modules.s90
 hionsn.f
-df bignpart,hugenpart,bignblz,hugenblz,beamgas,collimat,vvector,datamods
+df bignpart,hugenpart,bignblz,hugenblz,beamgas,collimat,datamods
 e mod_hions
 ex

--- a/SixTrack/ast_mask/parpro_scale.ast
+++ b/SixTrack/ast_mask/parpro_scale.ast
@@ -1,5 +1,5 @@
 common_modules.s90
 parpro_scalen.f
-df bignpart,hugenpart,bignblz,hugenblz,beamgas,collimat,vvector,datamods,fluka
+df bignpart,hugenpart,bignblz,hugenblz,beamgas,collimat,datamods,fluka
 e parpro_scale
 ex

--- a/SixTrack/ast_mask/postprocessing.ast
+++ b/SixTrack/ast_mask/postprocessing.ast
@@ -1,5 +1,5 @@
 postprocessing.s90 sixtrack.s90
 postprocessingn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,libarchive,g4collimat,naff,fluka,root
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,libarchive,g4collimat,naff,fluka,root
 e POSTPR
 ex

--- a/SixTrack/ast_mask/sixve.ast
+++ b/SixTrack/ast_mask/sixve.ast
@@ -1,6 +1,6 @@
 sixtrack.s90 debug_dump.s90
 sixven.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,libarchive,g4collimat,naff,fluka,root
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,nagfor,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,libarchive,g4collimat,naff,fluka,root
 e maincr,envarsv
 e ADIA,ADIB,DATEN,ENVARS,ERRF
 e COMNUL

--- a/SixTrack/ast_mask/sixvefox.ast
+++ b/SixTrack/ast_mask/sixvefox.ast
@@ -1,6 +1,6 @@
 sixtrack.s90
 sixvefoxn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,fio,lf95,hugenblz,bignpart,hugenpart,datamods,fluka
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,fio,lf95,hugenblz,bignpart,hugenpart,datamods,fluka
 e UMLAU6,ENVADA,SYNODA,ERRFF
 e CLOR6,MYDAINI
 e beam6df,wireda

--- a/SixTrack/ast_mask/track.ast
+++ b/SixTrack/ast_mask/track.ast
@@ -1,6 +1,6 @@
 sixtrack.s90
 trackn.f
-df vvector,crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,fluka,root
+df crlibm,tilt,fast,collimat,cr,boinc,beamgas,bnlelens,bignblz,debug,hdf5,fio,lf95,hugenblz,stf,bignpart,hugenpart,datamods,merlinscatter,fluka,root
 e tra_thck
 e tra_thin
 e nwrtbnl

--- a/SixTrack/dynk.s90
+++ b/SixTrack/dynk.s90
@@ -3067,9 +3067,10 @@ subroutine dynk_setvalue(element_name, att_name, newValue)
                 !Also update sigmv with the new beta0 = e0f/e0
                 sigmv(j)=((e0f*e0o)/(e0fo*e0))*sigmv(j)
               end do
-
+! FIXME: This is a dirty fix for DA version to make it compile.
+#ifndef DA
               if(ithick.eq.1) call synuthck
-
+#endif
         end if
         ldoubleElement = .true.
     end if

--- a/SixTrack/postprocessing.s90
+++ b/SixTrack/postprocessing.s90
@@ -45,9 +45,9 @@ subroutine postpr(posi,nnuml)
 +ei
       implicit none
 
-+if vvector
+! +if vvector
 +ca common2
-+ei
+! +ei
 +ca commonc
 +ca commphin
 +if cr
@@ -1944,7 +1944,7 @@ subroutine postpr(posi,nnuml)
 !--PRINTING
 !----------------------------------------------------------------------
       if(nstop.lt.ia.and.(ia.lt.numl.or.ia.lt.nint(dnumlr))) nlost=1
-+if vvector
+! +if vvector
       if(nnumxv(ifipa).eq.0.and.nnumxv(ilapa).eq.0) then
         sumda(22)=real(ia,fPrec)                                         !hr06
         sumda(23)=real(ia,fPrec)                                         !hr06
@@ -1952,11 +1952,11 @@ subroutine postpr(posi,nnuml)
         sumda(22)=real(nnumxv(ifipa),fPrec)                              !hr06
         sumda(23)=real(nnumxv(ilapa),fPrec)                              !hr06
       endif
-+ei
-+if .not.vvector
-      sumda(22)=real(ia,fPrec)                                           !hr06
-      sumda(23)=real(ia,fPrec)                                           !hr06
-+ei
+! +ei
+! +if .not.vvector
+!       sumda(22)=real(ia,fPrec)                                           !hr06
+!       sumda(23)=real(ia,fPrec)                                           !hr06
+! +ei
 +if cr
 ! TRY a FIX for nnuml
 ! should be redumdant now

--- a/SixTrack/postprocessing.s90
+++ b/SixTrack/postprocessing.s90
@@ -45,9 +45,7 @@ subroutine postpr(posi,nnuml)
 +ei
       implicit none
 
-! +if vvector
 +ca common2
-! +ei
 +ca commonc
 +ca commphin
 +if cr
@@ -1944,7 +1942,6 @@ subroutine postpr(posi,nnuml)
 !--PRINTING
 !----------------------------------------------------------------------
       if(nstop.lt.ia.and.(ia.lt.numl.or.ia.lt.nint(dnumlr))) nlost=1
-! +if vvector
       if(nnumxv(ifipa).eq.0.and.nnumxv(ilapa).eq.0) then
         sumda(22)=real(ia,fPrec)                                         !hr06
         sumda(23)=real(ia,fPrec)                                         !hr06
@@ -1952,11 +1949,10 @@ subroutine postpr(posi,nnuml)
         sumda(22)=real(nnumxv(ifipa),fPrec)                              !hr06
         sumda(23)=real(nnumxv(ilapa),fPrec)                              !hr06
       endif
-! +ei
-! +if .not.vvector
-!       sumda(22)=real(ia,fPrec)                                           !hr06
-!       sumda(23)=real(ia,fPrec)                                           !hr06
-! +ei
+#ifdef DA
+      sumda(22)=real(ia,fPrec)                                           !hr06
+      sumda(23)=real(ia,fPrec)                                           !hr06
+#endif
 +if cr
 ! TRY a FIX for nnuml
 ! should be redumdant now

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -8783,11 +8783,9 @@ subroutine daten
 
         !The value of nele will have been updated here
         call resize(bez0, max_name_len, nele, defaultstring, 'bez0')
-!+if vvector
 !        if (ithick.eq.1) then
 !          call expand_thickarrays(nele+10, npart, nblz, nblo )
 !        end if
-!+ei
       end if
 
       if(abs(kz(i)).ne.12 .or. (abs(kz(i)).eq.12.and.ncy2.eq.0) ) then
@@ -10327,9 +10325,7 @@ subroutine daten
       read(ch1,*) izu0, mmac, mout, mcut
 +ei
       mcut=iabs(mcut)
-! +if vvector
       if(mmac.gt.nmac) call prror(55)
-! +ei
       !Generate normal distributed random numbers into zfz
       call recuin(izu0,irecuin)
       call ranecu(zfz,nzfz,mcut)
@@ -14784,10 +14780,8 @@ subroutine daten
  1520 call prror(41)
  1530 call prror(42)
  1540 continue
-! +if vvector
       !Check that the number of particles is OK
       if(((2*mmac)*imc)*napx.gt.npart) call prror(54)                    !hr05
-! +ei
 !     compute elens theta at R2, if requested by user
       do j=1,melens
          if ( elens_lThetaR2(j) ) then
@@ -30585,11 +30579,9 @@ integer function INEESE()
   il=il+1
   if( il.gt.nele-2 ) then
     call expand_arrays(nele+50, npart, nblz, nblo )
-! +if vvector
     if (ithick.eq.1) then
       call expand_thickarrays(nele, npart, nblz, nblo )
     end if
-! +ei
   end if
 
 ! initialise element to empty

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -1010,12 +1010,10 @@
      &sigman,sigman2,sigmanq,clobeam,beamoff,parbe,track6d,ptnfac,      &
      &sigz,sige,partnum,parbe14,emitx,emity,emitz,gammar,nbeam,ibbc,    &
      &ibeco,ibtyp,lhc,cotr,rrtr,imtr,bbcu,ibb6d,imbb,wire_num,          &
-! +if vvector
-!      &as,al,sigm,dps,idz,dp1,itra,                                      &
-! +ei
-! +if .not.vvector
-     &as,at,a2,al,sigm,dps,idz,dp1,itra,                                &
-! +ei
+     &as,al,sigm,dps,idz,dp1,itra,                                      &
+#ifdef DA
+     &at,a2,                                                            &
+#endif
      &x,y,bet0,alf0,clo,clop,cro,is,ichrom,nnumxv,xsi,zsi,smi,aai,      &
      &bbi,ampt,tlim,tasm,preda,idial,nord,nvar,                         &
      &nvar2,nsix,ncor,ipar,nordf,                                       &
@@ -10329,9 +10327,9 @@ subroutine daten
       read(ch1,*) izu0, mmac, mout, mcut
 +ei
       mcut=iabs(mcut)
-+if vvector
+! +if vvector
       if(mmac.gt.nmac) call prror(55)
-+ei
+! +ei
       !Generate normal distributed random numbers into zfz
       call recuin(izu0,irecuin)
       call ranecu(zfz,nzfz,mcut)
@@ -14786,10 +14784,10 @@ subroutine daten
  1520 call prror(41)
  1530 call prror(42)
  1540 continue
-+if vvector
+! +if vvector
       !Check that the number of particles is OK
       if(((2*mmac)*imc)*napx.gt.npart) call prror(54)                    !hr05
-+ei
+! +ei
 !     compute elens theta at R2, if requested by user
       do j=1,melens
          if ( elens_lThetaR2(j) ) then
@@ -16029,9 +16027,9 @@ subroutine envars(j,dpp,rv)
   integer i,ih,j,kz1,l,ll
   real(kind=fPrec) aek,afok,as3,as4,as6,co,dpd,dpp,dpsq,fi,fok,fok1,fokq,g,gl,hc,hi,hi1,hm,&
                    hp,hs,rho,rhoc,rhoi,rv,si,siq,sm1,sm12,sm2,sm23,sm3,sm5,sm6,wf,wfa,wfhi
-+if .not.vvector
+#ifdef DA
   integer jm,k,m,na,ne
-+ei
+#endif
 +ca commont1
 +ca commondl
 +if bnlelens
@@ -16046,10 +16044,10 @@ subroutine envars(j,dpp,rv)
       do l=1,2
         al(ll,l,j,i) = zero
         as(ll,l,j,i) = zero
-+if .not.vvector
+#ifdef DA
         at(ll,l,j,i) = zero
         a2(ll,l,j,i) = zero
-+ei
+#endif
       end do
     end do
     
@@ -16339,7 +16337,7 @@ subroutine envars(j,dpp,rv)
     end select
   end do
   
-+if .not.vvector
+#ifdef DA
   do k=1,mblo
     jm=mel(k)
     do m=1,jm
@@ -16361,7 +16359,7 @@ subroutine envars(j,dpp,rv)
       end do
     end do
   end do
-+ei
+#endif
   return
   
 end subroutine envars
@@ -19693,6 +19691,7 @@ end subroutine wireda
       use parpro
       use mod_common
       use mod_commons
+      use mod_hions
       implicit none
       integer idaa
       real(kind=fPrec) betr0,dare,sigmdac


### PR DESCRIPTION
This removes the vvector flag. For standard SixTrack vvector is always on.
For DA version, the previously `+if .not.vvector` sections have now been changed to `#ifdef DA`