### PR TITLE
Some minor changes and updates

### DIFF
--- a/SixTrack/hdf5_output.f90
+++ b/SixTrack/hdf5_output.f90
@@ -428,11 +428,8 @@ end subroutine h5_initHDF5
 ! ================================================================================================ !
 subroutine h5_openFile()
   
-  character(len=23) timeStamp
-  character(len=8)  cDate
-  character(len=10) cTime
-  integer           accessFlag
-  logical           doesExist
+  integer accessFlag
+  logical doesExist
   
   if(.not. h5_isActive) then
     write(lout,"(a)") "HDF5> ERROR HDF5 file open called, but HDF5 is not active. This is a bug."
@@ -480,13 +477,33 @@ subroutine h5_openFile()
     h5_rootID = h5_fileID
   end if
   
+  h5_isReady = .true.
+  
+end subroutine h5_openFile
+
+! ================================================================================================ !
+!  Write Simulation Info
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Last Modified: 2018-05-31
+! ================================================================================================ !
+subroutine h5_writeSimInfo()
+  
+  use mod_common, only : napx, numl
+  
+  character(len=23) timeStamp
+  character(len=8)  cDate
+  character(len=10) cTime
+  
+  ! TimeStamp
   call date_and_time(cDate,cTime)
   timeStamp = cDate(1:4)//"-"//cDate(5:6)//"-"//cDate(7:8)//"T"//cTime(1:2)//":"//cTime(3:4)//":"//cTime(5:10)
   call h5_writeAttr(h5_rootID,"TimeStamp",timeStamp)
   
-  h5_isReady = .true.
+  ! Simulation info
+  call h5_writeAttr(h5_rootID,"Particles",napx*2)
+  call h5_writeAttr(h5_rootID,"Turns",numl)
   
-end subroutine h5_openFile
+end subroutine h5_writeSimInfo
 
 ! ================================================================================================ !
 !  HDF5 Finalise

--- a/SixTrack/sixtrack.s90
+++ b/SixTrack/sixtrack.s90
@@ -19431,7 +19431,10 @@ end interface
   call daten
   
 #ifdef HDF5
-  if(h5_isActive) call h5_openFile()
+  if(h5_isActive) then
+    call h5_openFile()
+    call h5_writeSimInfo()
+  end if
 #endif
   call aperture_init
 

--- a/SixTrack/sixtrack_input.f90
+++ b/SixTrack/sixtrack_input.f90
@@ -230,13 +230,13 @@ subroutine sixin_parseInputLineSING(inLine, iLine, iErr)
   end do
   
   ! Save Values
-  if(nSplit > 1) call chr_toInt(lnSplit(2),kz(sixin_nSing),iErr)
-  if(nSplit > 2) call chr_toReal(lnSplit(3),ed(sixin_nSing),iErr)
-  if(nSplit > 3) call chr_toReal(lnSplit(4),ek(sixin_nSing),iErr)
-  if(nSplit > 4) call chr_toReal(lnSplit(5),el(sixin_nSing),iErr)
-  if(nSplit > 5) call chr_toReal(lnSplit(6),bbbx(sixin_nSing),iErr)
-  if(nSplit > 6) call chr_toReal(lnSplit(7),bbby(sixin_nSing),iErr)
-  if(nSplit > 7) call chr_toReal(lnSplit(8),bbbs(sixin_nSing),iErr)
+  if(nSplit > 1) call chr_cast(lnSplit(2),kz(sixin_nSing),  iErr)
+  if(nSplit > 2) call chr_cast(lnSplit(3),ed(sixin_nSing),  iErr)
+  if(nSplit > 3) call chr_cast(lnSplit(4),ek(sixin_nSing),  iErr)
+  if(nSplit > 4) call chr_cast(lnSplit(5),el(sixin_nSing),  iErr)
+  if(nSplit > 5) call chr_cast(lnSplit(6),bbbx(sixin_nSing),iErr)
+  if(nSplit > 6) call chr_cast(lnSplit(7),bbby(sixin_nSing),iErr)
+  if(nSplit > 7) call chr_cast(lnSplit(8),bbbs(sixin_nSing),iErr)
   
   if(iErr) return
   
@@ -362,7 +362,7 @@ subroutine sixin_parseInputLineBLOC(inLine, iLine, iErr)
   
   ! If first line, read super period information
   if(iLine == 1) then
-    call chr_toInt(lnSplit(1),mper,iErr)
+    call chr_cast(lnSplit(1),mper,iErr)
     if(mper > nper) then
       write(lout,"(a,i0)") "GEOMETRY> ERROR Block definition number of super periods is too large. Max value is ",nper
       iErr = .true.
@@ -374,7 +374,7 @@ subroutine sixin_parseInputLineBLOC(inLine, iLine, iErr)
       return
     end if
     do i=1,mper
-      call chr_toInt(lnSplit(i+1),msym(i),iErr)
+      call chr_cast(lnSplit(i+1),msym(i),iErr)
     end do
     if(iErr) return
     
@@ -570,16 +570,16 @@ subroutine sixin_parseInputLineDISP(inLine, iErr)
   end if
   
   ! Save Values
-  if(nSplit > 1) call chr_toReal(lnSplit(2),xpl0,iErr)
-  if(nSplit > 2) call chr_toReal(lnSplit(3),xrms0,iErr)
-  if(nSplit > 3) call chr_toReal(lnSplit(4),zpl0,iErr)
-  if(nSplit > 4) call chr_toReal(lnSplit(5),zrms0,iErr)
+  if(nSplit > 1) call chr_cast(lnSplit(2),xpl0, iErr)
+  if(nSplit > 2) call chr_cast(lnSplit(3),xrms0,iErr)
+  if(nSplit > 3) call chr_cast(lnSplit(4),zpl0, iErr)
+  if(nSplit > 4) call chr_cast(lnSplit(5),zrms0,iErr)
   if(iErr) return
   
   if(sixin_debug) then
-    call sixin_echoVal("xpl0",xpl0,"DISP",0)
+    call sixin_echoVal("xpl0", xpl0, "DISP",0)
     call sixin_echoVal("xrms0",xrms0,"DISP",0)
-    call sixin_echoVal("zpl0",zpl0,"DISP",0)
+    call sixin_echoVal("zpl0", zpl0, "DISP",0)
     call sixin_echoVal("zrms0",zrms0,"DISP",0)
   end if
   
@@ -643,11 +643,11 @@ subroutine sixin_parseInputLineINIT(inLine, iLine, iErr)
   
   select case(iLine)
   case(1) ! Line One
-    if(nSplit > 0) call chr_toInt(lnSplit(1),itra,iErr)  ! Number of particles
-    if(nSplit > 1) call chr_toReal(lnSplit(2),chi0,iErr) ! Starting phase of the initial coordinate
-    if(nSplit > 2) call chr_toReal(lnSplit(3),chid,iErr) ! Phase difference between particles
-    if(nSplit > 3) call chr_toReal(lnSplit(4),rat,iErr)  ! Emittance ratio
-    if(nSplit > 4) call chr_toInt(lnSplit(5),iver,iErr)  ! Vertical coordinates switch
+    if(nSplit > 0) call chr_cast(lnSplit(1),itra,iErr) ! Number of particles
+    if(nSplit > 1) call chr_cast(lnSplit(2),chi0,iErr) ! Starting phase of the initial coordinate
+    if(nSplit > 2) call chr_cast(lnSplit(3),chid,iErr) ! Phase difference between particles
+    if(nSplit > 3) call chr_cast(lnSplit(4),rat, iErr) ! Emittance ratio
+    if(nSplit > 4) call chr_cast(lnSplit(5),iver,iErr) ! Vertical coordinates switch
     if(sixin_debug) then
       call sixin_echoVal("itra",itra,"INIT",iLine)
       call sixin_echoVal("chi0",chi0,"INIT",iLine)
@@ -668,77 +668,77 @@ subroutine sixin_parseInputLineINIT(inLine, iLine, iErr)
     end if
     
   case(2)  ! x [mm] coordinate of particle 1
-    call chr_toReal(lnSplit(1),exz(1,1),iErr)
+    call chr_cast(lnSplit(1),exz(1,1),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,1)",exz(1,1),"INIT",iLine)
     if(iErr) return
     
   case(3)  ! xp [mrad] coordinate of particle 1
-    call chr_toReal(lnSplit(1),exz(1,2),iErr)
+    call chr_cast(lnSplit(1),exz(1,2),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,2)",exz(1,2),"INIT",iLine)
     if(iErr) return
     
   case(4)  ! y [mm] coordinate of particle 1
-    call chr_toReal(lnSplit(1),exz(1,3),iErr)
+    call chr_cast(lnSplit(1),exz(1,3),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,3)",exz(1,3),"INIT",iLine)
     if(iErr) return
     
   case(5)  ! yp [mrad] coordinate of particle 1
-    call chr_toReal(lnSplit(1),exz(1,4),iErr)
+    call chr_cast(lnSplit(1),exz(1,4),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,4)",exz(1,4),"INIT",iLine)
     if(iErr) return
     
   case(6)  ! Path length difference 1(sigma = s−v0*t) [mm] of particle 1
-    call chr_toReal(lnSplit(1),exz(1,5),iErr)
+    call chr_cast(lnSplit(1),exz(1,5),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,5)",exz(1,5),"INIT",iLine)
     if(iErr) return
     
   case(7)  ! dp/p0 of particle 1
-    call chr_toReal(lnSplit(1),exz(1,6),iErr)
+    call chr_cast(lnSplit(1),exz(1,6),iErr)
     if(sixin_debug) call sixin_echoVal("exz(1,6)",exz(1,6),"INIT",iLine)
     if(iErr) return
     
   case(8)  ! x [mm] coordinate of particle 2
-    call chr_toReal(lnSplit(1),exz(2,1),iErr)
+    call chr_cast(lnSplit(1),exz(2,1),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,1)",exz(2,1),"INIT",iLine)
     if(iErr) return
     
   case(9)  ! xp [mrad] coordinate of particle 2
-    call chr_toReal(lnSplit(1),exz(2,2),iErr)
+    call chr_cast(lnSplit(1),exz(2,2),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,2)",exz(2,2),"INIT",iLine)
     if(iErr) return
     
   case(10) ! y [mm] coordinate of particle 2
-    call chr_toReal(lnSplit(1),exz(2,3),iErr)
+    call chr_cast(lnSplit(1),exz(2,3),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,3)",exz(2,3),"INIT",iLine)
     if(iErr) return
     
   case(11) ! yp [mrad] coordinate of particle 2
-    call chr_toReal(lnSplit(1),exz(2,4),iErr)
+    call chr_cast(lnSplit(1),exz(2,4),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,4)",exz(2,4),"INIT",iLine)
     if(iErr) return
     
   case(12) ! Path length difference 1(sigma = s−v0*t) [mm] of particle 2
-    call chr_toReal(lnSplit(1),exz(2,5),iErr)
+    call chr_cast(lnSplit(1),exz(2,5),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,5)",exz(2,5),"INIT",iLine)
     if(iErr) return
     
   case(13) ! dp/p0 of particle 2
-    call chr_toReal(lnSplit(1),exz(2,6),iErr)
+    call chr_cast(lnSplit(1),exz(2,6),iErr)
     if(sixin_debug) call sixin_echoVal("exz(2,6)",exz(2,6),"INIT",iLine)
     if(iErr) return
     
   case(14) ! energy [MeV] of the reference particle
-    call chr_toReal(lnSplit(1),e0,iErr)
+    call chr_cast(lnSplit(1),e0,iErr)
     if(sixin_debug) call sixin_echoVal("e0",e0,"INIT",iLine)
     if(iErr) return
     
   case(15) ! energy [MeV] of particle 1
-    call chr_toReal(lnSplit(1),ej(1),iErr)
+    call chr_cast(lnSplit(1),ej(1),iErr)
     if(sixin_debug) call sixin_echoVal("ej(1)",ej(1),"INIT",iLine)
     if(iErr) return
     
   case(16) ! energy [MeV] of particle 2
-    call chr_toReal(lnSplit(1),ej(2),iErr)
+    call chr_cast(lnSplit(1),ej(2),iErr)
     if(sixin_debug) call sixin_echoVal("ej(2)",ej(2),"INIT",iLine)
     if(iErr) return
     
@@ -780,17 +780,17 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       iErr = .true.
       return
     end if
-    if(nSplit > 0)  call chr_toInt(lnSplit(1),numl,iErr)     ! Number of turns in the forward direction
-    if(nSplit > 1)  call chr_toInt(lnSplit(2),numlr,iErr)    ! Number of turns in the backward direction
-    if(nSplit > 2)  call chr_toInt(lnSplit(3),napx,iErr)     ! Number of amplitude variations (i.e. particle pairs)
-    if(nSplit > 3)  call chr_toReal(lnSplit(4),amp(1),iErr)  ! End amplitude
-    if(nSplit > 4)  call chr_toReal(lnSplit(5),amp0,iErr)    ! Start amplitude
-    if(nSplit > 5)  call chr_toInt(lnSplit(6),ird,iErr)      ! Ignored
-    if(nSplit > 6)  call chr_toInt(lnSplit(7),imc,iErr)      ! Number of variations of the relative momentum deviation dp/p
-    if(nSplit > 7)  call chr_toInt(lnSplit(8),niu(1),iErr)   ! Unknown
-    if(nSplit > 8)  call chr_toInt(lnSplit(9),niu(2),iErr)   ! Unknown
-    if(nSplit > 9)  call chr_toInt(lnSplit(10),numlcp,iErr)  ! CR: How often to write checkpointing files
-    if(nSplit > 10) call chr_toInt(lnSplit(11),numlmax,iErr) ! CR: Maximum amount of turns; default is 1e6
+    if(nSplit > 0)  call chr_cast(lnSplit(1), numl,   iErr) ! Number of turns in the forward direction
+    if(nSplit > 1)  call chr_cast(lnSplit(2), numlr,  iErr) ! Number of turns in the backward direction
+    if(nSplit > 2)  call chr_cast(lnSplit(3), napx,   iErr) ! Number of amplitude variations (i.e. particle pairs)
+    if(nSplit > 3)  call chr_cast(lnSplit(4), amp(1), iErr) ! End amplitude
+    if(nSplit > 4)  call chr_cast(lnSplit(5), amp0,   iErr) ! Start amplitude
+    if(nSplit > 5)  call chr_cast(lnSplit(6), ird,    iErr) ! Ignored
+    if(nSplit > 6)  call chr_cast(lnSplit(7), imc,    iErr) ! Number of variations of the relative momentum deviation dp/p
+    if(nSplit > 7)  call chr_cast(lnSplit(8), niu(1), iErr) ! Unknown
+    if(nSplit > 8)  call chr_cast(lnSplit(9), niu(2), iErr) ! Unknown
+    if(nSplit > 9)  call chr_cast(lnSplit(10),numlcp, iErr) ! CR: How often to write checkpointing files
+    if(nSplit > 10) call chr_cast(lnSplit(11),numlmax,iErr) ! CR: Maximum amount of turns; default is 1e6
     
     ! Default nnmul to numl
     nnuml = numl
@@ -798,16 +798,16 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
     if(numlcp == 0) numlcp = 1000
     
     if(sixin_debug) then
-      call sixin_echoVal("numl",numl,"TRAC",iLine)
-      call sixin_echoVal("numlr",numlr,"TRAC",iLine)
-      call sixin_echoVal("napx",napx,"TRAC",iLine)
-      call sixin_echoVal("amp(1)",amp(1),"TRAC",iLine)
-      call sixin_echoVal("amp0",amp0,"TRAC",iLine)
-      call sixin_echoVal("ird",ird,"TRAC",iLine)
-      call sixin_echoVal("imc",imc,"TRAC",iLine)
-      call sixin_echoVal("niu(1)",niu(1),"TRAC",iLine)
-      call sixin_echoVal("niu(2)",niu(2),"TRAC",iLine)
-      call sixin_echoVal("numlcp",numlcp,"TRAC",iLine)
+      call sixin_echoVal("numl",   numl,   "TRAC",iLine)
+      call sixin_echoVal("numlr",  numlr,  "TRAC",iLine)
+      call sixin_echoVal("napx",   napx,   "TRAC",iLine)
+      call sixin_echoVal("amp(1)", amp(1), "TRAC",iLine)
+      call sixin_echoVal("amp0",   amp0,   "TRAC",iLine)
+      call sixin_echoVal("ird",    ird,    "TRAC",iLine)
+      call sixin_echoVal("imc",    imc,    "TRAC",iLine)
+      call sixin_echoVal("niu(1)", niu(1), "TRAC",iLine)
+      call sixin_echoVal("niu(2)", niu(2), "TRAC",iLine)
+      call sixin_echoVal("numlcp", numlcp, "TRAC",iLine)
       call sixin_echoVal("numlmax",numlmax,"TRAC",iLine)
     end if
     if(iErr) return
@@ -818,11 +818,11 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       iErr = .true.
       return
     end if
-    if(nSplit > 0) call chr_toInt(lnSplit(1),idz(1),iErr) ! Coupling on/off
-    if(nSplit > 1) call chr_toInt(lnSplit(2),idz(2),iErr) ! Coupling on/off
-    if(nSplit > 2) call chr_toInt(lnSplit(3),idfor,iErr)  ! Closed orbit and initial coordinates
-    if(nSplit > 3) call chr_toInt(lnSplit(4),irew,iErr)   ! Disable rewind
-    if(nSplit > 4) call chr_toInt(lnSplit(5),iclo6,iErr)  ! Calculate the 6D closed orbit
+    if(nSplit > 0) call chr_cast(lnSplit(1),idz(1),iErr) ! Coupling on/off
+    if(nSplit > 1) call chr_cast(lnSplit(2),idz(2),iErr) ! Coupling on/off
+    if(nSplit > 2) call chr_cast(lnSplit(3),idfor, iErr) ! Closed orbit and initial coordinates
+    if(nSplit > 3) call chr_cast(lnSplit(4),irew,  iErr) ! Disable rewind
+    if(nSplit > 4) call chr_cast(lnSplit(5),iclo6, iErr) ! Calculate the 6D closed orbit
     if(idz(1) < 0 .or. idz(1) > 1) then
       write(lout,"(a,i0,a)") "PARAM> ERROR TRAC first value (idz(1)) can only be 0 or 1, but ",idz(1)," given."
       iErr = .true.
@@ -852,9 +852,9 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
     if(sixin_debug) then
       call sixin_echoVal("idz(1)",idz(1),"TRAC",iLine)
       call sixin_echoVal("idz(2)",idz(2),"TRAC",iLine)
-      call sixin_echoVal("idfor",idfor,"TRAC",iLine)
-      call sixin_echoVal("irew",irew,"TRAC",iLine)
-      call sixin_echoVal("iclo6",iclo6,"TRAC",iLine)
+      call sixin_echoVal("idfor", idfor, "TRAC",iLine)
+      call sixin_echoVal("irew",  irew,  "TRAC",iLine)
+      call sixin_echoVal("iclo6", iclo6, "TRAC",iLine)
     end if
     if(iErr) return
     
@@ -871,15 +871,15 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       iErr = .true.
       return
     end if
-    if(nSplit > 0) call chr_toInt(lnSplit(1),nde(1),iErr) ! Number of turns at flat bottom
-    if(nSplit > 1) call chr_toInt(lnSplit(2),nde(2),iErr) ! Number of turns for the energy ramping
-    if(nSplit > 2) call chr_toInt(lnSplit(3),nwr(1),iErr) ! Every nth turn coordinates will be written
-    if(nSplit > 3) call chr_toInt(lnSplit(4),nwr(2),iErr) ! Every nth turn coordinates in the ramping region will be written
-    if(nSplit > 4) call chr_toInt(lnSplit(5),nwr(3),iErr) ! Every nth turn at the flat top a write out of the coordinates
-    if(nSplit > 5) call chr_toInt(lnSplit(6),nwr(4),iErr) ! Every nth turn coordinates are written to unit 6.
-    if(nSplit > 6) call chr_toInt(lnSplit(7),ntwin,iErr)  ! Flag for calculated distance of phase space
-    if(nSplit > 7) call chr_toInt(lnSplit(8),ibidu,iErr)  ! Switch to create or read binary dump
-    if(nSplit > 8) call chr_toInt(lnSplit(9),iexact,iErr) ! Switch to enable exact solution of the equation of motion
+    if(nSplit > 0) call chr_cast(lnSplit(1),nde(1),iErr) ! Number of turns at flat bottom
+    if(nSplit > 1) call chr_cast(lnSplit(2),nde(2),iErr) ! Number of turns for the energy ramping
+    if(nSplit > 2) call chr_cast(lnSplit(3),nwr(1),iErr) ! Every nth turn coordinates will be written
+    if(nSplit > 3) call chr_cast(lnSplit(4),nwr(2),iErr) ! Every nth turn coordinates in the ramping region will be written
+    if(nSplit > 4) call chr_cast(lnSplit(5),nwr(3),iErr) ! Every nth turn at the flat top a write out of the coordinates
+    if(nSplit > 5) call chr_cast(lnSplit(6),nwr(4),iErr) ! Every nth turn coordinates are written to unit 6.
+    if(nSplit > 6) call chr_cast(lnSplit(7),ntwin, iErr) ! Flag for calculated distance of phase space
+    if(nSplit > 7) call chr_cast(lnSplit(8),ibidu, iErr) ! Switch to create or read binary dump
+    if(nSplit > 8) call chr_cast(lnSplit(9),iexact,iErr) ! Switch to enable exact solution of the equation of motion
     
     if(sixin_debug) then
       call sixin_echoVal("nde(1)",nde(1),"TRAC",iLine)
@@ -888,8 +888,8 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       call sixin_echoVal("nwr(2)",nwr(2),"TRAC",iLine)
       call sixin_echoVal("nwr(3)",nwr(3),"TRAC",iLine)
       call sixin_echoVal("nwr(4)",nwr(4),"TRAC",iLine)
-      call sixin_echoVal("ntwin",ntwin,"TRAC",iLine)
-      call sixin_echoVal("ibidu",ibidu,"TRAC",iLine)
+      call sixin_echoVal("ntwin", ntwin, "TRAC",iLine)
+      call sixin_echoVal("ibidu", ibidu, "TRAC",iLine)
       call sixin_echoVal("iexact",iexact,"TRAC",iLine)
     end if
     if(iErr) return

--- a/SixTrack/string_tools.f90
+++ b/SixTrack/string_tools.f90
@@ -75,7 +75,7 @@ subroutine str_split(toSplit, returnArray, nArray)
   dblQ   = .false.
   do ch=1, len(toSplit%chr)
     if(toSplit%chr(ch:ch) == '"') dblQ = .not. dblQ
-    if((toSplit%chr(ch:ch) == " " .or. toSplit%chr(ch:ch) == char(9)) .and. .not. dblQ) then
+    if((toSplit%chr(ch:ch) == char(32) .or. toSplit%chr(ch:ch) == char(9)) .and. .not. dblQ) then
       if(newBit == 0) then
         cycle
       else
@@ -122,7 +122,7 @@ subroutine chr_split(toSplit, returnArray, nArray, isCont)
   dblQ   = .false.
   do ch=1, len(tmpSplit)
     if(tmpSplit(ch:ch) == '"') dblQ = .not. dblQ
-    if((tmpSplit(ch:ch) == " " .or. tmpSplit(ch:ch) == char(9)) .and. .not. dblQ) then
+    if((tmpSplit(ch:ch) == char(32) .or. tmpSplit(ch:ch) == char(9)) .and. .not. dblQ) then
       if(newBit == 0) then
         cycle
       else
@@ -278,8 +278,7 @@ subroutine chr_arrAppend(theArray, theString)
     
     maxLen = inLen
     do arrElem=1, len(theArray)
-      elemLen = len(theArray(arrElem))
-      if(elemLen > maxLen) maxLen = elemLen
+      maxLen = max(maxLen,len(theArray(arrElem)))
     end do
     
     arrSize = size(theArray,1)

--- a/SixTrack/string_tools.f90
+++ b/SixTrack/string_tools.f90
@@ -66,18 +66,16 @@ subroutine str_split(toSplit, returnArray, nArray)
   integer,                   intent(out) :: nArray
   
   integer ch, newBit
-  logical sngQ, dblQ
+  logical dblQ
   
   if(allocated(returnArray)) deallocate(returnArray)
   
   newBit = 0
   nArray = 0
-  sngQ   = .false.
   dblQ   = .false.
   do ch=1, len(toSplit%chr)
-    if(toSplit%chr(ch:ch) == "'") sngQ = .not. sngQ
     if(toSplit%chr(ch:ch) == '"') dblQ = .not. dblQ
-    if((toSplit%chr(ch:ch) == " " .or. toSplit%chr(ch:ch) == char(9)) .and. .not. sngQ .and. .not. dblQ) then
+    if((toSplit%chr(ch:ch) == " " .or. toSplit%chr(ch:ch) == char(9)) .and. .not. dblQ) then
       if(newBit == 0) then
         cycle
       else
@@ -102,7 +100,7 @@ subroutine chr_split(toSplit, returnArray, nArray, isCont)
   logical,          optional,    intent(out) :: isCont
   
   integer ch, newBit
-  logical sngQ, dblQ, allCont
+  logical dblQ, allCont
   character(len=:), allocatable :: tmpSplit
   
   if(allocated(returnArray)) deallocate(returnArray)
@@ -121,12 +119,10 @@ subroutine chr_split(toSplit, returnArray, nArray, isCont)
   
   newBit = 0
   nArray = 0
-  sngQ   = .false.
   dblQ   = .false.
   do ch=1, len(tmpSplit)
-    if(tmpSplit(ch:ch) == "'") sngQ = .not. sngQ
     if(tmpSplit(ch:ch) == '"') dblQ = .not. dblQ
-    if((tmpSplit(ch:ch) == " " .or. tmpSplit(ch:ch) == char(9)) .and. .not. sngQ .and. .not. dblQ) then
+    if((tmpSplit(ch:ch) == " " .or. tmpSplit(ch:ch) == char(9)) .and. .not. dblQ) then
       if(newBit == 0) then
         cycle
       else
@@ -173,7 +169,7 @@ function chr_expandBrackets(theString) result(theResult)
     return
   end if
   
-  ! Otherwise, Get all the positions for slicing
+  ! Otherwise, get all the positions for slicing
   allocate(bPos(3,nLB))
   theBuffer = " "//theString//" "
   bPos(:,:) = 0
@@ -468,7 +464,7 @@ end function chr_inStr
 !  Strip Quotes Routine
 !  V.K. Berglyd Olsen, BE-ABP-HSS
 !  Last modified: 2018-04-14
-!  Removes a matching pair of single or double quotes at the beginning or end of a string
+!  Removes a matching pair of double quotes at the beginning and end of a string
 ! ================================================================================================ !
 function str_stripQuotes(theString) result(retString)
   
@@ -487,9 +483,6 @@ function str_stripQuotes(theString) result(retString)
   end if
   
   if(tmpString%chr(1:1) == '"' .and. tmpString%chr(strLen:strLen) == '"') then
-    retString = str_sub(tmpString,2,strLen-1)
-    return
-  elseif(tmpString%chr(1:1) == "'" .and. tmpString%chr(strLen:strLen) == "'") then
     retString = str_sub(tmpString,2,strLen-1)
     return
   else
@@ -516,9 +509,6 @@ function chr_stripQuotes(theString) result(retString)
   end if
   
   if(tmpString(1:1) == '"' .and. tmpString(strLen:strLen) == '"') then
-    retString = tmpString(2:strLen-1)
-    return
-  elseif(tmpString(1:1) == "'" .and. tmpString(strLen:strLen) == "'") then
     retString = tmpString(2:strLen-1)
     return
   else

--- a/SixTrack/string_tools.f90
+++ b/SixTrack/string_tools.f90
@@ -35,6 +35,19 @@ module string_tools
   public str_inStr, chr_inStr
   public str_toReal, chr_toReal
   public str_toInt, chr_toInt
+  public str_toLog, chr_toLog
+  
+  interface str_cast
+    module procedure str_toReal
+    module procedure str_toInt
+    module procedure str_toLog
+  end interface str_cast
+  
+  interface chr_cast
+    module procedure chr_toReal
+    module procedure chr_toInt
+    module procedure chr_toLog
+  end interface chr_cast
   
   !
   ! Old stuff added for backwards compatibility
@@ -548,9 +561,9 @@ subroutine str_toReal(theString, theValue, rErr)
   theValue  = round_near(cErr,cLen,cString)
   
   if(cErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with CRLIBM"
-    write (lout,"(a)")    "TOREAL> Overfow/Underflow in round_near"
-    write (lout,"(a,i2)") "TOREAL> Error value: ",cErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with CRLIBM"
+    write (lout,"(a)")    "TYPECAST> Overfow/Underflow in round_near"
+    write (lout,"(a,i2)") "TYPECAST> Error value: ",cErr
     rErr = .true.
   end if
 #endif
@@ -561,9 +574,9 @@ subroutine str_toReal(theString, theValue, rErr)
   read(tmpString,*,round="nearest",iostat=readErr) theValue
   call disable_xp()
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with FIO overriding CRLIBM"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with FIO overriding CRLIBM"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -572,9 +585,9 @@ subroutine str_toReal(theString, theValue, rErr)
   tmpString = chr_trimZero(theString%chr)
   read(tmpString,*,round="nearest",iostat=readErr) theValue
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with FIO"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with FIO"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -583,9 +596,9 @@ subroutine str_toReal(theString, theValue, rErr)
   tmpString = chr_trimZero(theString%chr)
   read(tmpString,*,iostat=readErr) theValue
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -617,9 +630,9 @@ subroutine chr_toReal(theString, theValue, rErr)
   theValue  = round_near(cErr,cLen,cString)
   
   if(cErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with CRLIBM"
-    write (lout,"(a)")    "TOREAL> Overfow/Underflow in round_near"
-    write (lout,"(a,i2)") "TOREAL> Error value: ",cErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with CRLIBM"
+    write (lout,"(a)")    "TYPECAST> Overfow/Underflow in round_near"
+    write (lout,"(a,i2)") "TYPECAST> Error value: ",cErr
     rErr = .true.
   end if
 #endif
@@ -630,9 +643,9 @@ subroutine chr_toReal(theString, theValue, rErr)
   read(tmpString,*,round="nearest",iostat=readErr) theValue
   call disable_xp()
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with FIO overriding CRLIBM"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with FIO overriding CRLIBM"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -641,9 +654,9 @@ subroutine chr_toReal(theString, theValue, rErr)
   tmpString = chr_trimZero(theString)
   read(tmpString,*,round="nearest",iostat=readErr) theValue
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input with FIO"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input with FIO"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -652,9 +665,9 @@ subroutine chr_toReal(theString, theValue, rErr)
   tmpString = chr_trimZero(theString)
   read(tmpString,*,iostat=readErr) theValue
   if(readErr /= 0) then
-    write (lout,"(a)")    "TOREAL> ERROR Data Input"
-    write (lout,"(a)")    "TOREAL> Failed to cast '"//tmpString//"' to real"
-    write (lout,"(a,i2)") "TOREAL> iostat value: ",readErr
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to real"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
     rErr = .true.
   end if
 #endif
@@ -667,22 +680,99 @@ end subroutine chr_toReal
 !  Last modified: 2018-05-18
 ! ================================================================================================ !
 
-function str_toInt(theString) result(theValue)
-  type(string), intent(in)      :: theString
-  integer                       :: theValue
-  character(len=:), allocatable :: tmpString
+subroutine str_toInt(theString, theValue, rErr)
+  
+  use crcoall
+  
+  type(string),     intent(in)    :: theString
+  integer,          intent(out)   :: theValue
+  logical,          intent(inout) :: rErr
+  
+  character(len=:), allocatable   :: tmpString
+  integer                         :: readErr
+  
   tmpString = chr_trimZero(theString%chr)
-  read(tmpString,*) theValue
-end function str_toInt
+  read(tmpString,*,iostat=readErr) theValue
+  if(readErr /= 0) then
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to integer"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
+    rErr = .true.
+  end if
+  
+end subroutine str_toInt
 
-subroutine chr_toInt(theString, theValue, iErr)
+subroutine chr_toInt(theString, theValue, rErr)
+  
+  use crcoall
+  
   character(len=*), intent(in)    :: theString
   integer,          intent(out)   :: theValue
-  logical,          intent(inout) :: iErr
+  logical,          intent(inout) :: rErr
+  
   character(len=:), allocatable   :: tmpString
+  integer                         :: readErr
+  
   tmpString = chr_trimZero(theString)
-  read(tmpString,*) theValue
+  read(tmpString,*,iostat=readErr) theValue
+  if(readErr /= 0) then
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to integer"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
+    rErr = .true.
+  end if
+  
 end subroutine chr_toInt
+
+! ================================================================================================ !
+!  String to Logical
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Last modified: 2018-05-18
+! ================================================================================================ !
+
+subroutine str_toLog(theString, theValue, rErr)
+  
+  use crcoall
+  
+  type(string),     intent(in)    :: theString
+  logical,          intent(out)   :: theValue
+  logical,          intent(inout) :: rErr
+  
+  character(len=:), allocatable   :: tmpString
+  integer                         :: readErr
+  
+  tmpString = chr_trimZero(theString%chr)
+  read(tmpString,*,iostat=readErr) theValue
+  if(readErr /= 0) then
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to logical"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
+    rErr = .true.
+  end if
+  
+end subroutine str_toLog
+
+subroutine chr_toLog(theString, theValue, rErr)
+  
+  use crcoall
+  
+  character(len=*), intent(in)    :: theString
+  logical,          intent(out)   :: theValue
+  logical,          intent(inout) :: rErr
+  
+  character(len=:), allocatable   :: tmpString
+  integer                         :: readErr
+  
+  tmpString = chr_trimZero(theString)
+  read(tmpString,*,iostat=readErr) theValue
+  if(readErr /= 0) then
+    write (lout,"(a)")    "TYPECAST> ERROR Data Input"
+    write (lout,"(a)")    "TYPECAST> Failed to cast '"//tmpString//"' to logical"
+    write (lout,"(a,i2)") "TYPECAST> iostat value: ",readErr
+    rErr = .true.
+  end if
+  
+end subroutine chr_toLog
 
 ! ================================================================================================ !
 !  HERE FOLLOWS THE OLD ROUTINES


### PR DESCRIPTION
Removed support for single quoted strings in string_tools split routines. There was no checking that they single and double quoted regions overlapped, and there really isn't a need to support both formats. It is now only double quoted.

Also added some more simulation information to HDF5 output.

In addition, string_tools now have routines to cast logicals.