### PR TITLE
Fix for PRINT block conflict with LIMI block

### DIFF
--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -398,7 +398,7 @@ subroutine abend(cstring)
   character(len=*) cstring
   character(len=256) filename
   real(kind=fPrec) sumda(60)
-  logical fopen
+  logical fopen, rErr
   character(len=8192) ch
   character(len=25) ch1
   integer errno,l1,l2


### PR DESCRIPTION
This is a fix that caused DATEN to interpret the PRIN command in the LIMI block as the PRINTOUT flag that sits at the top of fort.3.

The conflict arises because Sixtrack pre-5.0 did not enforce a NEXT flag after the PRINTOUT statement. Since the new input parser has a global loop instead of a loop per block, this caused the PRIN command to be parsed as a PRINTOUT flag and the settings therefore ignored.

Ideally we should require the PRINTOUT block to be closed, but this fix should be able to handle the un closed case better than the previous code did.