### PR TITLE
Fileunits fix

### DIFF
--- a/source/file_units.f90
+++ b/source/file_units.f90
@@ -25,9 +25,15 @@ subroutine funit_initUnits
   allocate(funit_usedUnits(10))
   allocate(funit_usedByFile(10))
 
-  call funit_requestUnit("file_units.dat",funit_logUnit)
+  funit_logUnit       = funit_minUnit
+  funit_nextUnit      = funit_minUnit + 1
+  funit_nUnits        = 1
+  funit_usedUnits(1)  = funit_logUnit
+  funit_usedByFile(1) = "file_units.dat"
+
   open(funit_logUnit,file="file_units.dat",form="formatted")
-  write(funit_logUnit,"(a)") "# unit  assigned_to"
+  write(funit_logUnit,"(a)")    "# unit  assigned_to"
+  write(funit_logUnit,"(i6,a)") funit_usedUnits(1),"  "//funit_usedByFile(1)
 
 end subroutine funit_initUnits
 

--- a/test/fileunits_DYNK_DUMP/file_units.dat.canonical
+++ b/test/fileunits_DYNK_DUMP/file_units.dat.canonical
@@ -1,4 +1,5 @@
 # unit  assigned_to
+  1000  file_units.dat
   1001  mem_alloc.log
   1002  scatter_log.dat
   1003  dynksets.dat


### PR DESCRIPTION
This PR fixes issue #591 by having the file_units module bypass the funit_requestUnit call when assigning a file unit to its own log file.