### PR TITLE
Online ape check fixes

### DIFF
--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -984,7 +984,7 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
             xlos(2) = xLast(2,j)
             ylos(1) = yLast(1,j)
             ylos(2) = yLast(2,j)
-            slos    = dcum(iLast)
+            slos    = dcum(iLastThick)
           else
             xlos(1) = xv(1,j)
             xlos(2) = xv(2,j)

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -480,7 +480,7 @@ subroutine aperture_saveLastCoordinates( i, ix, iBack )
   integer i, ix, iBack
   ! temporary variables
   integer j
-
+  
   do j=1,napx
     xLast(1,j) = xv(1,j)
     xLast(2,j) = xv(2,j)
@@ -1163,14 +1163,18 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
 
     ! flush loss particle file
 #ifdef HDF5
-  if(.not. h5_useForAPER) then
+    if(.not. h5_useForAPER) then
 #endif
-    flush(losses_unit)
+       flush(losses_unit)
 #ifdef HDF5
-  end if
+    end if
 #endif
 
     call compactArrays(llostp)
+    
+    ! store old particle coordinates
+    ! necessary since aperture markers are downstream of lenses...
+    if ( lbacktracking ) call aperture_saveLastCoordinates(i,ix,-1)
 
   end if !if( llost ) then
 

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -1068,8 +1068,6 @@ subroutine thck4d(nthinerr)
       if ( lbacktracking ) then
          ! store infos of last aperture marker
          if ( kape(ix).ne.0 ) call aperture_saveLastMarker(i,ix)
-         ! store old particle coordinates
-         call aperture_saveLastCoordinates(i,ix,0)
       end if
 
 #ifdef FLUKA
@@ -1812,8 +1810,6 @@ subroutine thck6d(nthinerr)
       if ( lbacktracking ) then
          ! store infos of last aperture marker
          if ( kape(ix).ne.0 ) call aperture_saveLastMarker(i,ix)
-         ! store old particle coordinates
-         call aperture_saveLastCoordinates(i,ix,0)
       end if
 
 #ifdef FLUKA

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -1150,8 +1150,6 @@ subroutine thin4d(nthinerr)
       if ( lbacktracking ) then
          ! store infos of last aperture marker
          if ( kape(ix).ne.0 ) call aperture_saveLastMarker(i,ix)
-         ! store old particle coordinates
-         call aperture_saveLastCoordinates(i,ix,0)
       end if
 
 625 continue
@@ -2146,8 +2144,6 @@ subroutine thin6d(nthinerr)
       if ( lbacktracking ) then
          ! store infos of last aperture marker
          if ( kape(ix).ne.0 ) call aperture_saveLastMarker(i,ix)
-         ! store old particle coordinates
-         call aperture_saveLastCoordinates(i,ix,0)
       end if
 
 645   continue


### PR DESCRIPTION
restoring `call aperture_saveLastCoordinates(i,ix,-1)` but in the proper place (i.e. after any element where the online aperture checking has killed particles), and removed `call aperture_saveLastCoordinates(i,ix,0)` after any element. This last call was also fooling the backtracking algorithm, as the particle angles after the lens were saved and used, instead of the angles before the lens. hence the aperture checking was wrongly computing the transverse position of the lost particles (and also the longitudinal position, possibly not by a large amount).

At the same time, fixed bug at printing level - in previous dump, in case back-tracking was requested but not possible, the s-location of the last aperture marker was dumped instead of the last particle coordinates saving.

Pull request done before finalising test, otherwise simulations for FCC CDR may arrive too late...