### PR TITLE
User manual build test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       - image: debian:unstable
     steps:
       - run:
-         name: setup
-         command: apt-get update && apt-get install -y unzip git gfortran cmake gcc g++
+        name: setup
+        command: apt-get update && apt-get install -y unzip git gfortran cmake gcc g++ texlive
       - checkout
       - run:
           name: build and test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: debian:unstable
+      - image: debian:testing
     steps:
       - run:
          name: setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@ jobs:
       - image: debian:unstable
     steps:
       - run:
-        name: setup
-        command: apt-get update && apt-get install -y unzip git gfortran cmake gcc g++ texlive
+         name: setup
+         command: apt-get update && apt-get install -y unzip git gfortran cmake gcc g++ texlive
       - checkout
       - run:
           name: build and test

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/*/*.toc
 doc/*/*.bbl
 doc/*/*.blg
 doc/*/*.ilg
+doc/*/*.idx
 doc/*/*.synctex.gz
 
 # Python

--- a/doc/user_manual/makefile
+++ b/doc/user_manual/makefile
@@ -1,12 +1,13 @@
 
-manName=six
+TEXFLAGS  = 
+TEXFILES := $(wildcard *.tex)
 
-all: $(manName).pdf
+all: six.pdf
 
 clean:
-	rm -f $(manName).blg $(manName).bbl $(manName).toc $(manName).out $(manName).aux $(manName).log $(manName).lot $(manName).pdf
+	rm -f six.aux six.fdb_latexmk six.fls six.idx six.ilg six.ind six.log six.lot six.out six.toc six.pdf six.synctex.gz
 
-$(manName).pdf: $(manName).tex
-	pdflatex $(manName).tex
-	pdflatex $(manName).tex
-	pdflatex $(manName).tex
+six.pdf: $(TEXFILES)
+	pdflatex $(TEXFLAGS) six.tex
+	pdflatex $(TEXFLAGS) six.tex
+	pdflatex $(TEXFLAGS) six.tex

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,7 +26,7 @@ set_tests_properties(CheckTestInput_BOINC PROPERTIES FAIL_REGULAR_EXPRESSION "ER
 ADD_TEST(NAME CheckTestInput_STF WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/ COMMAND ${CMAKE_SOURCE_DIR}/test/CheckTestInputForSTF.sh $<TARGET_FILE:read90>)
 set_tests_properties(CheckTestInput_STF PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR")
 
-add_test(NAME CheckBuildManual WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/doc/user_manual COMMAND ${CMAKE_SOURCE_DIR}/test/CheckBuildManual.sh)
+add_test(NAME CheckBuildManual COMMAND ${CMAKE_SOURCE_DIR}/test/CheckBuildManual.sh "${CMAKE_SOURCE_DIR}")
 set_tests_properties(CheckBuildManual PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR")
 
 ##

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,6 +26,9 @@ set_tests_properties(CheckTestInput_BOINC PROPERTIES FAIL_REGULAR_EXPRESSION "ER
 ADD_TEST(NAME CheckTestInput_STF WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/ COMMAND ${CMAKE_SOURCE_DIR}/test/CheckTestInputForSTF.sh $<TARGET_FILE:read90>)
 set_tests_properties(CheckTestInput_STF PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR")
 
+add_test(NAME CheckBuildManual WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/doc/user_manual COMMAND ${CMAKE_SOURCE_DIR}/test/CheckBuildManual.sh)
+set_tests_properties(CheckBuildManual PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR")
+
 ##
 ## Needs checking: thick6dsingles (broken input files -- this test could probably be removed)
 ## thick6dblocks elensidealthck6d dynk_globalvars thick6ddynk - empty fort.10 (no POST block in fort.3) -- this is OK, we still test the tracking with fort.90 / STF.
@@ -441,7 +444,7 @@ foreach(TST IN ITEMS ${SIXTRACK_TESTS} ${SIXTRACK_DA_TESTS})
   endif()
 endforeach()
 
-#Tools
+# Tools
 SET(SELFTEST_TOOLS
   SelfTest_verify10
   SelfTest_compf10
@@ -455,11 +458,19 @@ foreach(TOOL IN ITEMS ${SELFTEST_TOOLS})
   set_property(TEST ${TOOL} PROPERTY LABELS tool fast)
 endforeach()
 
-#Inputs
+# Inputs
 SET(SELFTEST_INPUT
   CheckTestInput_BOINC
   CheckTestInput_STF
 )
 foreach(TOOL IN ITEMS ${SELFTEST_INPUT})
+  set_property(TEST ${TOOL} PROPERTY LABELS input fast)
+endforeach()
+
+# Other
+SET(SELFTEST_OTHER
+  CheckBuildManual
+)
+foreach(TOOL IN ITEMS ${SELFTEST_OTHER})
   set_property(TEST ${TOOL} PROPERTY LABELS input fast)
 endforeach()

--- a/test/CheckBuildManual.sh
+++ b/test/CheckBuildManual.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+cd ../doc/user_manual
+make clean
+make TEXFLAGS=-interaction=nonstopmode
+
+EXSTAT=$?
+
+if [ $EXSTAT -ne 0 ]; then
+  echo "ERROR Failed to build user manual"
+fi
+exit $EXSTAT

--- a/test/CheckBuildManual.sh
+++ b/test/CheckBuildManual.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-cd ../doc/user_manual
+rsync -a $1/doc/user_manual .
+cd user_manual
 make clean
-make TEXFLAGS=-interaction=nonstopmode
+make TEXFLAGS=-interaction=nonstopmode > build.log
 
 EXSTAT=$?
 


### PR DESCRIPTION
This PR adds a test for the user manual build.
I updated the makefile as well.
The test runs in the user manual folder directly, but I don't think that is a problem.
I assume the circleci test will fail as latex is not installed there.