### PR TITLE
Build bugfixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1011,7 +1011,9 @@ if(LIBARCHIVE)
 
 	#See also further down for SixTestWrapper linking
 	target_link_libraries(SixTrackCR libArchive_wrapper)
-	target_link_libraries(SixTrackDA libArchive_wrapper)
+	if(SIXDA)
+		target_link_libraries(SixTrackDA libArchive_wrapper)
+	endif()
 	add_library(libarchive STATIC IMPORTED)
 	if(WIN32)
 		set_target_properties(libarchive PROPERTIES IMPORTED_LOCATION ${LIBARCHIVE_BUILD_DIR}/libarchive/libarchive_static.a)
@@ -1025,7 +1027,9 @@ if(LIBARCHIVE)
 	set_target_properties(z PROPERTIES IMPORTED_LOCATION ${CMAKE_SOURCE_DIR}/lib/zlib/install/lib/libz.a)
 
 	target_link_libraries(SixTrackCR libarchive z Threads::Threads)
-	target_link_libraries(SixTrackDA libarchive z Threads::Threads)
+	if(SIXDA)
+		target_link_libraries(SixTrackDA libarchive z Threads::Threads)
+	endif()
 	target_link_libraries(libArchiveTester libarchive z Threads::Threads)
 
 	add_definitions( -DLIBARCHIVE )


### PR DESCRIPTION
While adding support for building SixDA with LIBARCHIVE, we forgot to disable if both BOINC and LIBARCHIVE is built. This fixes that.

Also adds a section in buildLibraries.sh that updates two source files in BOINC before build when run on MinGW.