### PR TITLE
Revert "Bugfix for DYNK FIR/IIR"

### DIFF
--- a/source/dynk.f90
+++ b/source/dynk.f90
@@ -798,7 +798,6 @@ subroutine dynk_parseFUN(inLine, iErr)
     ! Set pointers to start of funs data blocks
     dynk_nFuncs = dynk_nFuncs+1
     dynk_ncData = dynk_ncData+1
-    dynk_niData = dynk_niData+1
 
     ! Store pointers
     dynk_funcs(dynk_nFuncs,1) = dynk_ncData   ! NAME (in dynk_cData)


### PR DESCRIPTION
Reverts SixTrack/SixTrack#650

Hi, please revert this, I did not sign #650 it because it was not the right way to fix it but I needed to double check before I could review with "don't merge".

`N` is the number of lines read from the file, which is anyway stored elsewhere. The buggy value is not actually used anywhere except in a sanity check.

Also it doesn't call the `dynk_checkspace`. I'll follow up with a PR that actually fixes the problem in 5 minutes.