### PR TITLE
Beamgas build fix

### DIFF
--- a/source/beamgas.f90
+++ b/source/beamgas.f90
@@ -3,6 +3,7 @@
 !!
 !<
 module beamgascommon
+
   use floatPrecision
 !       common to beamGasInit and beamGas
   integer, parameter :: bgmaxx=40000,bamount=1000
@@ -21,6 +22,14 @@ module beamgascommon
 !       at this location
   real(kind=fPrec) bgParameters(3)
   real bgxpdb(bgmaxx),bgypdb(bgmaxx),bgEdb(bgmaxx)
+
+  ! File unit variables
+  integer, public, save :: bg_dpmJetUnit
+  integer, public, save :: bg_scatterLocUnit
+  integer, public, save :: bg_configUnit
+  integer, public, save :: bg_pressProUnit
+  integer, public, save :: bg_locLossesUnit
+
 end module beamgascommon
 
 module lorentzcommon
@@ -76,16 +85,8 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
 
   implicit none
 
-!+ca info
-!+ca dbcommon
-
-!YIL need to save, this is input variable
   real(kind=fPrec) myenom
   integer ipart(npart)
-
-!YIL: think this probably should be saved as well...
-!  integer mynp
-!  common /mynp/ mynp
 
 ! KNS (22/08/2017): The variable "secondary" is now visible
 ! from a +cd block as a COMMON variable;
@@ -137,7 +138,7 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
   if ((pressARRAY(2,pressID)*njobs*dpmjetevents).gt.(bgParameters(3)+1)) then
   bgParameters(3)=bgParameters(3)+1
   if (((bgParameters(2)+bgParameters(3)).gt.(dpmjetevents*njobthis)).and.((bgParameters(2)+bgParameters(3)).le.  &
- & (dpmjetevents*(njobthis+1)))) then
+    (dpmjetevents*(njobthis+1)))) then
 !       The scattering id is increased by one for each interaction
   bgid=bgid+1
 
@@ -148,12 +149,12 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
 
   if(bgid.lt.bgiddb(ibgloc)) then ! no proton for this scattering event
 !   check that this works correctly!!!!!!
-    write(777,*) ipart(j),iturn,totals,xv(1,j),yv(1,j),xv(2,j),yv(2,j),mys(j),(0-myenom)/myenom, &
- &  bgid+njobthis*dpmjetevents
+    write(bg_locLossesUnit,*) ipart(j),iturn,totals,xv(1,j),yv(1,j),xv(2,j),yv(2,j),mys(j),(0-myenom)/myenom, &
+      bgid+njobthis*dpmjetevents
 
 !   writing down the scattering location information
-    write(667,*) ipart(j),iturn,totals,xv(1,j),yv(1,j),xv(2,j),yv(2,j),sigmv(j),ejv(j),bgid+njobthis*dpmjetevents,&
- &  bgid,ejv(j),xv(1,j),xv(2,j),yv(1,j),yv(2,j)
+    write(bg_scatterLocUnit,*) ipart(j),iturn,totals,xv(1,j),yv(1,j),xv(2,j),yv(2,j),sigmv(j),ejv(j),bgid+njobthis*dpmjetevents,&
+      bgid,ejv(j),xv(1,j),xv(2,j),yv(1,j),yv(2,j)
 !    part_abs(j) = 1
     part_abs_pos(j)  = el_idx
     part_abs_turn(j) = turn
@@ -244,11 +245,11 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
     omoidpsv(j)=c1e3*((one-mtc(j))*oidpsv(j))
     dpsv1(j)=(dpsv(j)*c1e3)*oidpsv(j)
 ! writing down the scattering location information
-  write(667,*) ipart(j),iturn,totals,xv(1,j),      &
- &   yv(1,j),xv(2,j),yv(2,j),sigmv(j),oldCoordinates(3),            &
- &   bgid+njobthis*dpmjetevents,bgid,ejv(j),oldCoordinates(4),      &
- &   oldCoordinates(5),oldCoordinates(1),oldCoordinates(2)
-     mysecondary(j)=1
+  write(bg_scatterLocUnit,*) ipart(j),iturn,totals,xv(1,j),        &
+    yv(1,j),xv(2,j),yv(2,j),sigmv(j),oldCoordinates(3),            &
+    bgid+njobthis*dpmjetevents,bgid,ejv(j),oldCoordinates(4),      &
+    oldCoordinates(5),oldCoordinates(1),oldCoordinates(2)
+    mysecondary(j)=1
 
 ! if bgid.eq.bgiddb(ibgloc) end statement
   endif
@@ -292,11 +293,11 @@ subroutine beamGasInit(myenom)
   use numerical_constants
   use beamgascommon
   use crcoall
+  use file_units
 
   use collimation, only : mynp
 
-  IMPLICIT NONE
-
+  implicit none
 
   integer check,j,i
   real(kind=fPrec) myenom,minenergy
@@ -307,24 +308,28 @@ subroutine beamGasInit(myenom)
 
   write(lout,"(a)") "BEAMGAS> Initialising"
 
-! DEBUG: open debug file...
-!      open(684,file='debugfile.txt')
-! END DEBUG
-  open(666,file='dpmjet.eve')
-  open(667,file='scatterLOC.txt')
-  write(667,*)'# 1=name 2=turn 3=s 4=x 5=xp 6=y 7=yp 8=z 9=E',      &
- & ' 10=eventID 11=dpmjetID 12=newEnergy 13=oldX 14=oldY 15=oldXP 16=oldYP'
-  write(667,*)'# These are original coordinates of proton after impact, and old xp,yp'
-  write(667,*)
+  ! Get file units
+  call funit_requestUnit("dpmjet.eve",          bg_dpmJetUnit)
+  call funit_requestUnit("scatterLOC.txt",      bg_scatterLocUnit)
+  call funit_requestUnit("beamgas_config.txt",  bg_configUnit)
+  call funit_requestUnit("pressure_profile.txt",bg_pressProUnit)
+  call funit_requestUnit("localLOSSES.txt",     bg_locLossesUnit)
+
+  open(bg_dpmJetUnit,file='dpmjet.eve')
+  open(bg_scatterLocUnit,file='scatterLOC.txt')
+  write(bg_scatterLocUnit,*)'# 1=name 2=turn 3=s 4=x 5=xp 6=y 7=yp 8=z 9=E',      &
+    ' 10=eventID 11=dpmjetID 12=newEnergy 13=oldX 14=oldY 15=oldXP 16=oldYP'
+  write(bg_scatterLocUnit,*)'# These are original coordinates of proton after impact, and old xp,yp'
+  write(bg_scatterLocUnit,*)
 
 ! initialize pressure markers array
 ! DO THIS BEFORE OTHER STUFF, AS YOU MIGHT DO STUPID THINGS TO VARIABLES
 ! (LEARNED THE HARD WAY!!!)
-  open(778,file='beamgas_config.txt')
-  open(779,file='pressure_profile.txt')
+  open(bg_configUnit,file='beamgas_config.txt')
+  open(bg_pressProUnit,file='pressure_profile.txt')
   filereaderror=0
   do
-     read(778,*,IOSTAT=filereaderror) bg_var, bg_val
+     read(bg_configUnit,*,IOSTAT=filereaderror) bg_var, bg_val
   if (filereaderror.lt.0) then
 ! end of file
      exit
@@ -340,26 +345,26 @@ subroutine beamGasInit(myenom)
   end do
   j=1
   do
-     read(779,*,IOSTAT=filereaderror) pPOS, pVAL
-  if (filereaderror.eq.0) then
-  pressARRAY(1,j)=pPOS
-  pressARRAY(2,j)=pVAL
-  j=j+1
-   if (j>bgmaxx) then
-     write(lout,"(a)") "BEAMGAS> ERROR Too many pressure markers!"
-     call prror(-1)
-   endif
-  else if (filereaderror.lt.0) then
-! means that end of file is reached
-     exit
-  else if (filereaderror.gt.0) then
-! means that this line did not correspond to normal input
-! do not need to perform anything (probably a comment line)
-  end if
+    read(bg_pressProUnit,*,IOSTAT=filereaderror) pPOS, pVAL
+    if (filereaderror.eq.0) then
+      pressARRAY(1,j)=pPOS
+      pressARRAY(2,j)=pVAL
+      j=j+1
+      if (j>bgmaxx) then
+        write(lout,"(a)") "BEAMGAS> ERROR Too many pressure markers!"
+        call prror(-1)
+      endif
+    else if (filereaderror.lt.0) then
+      ! means that end of file is reached
+      exit
+    else if (filereaderror.gt.0) then
+      ! means that this line did not correspond to normal input
+      ! do not need to perform anything (probably a comment line)
+    end if
   end do
   do 1328 i = j,bgmaxx
-   pressARRAY(1,i)=-one
-   pressARRAY(2,i)=zero
+    pressARRAY(1,i)=-one
+    pressARRAY(2,i)=zero
 1328  continue
 ! count the number of lines in dpmjet
   j=1
@@ -375,7 +380,7 @@ subroutine beamGasInit(myenom)
 !    The other particles will be used to generate a complete file
 !    afterwards.
 !    ONLY LOAD PROTONS WITH ENERGY OFFSET BELOW 5%!!
-     read(666,*,IOSTAT=filereaderror) bgiddb(j), check, bgxpdb(j), bgypdb(j), bgEdb(j)
+     read(bg_dpmJetUnit,*,IOSTAT=filereaderror) bgiddb(j), check, bgxpdb(j), bgypdb(j), bgEdb(j)
      if (check.eq.2212.and.bgEdb(j).gt.minenergy) then
         if (bgiddb(j).ne.previousEvent) then
            previousEvent=bgiddb(j)
@@ -394,7 +399,7 @@ subroutine beamGasInit(myenom)
   enddo
 ! number of lines in dpmjet - 1
   bgmax=j
-  close(666)
+  close(bg_dpmJetUnit)
   write(lout,"(a,i0)") "BREAMGAS> Trackable events in dpmjet.eve: ",bgmax-1
 
   if (numberOfEvents.gt.mynp) then
@@ -406,12 +411,12 @@ subroutine beamGasInit(myenom)
   write(lout,"(a,i0)") "BEAMGAS> This is job number: ", njobthis
   write(lout,"(a,i0)") "BEAMGAS> Total number of jobs: ", njobs
   write(lout,"(a,i0)") "BEAMGAS> Total number of particles in simulation: ", njobs*dpmjetevents
-  close(778)
+  close(bg_configUnit)
 
-  open(777,file='localLOSSES.txt')
-  write(777,*) '# 1=name 2=turn 3=s 4=x 5=xp 6=y 7=yp 8=z 9=DE/E 10=CollisionID'
-  write(777,*) '# Note that name is not unique, but CollisionID is'
-  write(777,*) '# Note that s is particle coordinate, not bunch coordinate'
+  open(bg_locLossesUnit,file='localLOSSES.txt')
+  write(bg_locLossesUnit,*) '# 1=name 2=turn 3=s 4=x 5=xp 6=y 7=yp 8=z 9=DE/E 10=CollisionID'
+  write(bg_locLossesUnit,*) '# Note that name is not unique, but CollisionID is'
+  write(bg_locLossesUnit,*) '# Note that s is particle coordinate, not bunch coordinate'
 
 ! YOU HAVE TO PUT THESE INITIALIZATIONS AT THE END OF THE ROUTINE
 ! FOR SOME STRANGE FORTRAN-REASON

--- a/source/beamgas.f90
+++ b/source/beamgas.f90
@@ -68,6 +68,7 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
   use crcoall
   use parpro
   use parbeam
+  use mod_hions
   use mod_common
   use mod_commont
   use mod_commonmn


### PR DESCRIPTION
BEAMGAS flag now builds again. Was just missing a `use mod_hions`.
Also, in the same PR, the hard coded file units have been replaced by units assigned by the `file_units` module.