### PR TITLE
Less fort.6 output

### DIFF
--- a/doc/user_manual/chGeneralInput.tex
+++ b/doc/user_manual/chGeneralInput.tex
@@ -50,7 +50,9 @@ However, for backwards compatibility, the \texttt{PRIN} flag is still accepted.
 \begin{tabular}{@{}lp{0.8\linewidth}}
     \texttt{PRINT} & This causes the printing of the input data to the output file \texttt{fort.6}. \\
     \texttt{DEBUG} & A global debug flag that causes the majority of the blocks to echo back the value read from the input file after parsing. It may also print out secondary values set based on input values read, or modification made to input values based on other dependencies and criteria.\index{DEBUG}\\
-    \texttt{QUIET} & Followed by an integer specifying how ``quiet'' the output should be. A higher value causes less information to be printed back out. If the keyword is not present, the default value is 0, which means it is disabled. If it is present, but the integer value is omitted, it is set to be 1. This flag does not intefere with the \texttt{PRINT} flag.\index{QUIET}
+    \texttt{QUIET} & Followed by an integer specifying how ``quiet'' the output should be. A higher value causes less information to be printed back out. If the keyword is not present, the default value is 0, which means it is disabled. If it is present, but the integer value is omitted, it is set to be 1. This flag does not interfere with the \texttt{PRINT} flag.\index{QUIET}\\
+    \texttt{PRINT\_DCUM} & This will cause the calculated s-coordinate of each structure element to be printed to \texttt{fort.6}. \\
+    \texttt{PARTSUMMARY} & Enable or disable the printing of a particle summary after tracking. The flag takes an optional parameter to explicitly state whether it is ON or OFF. If omitted, it is assumed the user requests it to be ON. If the flag is omitted entirely, the default behaviour is determined by the particle count. If SixTrack is running with 64 particles or less, it is ON by default, otherwise OFF.\\
 \end{tabular}
 
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -94,16 +94,15 @@ end module parbeam
 ! ================================================================================================ !
 module mod_settings
 
-  use parpro, only : mDivLen, mStrLen, mNameLen
-
   implicit none
 
   ! PRINT Flag (fort.3)
-  logical, save :: st_print
+  logical, save :: st_print   = .false.
 
   ! SETTINGS Block (fort.3)
-  integer, save :: st_quiet ! QUIET Level
-  logical, save :: st_debug ! Global DEBUG flag
+  integer, save :: st_quiet   = 0       ! QUIET Level
+  logical, save :: st_debug   = .false. ! Global DEBUG flag
+  logical, save :: st_partsum = .false. ! Flag to print final particle summary
 
 end module mod_settings
 

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -2017,6 +2017,14 @@ end interface
       write(lout,"(a)") ""
       write(lout,"(a)") str_divLine
       write(lout,"(a)") ""
+
+      if(st_partsum .eqv. .false.) then
+        write(lout,"(a)") "MAINCR> NOTE Particle summary report is disabled."
+        write(lout,"(a)") "MAINCR>      This is controlled by the PARTICLESUMMARY flag in the SETTINGS block in fort.3."
+        write(lout,"(a)") ""
+        goto 470
+      end if
+
       write(lout,"(a)") "    PARTICLE SUMMARY:"
       write(lout,"(a)") ""
 
@@ -2048,7 +2056,7 @@ end interface
             xvl(1,ie),yvl(1,ie),xvl(2,ie),yvl(2,ie),sigmvl(ie),dpsvl(ie),e0,ejv(id),ejvl(ie)
           write(12,10280,iostat=ierro) xv(1,id),yv(1,id),xv(2,id),yv(2,id),sigmv(id),dpsv(id), &
             xvl(1,ie),yvl(1,ie),xvl(2,ie),yvl(2,ie),sigmvl(ie),dpsvl(ie),e0,ejv(id),ejvl(ie)
-          if(ierro.ne.0) write(lout,"(a,i0)") "MAINCR> WARNING fort.12 has corrupted output probably due to lost particle ",ie
+          if(ierro.ne.0) write(lout,"(a,i0)") "MAINCR> WARNING fort.12 has corrupted output, probably due to lost particle ",ie
         end if
 
         if(pstop(ia).and..not.pstop(ie)) then !-- FIRST PARTICLE LOST
@@ -2063,7 +2071,7 @@ end interface
             xv(1,id),yv(1,id),xv(2,id),yv(2,id),sigmv(id),dpsv(id),e0,ejvl(ia),ejv(id)
           write(12,10280,iostat=ierro) xvl(1,ia),yvl(1,ia),xvl(2,ia),yvl(2,ia),sigmvl(ia),dpsvl(ia), &
             xv(1,id),yv(1,id),xv(2,id),yv(2,id),sigmv(id),dpsv(id),e0,ejvl(ia),ejv(id)
-          if(ierro.ne.0) write(lout,"(a,i0)") "MAINCR> WARNING fort.12 has corrupted output probably due to lost particle ",ia
+          if(ierro.ne.0) write(lout,"(a,i0)") "MAINCR> WARNING fort.12 has corrupted output, probably due to lost particle ",ia
         end if
 
         if(.not.pstop(ia).and..not.pstop(ie)) then !-- BOTH PARTICLES STABLE
@@ -2078,7 +2086,7 @@ end interface
             xv(1,ig),yv(1,ig),xv(2,ig),yv(2,ig),sigmv(ig),dpsv(ig),e0,ejv(id),ejv(ig)
           write(12,10280,iostat=ierro) xv(1,id),yv(1,id),xv(2,id),yv(2,id),sigmv(id),dpsv(id), &
             xv(1,ig),yv(1,ig),xv(2,ig),yv(2,ig),sigmv(ig),dpsv(ig),e0,ejv(id),ejv(ig)
-          if(ierro.ne.0) write(lout,"(a)") "MAINCR> WARNING fort.12 has corrupted output although particles stable"
+          if(ierro.ne.0) write(lout,"(a)") "MAINCR> WARNING fort.12 has corrupted output, although particles are stable"
           id=ig
         end if
       end do
@@ -2108,6 +2116,7 @@ end interface
 
 ! POSTPROCESSING (POSTPR)
 
+470 continue
 ! and we need to open fort.10 unless already opened for BOINC
 #ifdef NAGFOR
 #ifdef BOINC

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -4922,10 +4922,8 @@ subroutine linopt(dpp)
 !c$$$              if(mod(nr,ntco).eq.0) call cpltwis(bez(jk),t,etl,phi)
 !c$$$            endif
 
-            write(lout,*) "ERROR in LINOPT:"
-            write(lout,*) "In block ", bezb(ix),                        &
-     &           "found a thick non-drift element",                     &
-     &           bez(jk), "while ithick=1. This should not be possible!"
+            write(lout,"(a)") "LINOPT> ERROR In block '"//trim(bezb(ix))//"': found a thick non-drift element '"//&
+              trim(bez(jk))//"' while ithick=1. This should not be possible!"
             call prror(-1)
             cycle STRUCTLOOP
           endif
@@ -5578,12 +5576,10 @@ subroutine linopt(dpp)
               endif
               do iiii=3,nmz
                  if(abs(bb(iiii)).gt.pieni) then
-                    write(34,10070)                                      &
-     &                   etl,bez(ix),iiii,bb(iiii),bexi,bezii,phi
+                    write(34,10070) etl,bez(ix),iiii,bb(iiii),bexi,bezii,phi
                  endif
                  if(abs(aa(iiii)).gt.pieni) then
-                    write(34,10070)                                      &
-     &                   etl,bez(ix),-iiii,aa(iiii),bexi,bezii,phi
+                    write(34,10070) etl,bez(ix),-iiii,aa(iiii),bexi,bezii,phi
                  endif
               enddo
            elseif(abs(ekk).gt.pieni.and.abs(kz(ix)).ge.3) then
@@ -5626,8 +5622,7 @@ subroutine linopt(dpp)
       bexi=t(2,1)**2+t(3,1)**2                                           !hr06
       bezii=t(4,3)**2+t(5,3)**2                                          !hr06
       if(ncorru.eq.0) write(34,10070) etl,idum,iiii,zero,bexi,bezii,phi
-      if(ncorru.eq.0)                                                   &
-     &write(lout,10060)
+      if(ncorru.eq.0) write(lout,10060)
 !-----------------------------------------------------------------------
       return
 10000 format(t5 ,'---- ENTRY LINOPT ----')

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -64,11 +64,6 @@ subroutine daten
 !  SET DEFAULT VALUES
 ! ================================================================================================ !
 
-  ! SixTrack Settings
-  st_print     = .false.
-  st_debug     = .false.
-  st_quiet     = 0
-
   ! Main Variables
   iHead        = " "
   sixtit       = " "
@@ -4871,9 +4866,9 @@ subroutine linopt(dpp)
         end do
       end do
 
-      if(ncorru.eq.0) then
+      if(ncorru.eq.0 .and. iprint.eq.1) then
         write(lout,10010)
-        if(iprint.eq.1) write(lout,10030)
+        write(lout,10030)
         write(lout,10020)
         write(lout,10010)
       endif

--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -1015,7 +1015,7 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       call expand_arrays(nele, napx*2, nblz, nblo)
     end if
 
-    if(napx > 2 .and. sixin_forcePartSummary .eqv. .false.) then
+    if(napx > 32 .and. sixin_forcePartSummary .eqv. .false.) then
       write(lout,"(a)") "TRAC> NOTE More than 64 particles requested, switching off printing of particle summary."
       st_partsum = .false.
     end if

--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -60,6 +60,9 @@ module sixtrack_input
   ! "Phase Trombone" Element
   integer,                       public, save :: sixin_imtr0
 
+  ! Settings
+  logical,                       private, save :: sixin_forcePartSummary = .false.
+
   interface sixin_echoVal
     module procedure sixin_echoVal_int
     module procedure sixin_echoVal_real32
@@ -315,6 +318,20 @@ subroutine sixin_parseInputLineSETT(inLine, iLine, iErr)
   case("PRINT_DCUM")
     print_dcum = .true.
     write(lout,"(a)") "INPUT> Printout of dcum array ENABLED"
+
+  case("PARTICLESUMMARY","PARTSUMMARY")
+    if(nSplit > 1) then
+      call chr_cast(lnSplit(2),st_partsum,iErr)
+      sixin_forcePartSummary = .true.
+    else
+      st_partsum = .true.
+      sixin_forcePartSummary = .true.
+    end if
+    if(st_partsum) then
+      write(lout,"(a,i0)") "INPUT> Printing of particle summary is ENABLED"
+    else
+      write(lout,"(a,i0)") "INPUT> Printing of particle summary is DISABLED"
+    end if
 
   case("QUIET")
     if(nSplit > 1) then
@@ -996,6 +1013,11 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
 
     if(napx*2 > npart) then
       call expand_arrays(nele, napx*2, nblz, nblo)
+    end if
+
+    if(napx > 2 .and. sixin_forcePartSummary .eqv. .false.) then
+      write(lout,"(a)") "TRAC> NOTE More than 64 particles requested, switching off printing of particle summary."
+      st_partsum = .false.
     end if
 
   case(2)

--- a/source/string_tools.f90
+++ b/source/string_tools.f90
@@ -18,6 +18,7 @@ module string_tools
   public str_stripQuotes, chr_stripQuotes
   public str_sub, chr_expandBrackets
   public chr_lpad, chr_rpad
+  public chr_toUpper, chr_toLower
   public str_inStr, chr_inStr
 
   interface str_cast
@@ -411,6 +412,39 @@ function chr_rpad(theString, theSize) result(retString)
     retString = theString
   end if
 end function chr_rpad
+
+! ================================================================================================ !
+!  Convert to Lower/Upper Case
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Last modified: 2018-10-04
+! ================================================================================================ !
+function chr_toUpper(theString) result(retString)
+  character(len=*), intent(in)  :: theString
+  character(len=:), allocatable :: retString
+  character          :: ch
+  integer, parameter :: ulOffset = ichar("A") - ichar("a")
+  integer            :: i
+  allocate(character(len(theString)) :: retString)
+  do i = 1,len(theString)
+    ch = theString(i:i)
+    if(ch >= "a" .and. ch <= "z") ch = char(ichar(ch)+ulOffset)
+    retString(i:i) = ch
+  end do
+end function chr_toUpper
+
+function chr_toLower(theString) result(retString)
+  character(len=*), intent(in)  :: theString
+  character(len=:), allocatable :: retString
+  character          :: ch
+  integer, parameter :: ulOffset = ichar("A") - ichar("a")
+  integer            :: i
+  allocate(character(len(theString)) :: retString)
+  do i = 1,len(theString)
+    ch = theString(i:i)
+    if(ch >= "A" .and. ch <= "Z") ch = char(ichar(ch)-ulOffset)
+    retString(i:i) = ch
+  end do
+end function chr_toLower
 
 ! ================================================================================================ !
 !  Trim Zero String Routine
@@ -1087,12 +1121,19 @@ subroutine chr_toLog(theString, theValue, rErr)
   character(len=:), allocatable   :: tmpString
   integer                         :: readErr
 
-  tmpString = trim(theString)
-  read(tmpString,*,iostat=readErr) theValue
-  if(readErr /= 0) then
-    write (lout,"(a,i0)") "TYPECAST> Failed to cast '"//tmpString//"' to logical width error ",readErr
-    rErr = .true.
-  end if
+  tmpString = chr_toUpper(trim(theString))
+  select case(tmpString)
+  case("ON")
+    theValue = .true.
+  case("OFF")
+    theValue = .false.
+  case default
+    read(tmpString,*,iostat=readErr) theValue
+    if(readErr /= 0) then
+      write (lout,"(a,i0)") "TYPECAST> Failed to cast '"//tmpString//"' to logical width error ",readErr
+      rErr = .true.
+    end if
+  end select
 
 end subroutine chr_toLog
 

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -1221,7 +1221,7 @@ subroutine thin6d(nthinerr)
 #endif
   implicit none
 
-  integer i,irrtr,ix,j,k,n,nmz,nthinerr,dotrack,xory,nac,nfree,nramp1,nplato,nramp2,turnrep
+  integer i,irrtr,ix,j,k,n,nmz,nthinerr,dotrack,xory,nac,nfree,nramp1,nplato,nramp2,turnrep,elemEnd
   real(kind=fPrec) pz,cccc,cikve,crkve,crkveuk,r0,stracki,xlvj,yv1j,yv2j,zlvj,acdipamp,qd,          &
     acphase,acdipamp2,acdipamp1,crabamp,crabfreq,crabamp2,crabamp3,crabamp4,kcrab,RTWO,NNORM,l,cur, &
     dx,dy,tx,ty,embl,chi,xi,yi,dxi,dyi,rrelens,frrelens,xelens,yelens, onedp,fppsig,costh_temp,     &
@@ -1416,13 +1416,12 @@ subroutine thin6d(nthinerr)
           ! JULY 2008 added changes (V6.503) for names in TCTV -> TCTVA and TCTVB
           ! both namings before and after V6.503 can be used
           !
-          if (      bez(myix)(1:2).eq.'TC'  &
-               .or. bez(myix)(1:2).eq.'tc'  &
-               .or. bez(myix)(1:2).eq.'TD'  &
-               .or. bez(myix)(1:2).eq.'td'  &
-               .or. bez(myix)(1:3).eq.'COL' &
-               .or. bez(myix)(1:3).eq.'col' &
-               ) then
+          elemEnd = len_trim(bez(myix))
+          ! write(lout,"(a)") "COLL> DEBUG Checking if aperture: '"//bez(myix)(elemEnd-2:elemEnd)//"' from '"//bez(myix)//"'"
+          if((    bez(myix)(1:2) == 'TC'  .or. bez(myix)(1:2) == 'tc'   &
+            .or.  bez(myix)(1:2) == 'TD'  .or. bez(myix)(1:2) == 'td'   &
+            .or.  bez(myix)(1:3) == 'COL' .or. bez(myix)(1:3) == 'col') &
+            .and. bez(myix)(elemEnd-2:elemEnd) /= "_AP") then
 
             call collimate_start_collimator(stracki)
 
@@ -1441,11 +1440,9 @@ subroutine thin6d(nthinerr)
               xv(1,j)  = xv(1,j) + stracki*yv(1,j)
               xv(2,j)  = xv(2,j) + stracki*yv(2,j)
 #ifdef FAST
-              sigmv(j) = sigmv(j) + &
-                   stracki*(c1e3-rvv(j)*(c1e3+(yv(1,j)*yv(1,j)+yv(2,j)*yv(2,j))*c5m4))
+              sigmv(j) = sigmv(j) + stracki*(c1e3-rvv(j)*(c1e3+(yv(1,j)*yv(1,j)+yv(2,j)*yv(2,j))*c5m4))
 #else
-              sigmv(j) = sigmv(j) + &
-                   stracki*(c1e3-rvv(j)*sqrt(c1e6+yv(1,j)*yv(1,j)+yv(2,j)*yv(2,j)))
+              sigmv(j) = sigmv(j) + stracki*(c1e3-rvv(j)*sqrt(c1e6+yv(1,j)*yv(1,j)+yv(2,j)*yv(2,j)))
 #endif
               xj     = (xv(1,j)-torbx(ie))/c1e3
               xpj    = (yv(1,j)-torbxp(ie))/c1e3
@@ -1487,11 +1484,9 @@ subroutine thin6d(nthinerr)
               xv(1,j)  = xv(1,j) + stracki*yv(1,j)
               xv(2,j)  = xv(2,j) + stracki*yv(2,j)
 #ifdef FAST
-              sigmv(j) = sigmv(j) + &
-                   stracki*(c1e3-rvv(j)*(c1e3+(yv(1,j)**2+yv(2,j)**2)*c5m4))
+              sigmv(j) = sigmv(j) + stracki*(c1e3-rvv(j)*(c1e3+(yv(1,j)**2+yv(2,j)**2)*c5m4))
 #else
-              sigmv(j) = sigmv(j) + &
-                   stracki*(c1e3-rvv(j)*sqrt((c1e6+yv(1,j)**2)+yv(2,j)**2))
+              sigmv(j) = sigmv(j) + stracki*(c1e3-rvv(j)*sqrt((c1e6+yv(1,j)**2)+yv(2,j)**2))
 #endif
             end do
           else


### PR DESCRIPTION
This PR adds a flag to the `SETTINGS` block that controls writing the particle summary at the end of the simulation. The amount of output is also controlled by the `QUIET` flag as before.

The new flag is `PARTICLESUMMARY` and when present is taken as `.true.`. An explicit parameter can be added, as the default behaviour otherwise depends on the number of particles tracked. If it is 64 or less, it is on by default, and otherwise it is off.

A modification to the `chr_cast` routine: it now also accepts `ON` and `OFF` as logical values (should work wherever the casting routine is used for parsing.) In relation to that, I also added two functions to the `string_tools` module for converting a string to upper or lower case. `chr_toUpper` and `chr_toLower`.

This PR also stops `track_thin` from calling the collimation module if it sees a collimator aperture marker.