### PR TITLE
Isnan fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,8 @@ OPTION(ROOT "Link to the root libraries" OFF)
 OPTION(32BIT "Create a 32bit binary" OFF)
 OPTION(64BIT "Create a 64bit binary" ON)
 OPTION(STATIC "Create a statically linked binary" ON)
-OPTION(NATIVE "Enable optimizations for the current machine" OFF)
+OPTION(NATIVE "Enable optimisations for the current machine" OFF)
+OPTION(LTO "Enable link time optimisations" OFF)
 OPTION(AVX "Enable use of the Advanced Vector Extensions (AVX) instruction set - Sandy Bridge and later" OFF)
 OPTION(AVX2 "Enable use of the Advanced Vector Extensions 2 (AVX2) instruction set - Haswell and later" OFF)
 OPTION(AVX-512 "Enable use of the Advanced Vector Extensions 512 (AVX-512) instruction set - (Currently targeting Skylake-X)" OFF)
@@ -265,9 +266,9 @@ set(SIXTRACK_BINARY_NAME_DA "SixDA_${NUM_VERSION}${GIT_BUILD}_${SIXTRACK_FEAT_DA
 # Setting the c pre-processor definitons
 ###################################################################################################
 
-LIST(APPEND PREPRO_FLAGS_TOOLS TILT FAST BOINC BEAMGAS STF MERLINSCATTER G4COLLIMAT FLUKA CR)
-LIST(APPEND PREPRO_FLAGS_LIB CRLIBM ROUND_NEAR ROUND_UP ROUND_DOWN ROUND_ZERO CERNLIB DEBUG HDF5 FIO LIBARCHIVE ROOT)
-LIST(APPEND PREPRO_FLAGS_COMPILE NAGFOR)
+list(APPEND PREPRO_FLAGS_TOOLS TILT FAST BOINC BEAMGAS STF MERLINSCATTER G4COLLIMAT FLUKA CR)
+list(APPEND PREPRO_FLAGS_LIB CRLIBM ROUND_NEAR ROUND_UP ROUND_DOWN ROUND_ZERO CERNLIB DEBUG HDF5 FIO LIBARCHIVE ROOT)
+list(APPEND PREPRO_FLAGS_COMPILE GFORTRAN IFORT NAGFOR)
 
 ###################################################################################################
 # Select which fortran files to generate and compile
@@ -524,7 +525,8 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
   #  gfortran  #
   ##############
 
-  SET(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops -std=f2008")
+  set(GFORTRAN ON)
+  set(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops -std=f2008")
   set(PREPRO_EXEC  ${CMAKE_Fortran_COMPILER})
   set(PREPRO_FLAGS -cpp -E -P)
 
@@ -532,12 +534,14 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
     set (CMAKE_Fortran_FLAGS "-ffp-contract=off ${CMAKE_Fortran_FLAGS}")
   endif()
 
-  SET(CMAKE_Fortran_FLAGS_RELEASE "-O3")
-  # SET(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g3 -ffpe-trap=invalid,zero,overflow,underflow -fcheck=all")
-  SET(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g3 -ffpe-trap=invalid,zero,overflow -fcheck=all")
+  set(CMAKE_Fortran_FLAGS_RELEASE "-O3")
+  set(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g3 -ffpe-trap=invalid,zero,overflow -fcheck=all")
 
   if(${CMAKE_SYSTEM_PROCESSOR} MATCHES ppc64le )
-    SET(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -fno-expensive-optimizations -fno-inline-functions")
+    set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -fno-expensive-optimizations -fno-inline-functions")
+  endif()
+  if(LTO)
+    set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -flto")
   endif()
 
   if(${CMAKE_SYSTEM_PROCESSOR} MATCHES AMD64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64 OR ${CMAKE_SYSTEM_PROCESSOR} MATCHES i686)
@@ -564,7 +568,7 @@ if (Fortran_COMPILER_NAME MATCHES "gfortran.*")
     endif(AVX-512)
 
     if(NATIVE)
-      SET(CMAKE_Fortran_FLAGS "-march=native -mno-fma4 -mno-fma ${CMAKE_Fortran_FLAGS}")
+      set(CMAKE_Fortran_FLAGS "-march=native -mno-fma4 -mno-fma ${CMAKE_Fortran_FLAGS}")
     endif(NATIVE)
   endif()
 
@@ -591,10 +595,15 @@ elseif (Fortran_COMPILER_NAME MATCHES "ifort.*")
   #  ifort  #
   ###########
 
+  set(IFORT ON)
   set(CMAKE_Fortran_FLAGS_RELEASE "-fp-model source -fp-model strict -fp-model no-except -O3 -no-fma -std15 -assume realloc-lhs")
   set(CMAKE_Fortran_FLAGS_DEBUG   "-fp-model source -fp-model strict -fp-model no-except -O0 -g -no-fma -std15 -assume realloc-lhs")
   set(PREPRO_EXEC  ${CMAKE_Fortran_COMPILER})
   set(PREPRO_FLAGS -fpp -E -P)
+
+  if(LTO)
+    set(CMAKE_Fortran_FLAGS_RELEASE "${CMAKE_Fortran_FLAGS_RELEASE} -ffat-lto-objects")
+  endif()
 
   if(WARN)
     set(CMAKE_Fortran_FLAGS "-warn unused ${CMAKE_Fortran_FLAGS}")
@@ -603,13 +612,13 @@ elseif (Fortran_COMPILER_NAME MATCHES "ifort.*")
   if(32BIT)
     set(CMAKE_Fortran_FLAGS_RELEASE "-m32 ${CMAKE_Fortran_FLAGS_RELEASE}")
     set(CMAKE_Fortran_FLAGS_DEBUG "-m32 ${CMAKE_Fortran_FLAGS_DEBUG}")
-    SET(CMAKE_Fortran_LINKER_FLAGS "-m32 ${CMAKE_Fortran_LINKER_FLAGS}")
+    set(CMAKE_Fortran_LINKER_FLAGS "-m32 ${CMAKE_Fortran_LINKER_FLAGS}")
   endif(32BIT)
 
   if(64BIT)
     set(CMAKE_Fortran_FLAGS_RELEASE "-m64 ${CMAKE_Fortran_FLAGS_RELEASE}")
     set(CMAKE_Fortran_FLAGS_DEBUG "-m64 ${CMAKE_Fortran_FLAGS_DEBUG}")
-    SET(CMAKE_Fortran_LINKER_FLAGS "-m64 ${CMAKE_Fortran_LINKER_FLAGS}")
+    set(CMAKE_Fortran_LINKER_FLAGS "-m64 ${CMAKE_Fortran_LINKER_FLAGS}")
   endif(64BIT)
 
   if(AVX)
@@ -625,12 +634,11 @@ elseif (Fortran_COMPILER_NAME MATCHES "ifort.*")
   endif(AVX-512)
 
   if(NATIVE)
-    SET(CMAKE_Fortran_FLAGS_RELEASE "-xHost ${CMAKE_Fortran_FLAGS_RELEASE}")
-    #Nothing to do for DEBUG
+    set(CMAKE_Fortran_FLAGS_RELEASE "-xHost ${CMAKE_Fortran_FLAGS_RELEASE}")
   endif(NATIVE)
 
   if(STATIC)
-    SET(CMAKE_Fortran_LINKER_FLAGS "-static ${CMAKE_Fortran_LINKER_FLAGS}")
+    set(CMAKE_Fortran_LINKER_FLAGS "-static ${CMAKE_Fortran_LINKER_FLAGS}")
   endif(STATIC)
 
 elseif (Fortran_COMPILER_NAME MATCHES "nagfor.*")
@@ -638,18 +646,17 @@ elseif (Fortran_COMPILER_NAME MATCHES "nagfor.*")
   #  nagfor  #
   ############
 
-  SET(NAGFOR ON)
-  #Here I am going to assume that since we are using nagfor we are on lxplus for now
+  set(NAGFOR ON)
   set(CMAKE_Fortran_FLAGS_RELEASE "-O4 -dusty -ieee=full -dcfuns")
   set(CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g -dusty -ieee=full -dcfuns -gline")
   set(PREPRO_EXEC  fpp)
   set(PREPRO_FLAGS -P -free)
 
-if(WARN)
-  set(CMAKE_Fortran_FLAGS "-w=ulv -w=uparam ${CMAKE_Fortran_FLAGS}")
-else()
-  set(CMAKE_Fortran_FLAGS "-w=all ${CMAKE_Fortran_FLAGS}")
-endif(WARN)
+  if(WARN)
+    set(CMAKE_Fortran_FLAGS "-w=ulv -w=uparam ${CMAKE_Fortran_FLAGS}")
+  else()
+    set(CMAKE_Fortran_FLAGS "-w=all ${CMAKE_Fortran_FLAGS}")
+  endif(WARN)
 
   if(32BIT)
     set(CMAKE_Fortran_FLAGS_RELEASE "-abi=32 ${CMAKE_Fortran_FLAGS_RELEASE}")

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -547,7 +547,6 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
 !     7 April 2014
 !-----------------------------------------------------------------------
 
-  use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
   use physical_constants
 
 #ifdef FLUKA
@@ -637,16 +636,16 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkTR(xchk(1),xchk(2),ape(1,ix),ape(2,ix),ape(3,ix),ape(4,ix),apxx,apyy,apxy,ape(5,ix),ape(6,ix)).or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)= &
                 checkTR(xLast(1,j),xLast(2,j),ape(1,ix),ape(2,ix),ape(3,ix),ape(4,ix),apxx,apyy,apxy,ape(5,ix),ape(6,ix)) .or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)= &
                 checkTR(xv(1,j),xv(2,j),ape(1,ix),ape(2,ix),ape(3,ix),ape(4,ix),apxx,apyy,apxy,ape(5,ix),ape(6,ix))       .or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -669,14 +668,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkCR( xchk(1),xchk(2),radius2 ) .or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkCR( xLast(1,j),xLast(2,j),radius2 ) .or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkCR( xv(1,j),xv(2,j),radius2 ) .or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -698,14 +697,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkRE( xchk(1),xchk(2),ape(1,ix),ape(2,ix) ) .or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkRE( xLast(1,j),xLast(2,j),ape(1,ix),ape(2,ix) ) .or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkRE( xv(1,j),xv(2,j),ape(1,ix),ape(2,ix) ) .or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -729,14 +728,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkEL( xchk(1),xchk(2),apxx,apyy,apxy ) .or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkEL( xLast(1,j),xLast(2,j),apxx,apyy,apxy ) .or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkEL( xv(1,j),xv(2,j),apxx,apyy,apxy ) .or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -760,14 +759,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkRL( xchk(1),xchk(2),ape(1,ix),ape(2,ix),apxx,apyy,apxy ) .or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkRL( xLast(1,j),xLast(2,j),ape(1,ix),ape(2,ix),apxx,apyy,apxy ) .or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkRL( xv(1,j),xv(2,j),ape(1,ix),ape(2,ix),apxx,apyy,apxy ) .or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -788,14 +787,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkOC(xchk(1),xchk(2),ape(1,ix),ape(2,ix),ape(5,ix),ape(6,ix)).or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkOC(xLast(1,j),xLast(2,j),ape(1,ix),ape(2,ix),ape(5,ix),ape(6,ix)).or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkOC(xv(1,j),xv(2,j),ape(1,ix),ape(2,ix),ape(5,ix),ape(6,ix)).or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -818,14 +817,14 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               call roffpos(xv(1,j),xv(2,j),xchk(1),xchk(2),ape(7,ix),ape(8,ix),ape(9,ix))
             end if
             llostp(j)=checkRT(xchk(1),xchk(2),ape(1,ix),ape(2,ix),ape(3,ix),apxy).or. &
-              ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+              isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
           else
             if(lbacktracking) then
               llostp(j)=checkRT(xLast(1,j),xLast(2,j),ape(1,ix),ape(2,ix),ape(3,ix),apxy).or. &
-                ieee_is_nan(xLast(1,j)).or.ieee_is_nan(xLast(2,j))
+                isnan_mb(xLast(1,j)).or.isnan_mb(xLast(2,j))
             else
               llostp(j)=checkRT(xv(1,j),xv(2,j),ape(1,ix),ape(2,ix),ape(3,ix),apxy).or. &
-                ieee_is_nan(xv(1,j)).or.ieee_is_nan(xv(2,j))
+                isnan_mb(xv(1,j)).or.isnan_mb(xv(2,j))
             end if
           end if
           llost=llost.or.llostp(j)
@@ -927,32 +926,32 @@ subroutine lostpart(turn, i, ix, llost, nthinerr)
               apyy = aprr(4)**2.
               apxy = apxx * apyy
               llos=checkTR(xchk(1),xchk(2),aprr(1),aprr(2),aprr(3),aprr(4),apxx,apyy,apxy,aprr(5),aprr(6)).or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (1) ! Circle
               radius2 = aprr(3)**2
               llos=checkCR(xchk(1),xchk(2),radius2) .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (2) ! Rectangle
               llos=checkRE(xchk(1),xchk(2),aprr(1),aprr(2)) .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (3) ! Ellipse
               apxx = aprr(3)**2.
               apyy = aprr(4)**2.
               apxy = apxx * apyy
               llos=checkEL( xchk(1),xchk(2),apxx,apyy,apxy )  .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (4) ! RectEllipse
               apxx = aprr(3)**2.
               apyy = aprr(4)**2.
               apxy = apxx * apyy
               llos = checkRL( xchk(1),xchk(2),aprr(1),aprr(2),apxx, apyy, apxy ) .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (5) ! Octagon
               llos=checkOC(xchk(1), xchk(2), aprr(1), aprr(2), aprr(5), aprr(6) ) .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             case (6) ! RaceTrack
               llos=checkRT( xchk(1), xchk(2), aprr(1), aprr(2), aprr(3), aprr(3)**2. ) .or. &
-                ieee_is_nan(xchk(1)).or.ieee_is_nan(xchk(2))
+                isnan_mb(xchk(1)).or.isnan_mb(xchk(2))
             end select
           end do !do jj=1,niter
 

--- a/source/bouncy_castle.f90
+++ b/source/bouncy_castle.f90
@@ -1,275 +1,224 @@
 ! =================================================================================================
 !  Mathlib Bouncer
-!  Last modified: 2018-04-27
+!  Last modified: 2018-10-23
 ! =================================================================================================
 module mathlib_bouncer
 
   use floatPrecision
-! use, intrinsic :: ieee_arithmetic
-  use, intrinsic :: iso_fortran_env, only : real64, int64
+
   implicit none
+  private
 
-  !These are the actual "bouncy functions" users are supposed to call
-  public :: sin_mb, asin_mb, sinh_mb, cos_mb, acos_mb, cosh_mb, tan_mb, atan_mb, atan2_mb, exp_mb, log_mb, log10_mb, isnan_mb
+  public :: sin_mb, asin_mb, sinh_mb, cos_mb, acos_mb, cosh_mb
+  public :: tan_mb, atan_mb, atan2_mb, exp_mb, log_mb, log10_mb, isnan_mb
 
-! real(kind=fPrec), parameter :: mb_pi   = 3.1415926535897932d0
-! real(kind=fPrec), parameter :: mb_pi2  = 1.5707963267948966d0
   real(kind=fPrec), parameter :: mb_pi   = 3.141592653589793238462643383279502884197169399375105820974_fPrec
   real(kind=fPrec), parameter :: mb_pi2  = 1.570796326794896619231321691639751442098584699687552910487_fPrec
-! #ifdef NAGFOR
-!   real(kind=fPrec), parameter :: mb_qnan = ieee_value(1.0_fPrec, ieee_quiet_nan)
-! #else
-!   real(kind=fPrec), parameter :: mb_qnan = transfer(-2251799813685248_int64, 1.0_real64)
-! #endif
 
-  !For linking with CRLIBM
+  ! For linking with CRLIBM
 #ifdef CRLIBM
-
 #ifdef ROUND_NEAR
   private :: acos_rn, asin_rn, atan2_rn
 #endif
-
 #ifdef ROUND_UP
   private :: acos_ru, asin_ru, atan2_ru
 #endif
-
 #ifdef ROUND_DOWN
   private :: acos_rd, asin_rd, atan2_rd
 #endif
-
 #ifdef ROUND_ZERO
   private :: acos_rz, asin_rz, atan2_rz
 #endif
 
-  !Can't declare them private as they have BIND labels,
-  ! however they should not be called from outside this module.
-  !private :: exp_rn, log_rn, log10_rn, atan_rn, tan_rn, sin_rn, cos_rn, sinh_rn, cosh_rn
-
-  !! Interface definitions for the other functions in crlibm
+  ! Interface definitions for the other functions in CRLIBM
   interface
 
 #ifdef ROUND_NEAR
-     real(kind=c_double) function exp_rn(arg) bind(C,name="exp_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function exp_rn
+    real(kind=c_double) pure function exp_rn(arg) bind(C,name="exp_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function exp_rn
 
-     real(kind=c_double) function log_rn(arg) bind(C,name="log_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log_rn
+    real(kind=c_double) pure function log_rn(arg) bind(C,name="log_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log_rn
 
-     real(kind=c_double) function log10_rn(arg) bind(C,name="log10_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log10_rn
+    real(kind=c_double) pure function log10_rn(arg) bind(C,name="log10_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log10_rn
 
-     real(kind=c_double) function atan_rn(arg) bind(C,name="atan_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function atan_rn
+    real(kind=c_double) pure function atan_rn(arg) bind(C,name="atan_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function atan_rn
 
-     real(kind=c_double) function tan_rn(arg) bind(C,name="tan_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function tan_rn
+    real(kind=c_double) pure function tan_rn(arg) bind(C,name="tan_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function tan_rn
 
-     real(kind=c_double) function sin_rn(arg) bind(C,name="sin_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sin_rn
+    real(kind=c_double) pure function sin_rn(arg) bind(C,name="sin_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sin_rn
 
-     real(kind=c_double) function cos_rn(arg) bind(C,name="cos_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cos_rn
+    real(kind=c_double) pure function cos_rn(arg) bind(C,name="cos_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cos_rn
 
-     real(kind=c_double) function sinh_rn(arg) bind(C,name="sinh_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sinh_rn
+    real(kind=c_double) pure function sinh_rn(arg) bind(C,name="sinh_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sinh_rn
 
-     real(kind=c_double) function cosh_rn(arg) bind(C,name="cosh_rn")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cosh_rn
+    real(kind=c_double) pure function cosh_rn(arg) bind(C,name="cosh_rn")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cosh_rn
 #endif
 
 #ifdef ROUND_UP
-     real(kind=c_double) function exp_ru(arg) bind(C,name="exp_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function exp_ru
+    real(kind=c_double) pure function exp_ru(arg) bind(C,name="exp_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function exp_ru
 
-     real(kind=c_double) function log_ru(arg) bind(C,name="log_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log_ru
+    real(kind=c_double) pure function log_ru(arg) bind(C,name="log_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log_ru
 
-     real(kind=c_double) function log10_ru(arg) bind(C,name="log10_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log10_ru
+    real(kind=c_double) pure function log10_ru(arg) bind(C,name="log10_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log10_ru
 
-     real(kind=c_double) function atan_ru(arg) bind(C,name="atan_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function atan_ru
+    real(kind=c_double) pure function atan_ru(arg) bind(C,name="atan_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function atan_ru
 
-     real(kind=c_double) function tan_ru(arg) bind(C,name="tan_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function tan_ru
+    real(kind=c_double) pure function tan_ru(arg) bind(C,name="tan_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function tan_ru
 
-     real(kind=c_double) function sin_ru(arg) bind(C,name="sin_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sin_ru
+    real(kind=c_double) pure function sin_ru(arg) bind(C,name="sin_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sin_ru
 
-     real(kind=c_double) function cos_ru(arg) bind(C,name="cos_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cos_ru
+    real(kind=c_double) pure function cos_ru(arg) bind(C,name="cos_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cos_ru
 
-     real(kind=c_double) function sinh_ru(arg) bind(C,name="sinh_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sinh_ru
+    real(kind=c_double) pure function sinh_ru(arg) bind(C,name="sinh_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sinh_ru
 
-     real(kind=c_double) function cosh_ru(arg) bind(C,name="cosh_ru")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cosh_ru
+    real(kind=c_double) pure function cosh_ru(arg) bind(C,name="cosh_ru")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cosh_ru
 #endif
 
 #ifdef ROUND_DOWN
-     real(kind=c_double) function exp_rd(arg) bind(C,name="exp_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function exp_rd
+    real(kind=c_double) pure function exp_rd(arg) bind(C,name="exp_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function exp_rd
 
-     real(kind=c_double) function log_rd(arg) bind(C,name="log_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log_rd
+    real(kind=c_double) pure function log_rd(arg) bind(C,name="log_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log_rd
 
-     real(kind=c_double) function log10_rd(arg) bind(C,name="log10_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log10_rd
+    real(kind=c_double) pure function log10_rd(arg) bind(C,name="log10_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log10_rd
 
-     real(kind=c_double) function atan_rd(arg) bind(C,name="atan_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function atan_rd
+    real(kind=c_double) pure function atan_rd(arg) bind(C,name="atan_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function atan_rd
 
-     real(kind=c_double) function tan_rd(arg) bind(C,name="tan_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function tan_rd
+    real(kind=c_double) pure function tan_rd(arg) bind(C,name="tan_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function tan_rd
 
-     real(kind=c_double) function sin_rd(arg) bind(C,name="sin_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sin_rd
+    real(kind=c_double) pure function sin_rd(arg) bind(C,name="sin_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sin_rd
 
-     real(kind=c_double) function cos_rd(arg) bind(C,name="cos_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cos_rd
+    real(kind=c_double) pure function cos_rd(arg) bind(C,name="cos_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cos_rd
 
-     real(kind=c_double) function sinh_rd(arg) bind(C,name="sinh_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sinh_rd
+    real(kind=c_double) pure function sinh_rd(arg) bind(C,name="sinh_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sinh_rd
 
-     real(kind=c_double) function cosh_rd(arg) bind(C,name="cosh_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cosh_rd
+    real(kind=c_double) pure function cosh_rd(arg) bind(C,name="cosh_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cosh_rd
 #endif
 
 #ifdef ROUND_ZERO
-     real(kind=c_double) function exp_rz(arg) bind(C,name="exp_rd")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function exp_rz
+    real(kind=c_double) pure function exp_rz(arg) bind(C,name="exp_rd")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function exp_rz
 
-     real(kind=c_double) function log_rz(arg) bind(C,name="log_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log_rz
+    real(kind=c_double) pure function log_rz(arg) bind(C,name="log_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log_rz
 
-     real(kind=c_double) function log10_rz(arg) bind(C,name="log10_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function log10_rz
+    real(kind=c_double) pure function log10_rz(arg) bind(C,name="log10_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function log10_rz
 
-     real(kind=c_double) function atan_rz(arg) bind(C,name="atan_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function atan_rz
+    real(kind=c_double) pure function atan_rz(arg) bind(C,name="atan_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function atan_rz
 
-     real(kind=c_double) function tan_rz(arg) bind(C,name="tan_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function tan_rz
+    real(kind=c_double) pure function tan_rz(arg) bind(C,name="tan_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function tan_rz
 
-     real(kind=c_double) function sin_rz(arg) bind(C,name="sin_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sin_rz
+    real(kind=c_double) pure function sin_rz(arg) bind(C,name="sin_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sin_rz
 
-     real(kind=c_double) function cos_rz(arg) bind(C,name="cos_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cos_rz
+    real(kind=c_double) pure function cos_rz(arg) bind(C,name="cos_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cos_rz
 
-     real(kind=c_double) function sinh_rz(arg) bind(C,name="sinh_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function sinh_rz
+    real(kind=c_double) pure function sinh_rz(arg) bind(C,name="sinh_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function sinh_rz
 
-     real(kind=c_double) function cosh_rz(arg) bind(C,name="cosh_rz")
-       use, intrinsic :: iso_c_binding, only : c_double
-       implicit none
-       real(kind=c_double), intent(in), VALUE :: arg
-     end function cosh_rz
+    real(kind=c_double) pure function cosh_rz(arg) bind(C,name="cosh_rz")
+      use, intrinsic :: iso_c_binding, only : c_double
+      real(kind=c_double), intent(in), value :: arg
+    end function cosh_rz
 #endif
 
   end interface
@@ -277,28 +226,18 @@ module mathlib_bouncer
 
 contains
 
-  ! Definition of the MathlibBouncer (_mb) functions
+  ! ========================================================================== !
+  !  Definition of the MathlibBouncer (_mb) callable functions
+  ! ========================================================================== !
 
-! #ifdef IFORT
-!   logical pure elemental function isnan_mb(arg)
-!     use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
-!     real(kind=fPrec), intent(in) :: arg
-!     isnan_mb = ieee_is_nan(arg)
-!   end function isnan_mb
-! #else
   logical pure elemental function isnan_mb(arg)
     real(kind=fPrec), intent(in) :: arg
     isnan_mb = arg /= arg
   end function isnan_mb
-! #endif
 
-  real(kind=fPrec) function sin_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function sin_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     sin_mb=sin(arg)
 #else
 #ifdef ROUND_NEAR
@@ -316,13 +255,9 @@ contains
 #endif
   end function sin_mb
 
-  real(kind=fPrec) function asin_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function asin_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     asin_mb=asin(arg)
 #else
 #ifdef ROUND_NEAR
@@ -340,13 +275,9 @@ contains
 #endif
   end function asin_mb
 
-  real(kind=fPrec) function sinh_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function sinh_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     sinh_mb=sinh(arg)
 #else
 #ifdef ROUND_NEAR
@@ -364,13 +295,9 @@ contains
 #endif
   end function sinh_mb
 
-  real(kind=fPrec) function cos_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function cos_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     cos_mb=cos(arg)
 #else
 #ifdef ROUND_NEAR
@@ -388,13 +315,9 @@ contains
 #endif
   end function cos_mb
 
-  real(kind=fPrec) function acos_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function acos_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     acos_mb=acos(arg)
 #else
 #ifdef ROUND_NEAR
@@ -412,13 +335,9 @@ contains
 #endif
   end function acos_mb
 
-  real(kind=fPrec) function cosh_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function cosh_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     cosh_mb=cosh(arg)
 #else
 #ifdef ROUND_NEAR
@@ -436,13 +355,9 @@ contains
 #endif
   end function cosh_mb
 
-  real(kind=fPrec) function tan_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function tan_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     tan_mb=tan(arg)
 #else
 #ifdef ROUND_NEAR
@@ -460,13 +375,9 @@ contains
 #endif
   end function tan_mb
 
-  real(kind=fPrec) function atan_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function atan_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     atan_mb=atan(arg)
 #else
 #ifdef ROUND_NEAR
@@ -484,12 +395,10 @@ contains
 #endif
   end function atan_mb
 
-  real(kind=fPrec) function atan2_mb(y,x)
-    implicit none
+  real(kind=fPrec) pure function atan2_mb(y,x)
     real(kind=fPrec), intent(in) :: y,x
 #ifndef CRLIBM
 #ifdef NAGFOR
-    ! Nagfor
     if(x == 0.0_fPrec .and. y == 0.0_fPrec) then
       atan2_mb=0.0_fPrec
     else
@@ -514,13 +423,9 @@ contains
 #endif
   end function atan2_mb
 
-  real(kind=fPrec) function exp_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function exp_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     exp_mb=exp(arg)
 #else
 #ifdef ROUND_NEAR
@@ -538,13 +443,9 @@ contains
 #endif
   end function exp_mb
 
-  real(kind=fPrec) function log_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function log_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     log_mb=log(arg)
 #else
 #ifdef ROUND_NEAR
@@ -562,13 +463,9 @@ contains
 #endif
   end function log_mb
 
-  real(kind=fPrec) function log10_mb(arg)
-    implicit none
-    real(kind=fPrec) arg
-    intent(in) arg
-
+  real(kind=fPrec) pure function log10_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
 #ifndef CRLIBM
-    !Input KIND = output KIND
     log10_mb=log10(arg)
 #else
 #ifdef ROUND_NEAR
@@ -587,52 +484,48 @@ contains
   end function log10_mb
 
 #ifdef CRLIBM
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-! Functions moved from sixtrack.s, wrapping parts of crlibm !
-!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  ! ========================================================================== !
+  !  ROUND NEAR SPEACIAL FUNCTIONS
+  ! ========================================================================== !
+
 #ifdef ROUND_NEAR
-  real(kind=real64) function acos_rn(x)
+  real(kind=real64) pure function acos_rn(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       acos_rn=x
-    elseif (abs(x).eq.0.0d0) then
-       acos_rn=mb_pi2
+      acos_rn=x
+    elseif(abs(x) == 0.0d0) then
+      acos_rn=mb_pi2
     else
-       !       acos_rn=atan_rn(sqrt(1.0d0-x*x)/x)
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       acos_rn=atan_rn(sqrt((1.0d0-x)*(1.0d0+x))/x)
-       if (x.lt.0d0) then
-          acos_rn=mb_pi+acos_rn
-       endif
-    endif
+      ! Try using (1-x)*(1+x) in case x is very small or close to 1. Write a test program?
+      acos_rn=atan_rn(sqrt((1.0d0-x)*(1.0d0+x))/x)
+      if(x < 0d0) then
+        acos_rn=mb_pi+acos_rn
+      end if
+    end if
   end function acos_rn
 
-  real(kind=real64) function asin_rn(x)
+  real(kind=real64) pure function asin_rn(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x,mb_pi2
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       asin_rn=x
-       return
-    endif
-    if (abs(x).eq.1.0d0) then
-       asin_rn=sign(mb_pi2,x)
+      asin_rn=x
+      return
+    end if
+    if(abs(x) == 1.0d0) then
+      asin_rn=sign(mb_pi2,x)
     else
-       !       asin_rn=atan_rn(x/sqrt(1.0d0-x*x))
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       asin_rn=atan_rn(x/sqrt((1.0d0-x)*(1.0d0+x)))
-    endif
+      ! Try using (1-x)*(1+x) in case x is very small or close to 1. Write a test program?
+      asin_rn=atan_rn(x/sqrt((1.0d0-x)*(1.0d0+x)))
+    end if
   end function asin_rn
 
-  real(kind=real64) function atan2_rn(y,x)
-    implicit none
-    real(kind=real64) x,y
-    if (x.eq.0d0) then
-      if (y.eq.0d0) then
+  real(kind=real64) pure function atan2_rn(y,x)
+    use, intrinsic :: iso_fortran_env, only : real64
+    real(kind=real64), intent(in) :: x,y
+    if(x == 0d0) then
+      if(y == 0d0) then
 #ifdef NAGFOR
         atan2_rn=0d0
 #else
@@ -641,138 +534,129 @@ contains
 #endif
       else
         atan2_rn=sign(mb_pi2,y)
-      endif
+      end if
     else
-       if (y.eq.0d0) then
-        if (x.gt.0d0) then
+      if(y == 0d0) then
+        if(x > 0d0) then
           ! Let the internal atan2 handle this case according to ieee
           atan2_rn=atan2(y,x)
         else
           atan2_rn=mb_pi
-        endif
+        end if
       else
         atan2_rn=atan_rn(y/x)
-        if (x.lt.0d0) then
+        if(x < 0d0) then
           atan2_rn=sign(mb_pi,y)+atan2_rn
-        endif
-       endif
-    endif
+        end if
+      end if
+    end if
   end function atan2_rn
 #endif
 
+  ! ========================================================================== !
+  !  ROUND UP SPEACIAL FUNCTIONS
+  ! ========================================================================== !
+
 #ifdef ROUND_UP
-  real(kind=real64) function acos_ru(x)
+  real(kind=real64) pure function acos_ru(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       acos_ru=x
-    elseif (abs(x).eq.0.0d0) then
-       acos_ru=mb_pi2
+      acos_ru=x
+    elseif(abs(x) == 0.0d0) then
+      acos_ru=mb_pi2
     else
-       !       acos_ru=atan_ru(sqrt(1.0d0-x*x)/x)
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       acos_ru=atan_ru(sqrt((1.0d0-x)*(1.0d0+x))/x)
-       if (x.lt.0d0) then
-          acos_ru=mb_pi+acos_ru
-       endif
-    endif
+      acos_ru=atan_ru(sqrt((1.0d0-x)*(1.0d0+x))/x)
+      if(x < 0d0) then
+        acos_ru=mb_pi+acos_ru
+      end if
+    end if
   end function acos_ru
 
-  real(kind=real64) function asin_ru(x)
+  real(kind=real64) pure function asin_ru(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       asin_ru=x
-       return
-    endif
-    if (abs(x).eq.1.0d0) then
-       asin_ru=sign(mb_pi2,x)
+      asin_ru=x
+      return
+    end if
+    if(abs(x) == 1.0d0) then
+      asin_ru=sign(mb_pi2,x)
     else
-       !       asin_ru=atan_ru(x/sqrt(1.0d0-x*x))
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       asin_ru=atan_ru(x/sqrt((1.0d0-x)*(1.0d0+x)))
-    endif
+      asin_ru=atan_ru(x/sqrt((1.0d0-x)*(1.0d0+x)))
+    end if
   end function asin_ru
 
-  real(kind=real64) function atan2_ru(y,x)
-    implicit none
-    real(kind=real64) x,y
-    if (x.eq.0d0) then
-      if (y.eq.0d0) then
+  real(kind=real64) pure function atan2_ru(y,x)
+    use, intrinsic :: iso_fortran_env, only : real64
+    real(kind=real64), intent(in) :: x,y
+    if(x == 0d0) then
+      if(y == 0d0) then
 #ifdef NAGFOR
-          atan2_ru=0d0
+        atan2_ru=0d0
 #else
         ! Let the internal atan2 handle this case according to ieee
         atan2_ru=atan2(y,x)
 #endif
       else
         atan2_ru=sign(mb_pi2,y)
-      endif
+      end if
     else
-      if (y.eq.0d0) then
-        if (x.gt.0d0) then
+      if(y == 0d0) then
+        if(x > 0d0) then
           ! Let the internal atan2 handle this case according to ieee
           atan2_ru=atan2(y,x)
         else
           atan2_ru=mb_pi
-        endif
+        end if
       else
         atan2_ru=atan_ru(y/x)
-        if (x.lt.0d0) then
+        if(x < 0d0) then
           atan2_ru=sign(mb_pi,y)+atan2_ru
-        endif
-      endif
-    endif
+        end if
+      end if
+    end if
   end function atan2_ru
 #endif
 
+  ! ========================================================================== !
+  !  ROUND DOWN SPEACIAL FUNCTIONS
+  ! ========================================================================== !
+
 #ifdef ROUND_DOWN
-  real(kind=real64) function acos_rd(x)
+  real(kind=real64) pure function acos_rd(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       acos_rd=x
-    elseif (abs(x).eq.0.0d0) then
-       acos_rd=mb_pi2
+      acos_rd=x
+    elseif(abs(x) == 0.0d0) then
+      acos_rd=mb_pi2
     else
-       !       acos_rd=atan_rd(sqrt(1.0d0-x*x)/x)
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       acos_rd=atan_rd(sqrt((1.0d0-x)*(1.0d0+x))/x)
-       if (x.lt.0d0) then
-          acos_rd=mb_pi+acos_rd
-       endif
-    endif
+      acos_rd=atan_rd(sqrt((1.0d0-x)*(1.0d0+x))/x)
+      if(x < 0d0) then
+        acos_rd=mb_pi+acos_rd
+      end if
+    end if
   end function acos_rd
 
-  real(kind=real64) function asin_rd(x)
+  real(kind=real64) pure function asin_rd(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       asin_rd=x
-       return
-    endif
-    if (abs(x).eq.1.0d0) then
-       asin_rd=sign(mb_pi2,x)
+      asin_rd=x
+      return
+    end if
+    if(abs(x) == 1.0d0) then
+      asin_rd=sign(mb_pi2,x)
     else
-       !       asin_rd=atan_rd(x/sqrt(1.0d0-x*x))
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       asin_rd=atan_rd(x/sqrt((1.0d0-x)*(1.0d0+x)))
-    endif
+      asin_rd=atan_rd(x/sqrt((1.0d0-x)*(1.0d0+x)))
+    end if
   end function asin_rd
 
-  real(kind=real64) function atan2_rd(y,x)
-    implicit none
-    real(kind=real64) x,y
-    if (x.eq.0d0) then
-      if (y.eq.0d0) then
+  real(kind=real64) pure function atan2_rd(y,x)
+    real(kind=real64), intent(in) :: x,y
+    if(x == 0d0) then
+      if(y == 0d0) then
 #ifdef NAGFOR
         atan2_rd=0d0
 #else
@@ -781,68 +665,64 @@ contains
 #endif
       else
         atan2_rd=sign(mb_pi2,y)
-      endif
+      end if
     else
-      if (y.eq.0d0) then
-        if (x.gt.0d0) then
+      if(y == 0d0) then
+        if(x > 0d0) then
           ! Let the internal atan2 handle this case according to ieee
           atan2_rd=atan2(y,x)
         else
           atan2_rd=mb_pi
-        endif
+        end if
       else
         atan2_rd=atan_rd(y/x)
-        if (x.lt.0d0) then
+        if(x < 0d0) then
           atan2_rd=sign(mb_pi,y)+atan2_rd
-        endif
-      endif
-    endif
+        end if
+      end if
+    end if
   end function atan2_rd
 #endif
 
+  ! ========================================================================== !
+  !  ROUND ZERO SPEACIAL FUNCTIONS
+  ! ========================================================================== !
+
 #ifdef ROUND_ZERO
-  real(kind=real64) function acos_rz(x)
+  real(kind=real64) pure function acos_rz(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       acos_rz=x
-    elseif (abs(x).eq.0.0d0) then
-       acos_rz=mb_pi2
+      acos_rz=x
+    elseif(abs(x) == 0.0d0) then
+      acos_rz=mb_pi2
     else
-       !       acos_rz=atan_rz(sqrt(1.0d0-x*x)/x)
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       acos_rz=atan_rz(sqrt((1.0d0-x)*(1.0d0+x))/x)
-       if (x.lt.0d0) then
-          acos_rz=mb_pi+acos_rz
-       endif
-    endif
+      acos_rz=atan_rz(sqrt((1.0d0-x)*(1.0d0+x))/x)
+      if(x < 0d0) then
+        acos_rz=mb_pi+acos_rz
+      end if
+    end if
   end function acos_rz
 
-  real(kind=real64) function asin_rz(x)
+  real(kind=real64) pure function asin_rz(x)
     use, intrinsic :: iso_fortran_env, only : real64
-    implicit none
-    real(kind=real64) x
+    real(kind=real64), intent(in) :: x
     if(x /= x) then ! Check if NaN
-       asin_rz=x
-       return
-    endif
-    if (abs(x).eq.1.0d0) then
-       asin_rz=sign(mb_pi2,x)
+      asin_rz=x
+      return
+    end if
+    if(abs(x) == 1.0d0) then
+      asin_rz=sign(mb_pi2,x)
     else
-       !       asin_rz=atan_rz(x/sqrt(1.0d0-x*x))
-       ! Try using (1-x)*(1+x) in case x is very small.........
-       ! or close to 1.....write a test program!!!
-       asin_rz=atan_rz(x/sqrt((1.0d0-x)*(1.0d0+x)))
-    endif
+      asin_rz=atan_rz(x/sqrt((1.0d0-x)*(1.0d0+x)))
+    end if
   end function asin_rz
 
-  real(kind=real64) function atan2_rz(y,x)
-    implicit none
-    real(kind=real64) x,y
-    if (x.eq.0d0) then
-      if (y.eq.0d0) then
+  real(kind=real64) pure function atan2_rz(y,x)
+    use, intrinsic :: iso_fortran_env, only : real64
+    real(kind=real64), intent(in) :: x,y
+    if(x == 0d0) then
+      if(y == 0d0) then
 #ifdef NAGFOR
         atan2_rz=0d0
 #else
@@ -851,22 +731,22 @@ contains
 #endif
       else
         atan2_rz=sign(mb_pi2,y)
-      endif
+      end if
     else
-      if (y.eq.0d0) then
-        if (x.gt.0d0) then
+      if(y == 0d0) then
+        if(x > 0d0) then
           ! Let the internal atan2 handle this case according to ieee
           atan2_rz=atan2(y,x)
         else
           atan2_rz=mb_pi
-        endif
+        end if
       else
         atan2_rz=atan_rz(y/x)
-        if (x.lt.0d0) then
+        if(x < 0d0) then
           atan2_rz=sign(mb_pi,y)+atan2_rz
-        endif
-      endif
-    endif
+        end if
+      end if
+    end if
   end function atan2_rz
 #endif
 

--- a/source/bouncy_castle.f90
+++ b/source/bouncy_castle.f90
@@ -279,18 +279,18 @@ contains
 
   ! Definition of the MathlibBouncer (_mb) functions
 
-#ifdef IFORT
-  logical pure elemental function isnan_mb(arg)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
-    real(kind=fPrec), intent(in) :: arg
-    isnan_mb = ieee_is_nan(arg)
-  end function isnan_mb
-#else
+! #ifdef IFORT
+!   logical pure elemental function isnan_mb(arg)
+!     use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+!     real(kind=fPrec), intent(in) :: arg
+!     isnan_mb = ieee_is_nan(arg)
+!   end function isnan_mb
+! #else
   logical pure elemental function isnan_mb(arg)
     real(kind=fPrec), intent(in) :: arg
     isnan_mb = arg /= arg
   end function isnan_mb
-#endif
+! #endif
 
   real(kind=fPrec) function sin_mb(arg)
     implicit none

--- a/source/bouncy_castle.f90
+++ b/source/bouncy_castle.f90
@@ -5,12 +5,12 @@
 module mathlib_bouncer
 
   use floatPrecision
-  use, intrinsic :: ieee_arithmetic
+! use, intrinsic :: ieee_arithmetic
   use, intrinsic :: iso_fortran_env, only : real64, int64
   implicit none
 
   !These are the actual "bouncy functions" users are supposed to call
-  public :: sin_mb, asin_mb, sinh_mb, cos_mb, acos_mb, cosh_mb, tan_mb, atan_mb, atan2_mb, exp_mb, log_mb, log10_mb
+  public :: sin_mb, asin_mb, sinh_mb, cos_mb, acos_mb, cosh_mb, tan_mb, atan_mb, atan2_mb, exp_mb, log_mb, log10_mb, isnan_mb
 
 ! real(kind=fPrec), parameter :: mb_pi   = 3.1415926535897932d0
 ! real(kind=fPrec), parameter :: mb_pi2  = 1.5707963267948966d0
@@ -277,7 +277,21 @@ module mathlib_bouncer
 
 contains
 
-  !Definition of the MathlibBouncer (_mb) functions
+  ! Definition of the MathlibBouncer (_mb) functions
+
+#ifdef IFORT
+  logical pure elemental function isnan_mb(arg)
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+    real(kind=fPrec), intent(in) :: arg
+    isnan_mb = ieee_is_nan(arg)
+  end function isnan_mb
+#else
+  logical pure elemental function isnan_mb(arg)
+    real(kind=fPrec), intent(in) :: arg
+    isnan_mb = arg /= arg
+  end function isnan_mb
+#endif
+
   real(kind=fPrec) function sin_mb(arg)
     implicit none
     real(kind=fPrec) arg
@@ -475,7 +489,7 @@ contains
     real(kind=fPrec), intent(in) :: y,x
 #ifndef CRLIBM
 #ifdef NAGFOR
-    ! Nagfoir
+    ! Nagfor
     if(x == 0.0_fPrec .and. y == 0.0_fPrec) then
       atan2_mb=0.0_fPrec
     else
@@ -578,11 +592,10 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #ifdef ROUND_NEAR
   real(kind=real64) function acos_rn(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        acos_rn=x
     elseif (abs(x).eq.0.0d0) then
        acos_rn=mb_pi2
@@ -598,11 +611,10 @@ contains
   end function acos_rn
 
   real(kind=real64) function asin_rn(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x,mb_pi2
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        asin_rn=x
        return
     endif
@@ -622,7 +634,7 @@ contains
     if (x.eq.0d0) then
       if (y.eq.0d0) then
 #ifdef NAGFOR
-          atan2_rn=0d0
+        atan2_rn=0d0
 #else
         ! Let the internal atan2 handle this case according to ieee
         atan2_rn=atan2(y,x)
@@ -650,11 +662,10 @@ contains
 
 #ifdef ROUND_UP
   real(kind=real64) function acos_ru(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        acos_ru=x
     elseif (abs(x).eq.0.0d0) then
        acos_ru=mb_pi2
@@ -670,11 +681,10 @@ contains
   end function acos_ru
 
   real(kind=real64) function asin_ru(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        asin_ru=x
        return
     endif
@@ -722,11 +732,10 @@ contains
 
 #ifdef ROUND_DOWN
   real(kind=real64) function acos_rd(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        acos_rd=x
     elseif (abs(x).eq.0.0d0) then
        acos_rd=mb_pi2
@@ -742,11 +751,10 @@ contains
   end function acos_rd
 
   real(kind=real64) function asin_rd(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        asin_rd=x
        return
     endif
@@ -794,11 +802,10 @@ contains
 
 #ifdef ROUND_ZERO
   real(kind=real64) function acos_rz(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        acos_rz=x
     elseif (abs(x).eq.0.0d0) then
        acos_rz=mb_pi2
@@ -814,11 +821,10 @@ contains
   end function acos_rz
 
   real(kind=real64) function asin_rz(x)
-    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
     use, intrinsic :: iso_fortran_env, only : real64
     implicit none
     real(kind=real64) x
-    if (ieee_is_nan(x)) then
+    if(x /= x) then ! Check if NaN
        asin_rz=x
        return
     endif


### PR DESCRIPTION
This works on all compilers. Timing info below:

```
Before
gfortran : 1543.38 sec
ifort    :  494.28 sec
nagfor   :  453.12 sec

After    :    x /= x   | ieee_is_nan
gfortran :  453.61 sec |  599.47 sec
ifort    :  482.28 sec |  478.88 sec
nagfor   :  438.23 sec |  446.21 sec
```

Before here is current master.
After, 1st column uses x /= x to check for NaN for new isnan_mb function, 2nd column uses ieee_is_nan.

For ifort and nagfor there is minimal difference. For gfortran the difference is in the aperture check which uses NaN checks a lot.

The PR manually inlines NaN checks internally in mathlib_bouncer, which is why the test time drops from 1543 sec to 599 sec for gfortran.