### PR TITLE
Bug fixes before50003

### DIFF
--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -128,6 +128,8 @@ featList = ""
   call meta_write("GitHash",           trim(git_revision))
   call meta_write("StartTime",         timeStamp)
 
+  meta_nPartTurn = 2
+
   ! Init stuff
   do i=1,2
     eps(i)=zero

--- a/source/mod_time.f90
+++ b/source/mod_time.f90
@@ -79,26 +79,32 @@ end subroutine time_initialise
 subroutine time_finalise
 
   use mod_meta
-  use mod_common, only : numl, mbloz
+  use mod_common, only : numl, mbloz, napx
+  use numerical_constants, only : zero
 
   real(kind=fPrec) trackTime, nP, nT, nE, nPT, nPTE
 
   ! Tracking Averages
 
   trackTime = time_timeRecord(time_afterTracking) - time_timeRecord(time_afterPreTrack)
+  call time_writeReal("Sum_Tracking", trackTime, "s")
 
   nT   = real(numl,fPrec)
   nE   = real(mbloz,fPrec)
   nPT  = real(meta_nPartTurn,fPrec)
-  nP   = nPT/nT
   nPTE = nPT*nE
+  if(nT > zero) then
+    nP = nPT/nT
+  else
+    nP = nPT
+  end if
 
-  call time_writeReal("Sum_Tracking",                     trackTime,      "s")
-  call time_writeReal("Avg_PerParticle",            1.0e3*trackTime/nP,   "ms")
-  call time_writeReal("Avg_PerTurn",                1.0e3*trackTime/nT,   "ms")
-  call time_writeReal("Avg_PerElement",             1.0e3*trackTime/nE,   "ms")
-  call time_writeReal("Avg_PerParticleTurn",        1.0e6*trackTime/nPT,  "us")
-  call time_writeReal("Avg_PerParticleTurnElement", 1.0e9*trackTime/nPTE, "ns")
+  ! Check for zeros just to be safe
+  if(nP   > zero) call time_writeReal("Avg_PerParticle",            1.0e3*trackTime/nP,   "ms")
+  if(nT   > zero) call time_writeReal("Avg_PerTurn",                1.0e3*trackTime/nT,   "ms")
+  if(nE   > zero) call time_writeReal("Avg_PerElement",             1.0e3*trackTime/nE,   "ms")
+  if(nPT  > zero) call time_writeReal("Avg_PerParticleTurn",        1.0e6*trackTime/nPT,  "us")
+  if(nPTE > zero) call time_writeReal("Avg_PerParticleTurnElement", 1.0e9*trackTime/nPTE, "ns")
 
   ! Timer Reports
 

--- a/source/zipf.f90
+++ b/source/zipf.f90
@@ -85,11 +85,11 @@ subroutine zipf_dozip
   implicit none
 
 #ifdef BOINC
-  character(256)               zipf_outFile_boinc
+  character(256) zipf_outFile_boinc
   character(len=:), allocatable :: zipf_fileNames_boinc(:)
   integer ii
 
-  call alloc(zipf_fileNames_boinc, 256, zipf_numFiles, str_dSpace, "zipf_fileNames_boinc")
+  call alloc(zipf_fileNames_boinc, 256, zipf_numFiles, " ", "zipf_fileNames_boinc")
 #endif
 
 !+if libarchive

--- a/source/zipf.f90
+++ b/source/zipf.f90
@@ -85,11 +85,11 @@ subroutine zipf_dozip
   implicit none
 
 #ifdef BOINC
-  character(mStrLen)               zipf_outFile_boinc
+  character(256)               zipf_outFile_boinc
   character(len=:), allocatable :: zipf_fileNames_boinc(:)
   integer ii
 
-  call alloc(zipf_fileNames_boinc, mStrLen, zipf_numFiles, str_dSpace, "zipf_fileNames_boinc")
+  call alloc(zipf_fileNames_boinc, 256, zipf_numFiles, str_dSpace, "zipf_fileNames_boinc")
 #endif
 
 !+if libarchive


### PR DESCRIPTION
Fixed a bug in mod_time that caused division by zero when running DA version where nTurnPart = 0.
This only affected Debug builds.

Also fixed the bug in ZIPF with BOINC. I already fixed it, but it looks like I forgot to include it in the previous PR.