### PR TITLE
That same stupid fort.95/96 infinite loop bug again.

### DIFF
--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -360,7 +360,7 @@ subroutine crcheck
     write(93,"(a)") "SIXTRACR> CRCHECK reading fort.96 Record META"
     flush(93)
     call meta_crcheck(96,lerror)
-    if(lerror) goto 100
+    if(lerror) goto 101
 
     write(93,"(a)") "SIXTRACR> CRCHECK reading fort.96 Record 5 DUMP"
     flush(93)


### PR DESCRIPTION
CR goes into an infinite loop if both fort.95 and fort.96 files are corrupt. This is for the META block, but was the same bug we had for DUMP before. It happens because the same code is repeated twice for the files, but the error goto is label 100 and 101 for the two files. This should probably be wrapped in a better way.