### PR TITLE
Fix ref part initialisation

### DIFF
--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -278,7 +278,9 @@ module mod_common
   real(kind=fPrec),              save :: sigman(2,nbb),sigman2(2,nbb),sigmanq(2,nbb)
   real(kind=fPrec),              save :: clobeam(6,nbb),beamoff(6,nbb)
   real(kind=fPrec), allocatable, save :: track6d(:,:) ! (6,npart)
-  real(kind=fPrec),              save :: sigz,sige,partnum,parbe14,emitx,emity,emitz,gammar
+  real(kind=fPrec),              save :: sigz,sige,partnum,parbe14,emitx,emity,emitz
+  real(kind=fPrec),              save :: gammar = one
+  real(kind=fPrec),              save :: betrel = zero
   integer,                       save :: nbeam,ibbc,ibeco,ibtyp,lhc
   real(kind=fPrec), allocatable, save :: parbe(:,:) ! (nele,18)
   real(kind=fPrec), allocatable, save :: ptnfac(:)  ! (nele)

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -113,7 +113,7 @@ module mod_common
 
   use parpro
   use floatPrecision
-  use numerical_constants, only : c1m6, c180e0, pi, two, half
+  use numerical_constants, only : c1m6, c180e0, pi, two, half, one, zero
 
   implicit none
 

--- a/source/mod_particles.f90
+++ b/source/mod_particles.f90
@@ -77,6 +77,7 @@ subroutine part_updateRefEnergy(refEnergy)
   e0     = refEnergy
   e0f    = sqrt(e0**2 - nucm0**2)
   gammar = nucm0/e0
+  betrel = sqrt((one+gammar)*(one-gammar))
 
   ! Also update sigmv with the new beta0 = e0f/e0
   sigmv(1:napx) = ((e0f*e0o)/(e0fo*e0))*sigmv(1:napx)

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -882,10 +882,13 @@ subroutine daten
       call prror(-1)
     end if
 
+    call hions_postInput
+    gammar = nucm0/e0
+    betrel = sqrt((one+gammar)*(one-gammar))
+    
     if(nbeam >= 1) then
       parbe14 = (((((-one*crad)*partnum)/four)/pi)/sixin_emitNX)*c1e6
     end if
-    gammar = pma/e0
     crad   = (((two*crad)*partnum)*gammar)*c1e6
     emitx  = sixin_emitNX*gammar
     emity  = sixin_emitNY*gammar
@@ -915,7 +918,6 @@ subroutine daten
 
   end if
 
-  call hions_postInput
   call elens_postInput
 
   if(idp == 0 .or. ition == 0 .or. nbeam < 1) then
@@ -2859,7 +2861,6 @@ subroutine comnul
       emitx=zero
       emity=zero
       emitz=zero
-      gammar=one
       sigz=zero
       sige=zero
       damp=zero


### PR DESCRIPTION
fixing steps in setting up of reference particle and dependent calls/variables.
Mainly:
   * call `hions_postInput` preceeds anything concerning ref particle;
   * calculation of `gammar` and `betrel`;
   * all the rest comes afterwards (eg collimation setting up);
   * subroutine for updating ref particle updated as well.