### PR TITLE
C/R bug fixes

### DIFF
--- a/source/dump.f90
+++ b/source/dump.f90
@@ -1922,8 +1922,8 @@ subroutine dump_crpoint(fileunit,lerror,ierro)
   use parpro !nele
   implicit none
 
-  integer, intent(in) :: fileunit
-  logical, intent(out) :: lerror
+  integer, intent(in)    :: fileunit
+  logical, intent(inout) :: lerror
   integer, intent(inout) :: ierro
   integer j
 

--- a/source/dynk.f90
+++ b/source/dynk.f90
@@ -2992,7 +2992,7 @@ subroutine dynk_crpoint(fileunit,fileerror,ierro)
   implicit none
 
   integer, intent(in)    :: fileunit
-  logical, intent(out)   :: fileerror
+  logical, intent(inout) :: fileerror
   integer, intent(inout) :: ierro
 
   integer j

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -179,7 +179,7 @@ subroutine abend(cstring)
 #ifdef BOINC
   do i=2,120
     inquire(i,opened=fOpen)
-    write(93,"(a,i0.a.l1)") "SIXTRACR> Unit ",i,": Opened = ",fOpen
+    write(93,"(a,i0,a,l1)") "SIXTRACR> Unit ",i,": Opened = ",fOpen
   end do
   ! call boinc_zipitall()
   ! call boinc_finish_graphics()
@@ -213,7 +213,7 @@ subroutine abend(cstring)
 #ifdef BOINC
   do i=2,120
     inquire(i,opened=fOpen)
-    write(6,"(a,i0,a,l1") "ABEND> Unit ",i,": Opened = ",fOpen
+    write(6,"(a,i0,a,l1)") "ABEND> Unit ",i,": Opened = ",fOpen
   end do
   close(6,err=31)
 31 continue

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -183,7 +183,7 @@ subroutine abend(cstring)
   end do
   ! call boinc_zipitall()
   ! call boinc_finish_graphics()
-  if(errout_status.ne.0) then
+  if(errout_status /= 0) then
     close(93)
     call boincrf('fort.93',filename)
     call print_lastlines_to_stderr(93,filename)
@@ -192,7 +192,7 @@ subroutine abend(cstring)
   end if
   call boinc_finish(errout_status) !This call does not return
 #else
-  if(errout_status.ne.0) then
+  if(errout_status /= 0) then
     close(93)
     call print_lastlines_to_stderr(93,"fort.93")
     call print_lastlines_to_stderr(6,"fort.6")

--- a/source/hions.f90
+++ b/source/hions.f90
@@ -160,7 +160,7 @@ subroutine hions_crpoint(fileUnit, writeErr, iErro)
   implicit none
 
   integer, intent(in)    :: fileUnit
-  logical, intent(out)   :: writeErr
+  logical, intent(inout) :: writeErr
   integer, intent(inout) :: iErro
 
   integer i

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -492,7 +492,7 @@ end interface
   ! Postprocessing is on, but there are no particles
   if(ipos.eq.1.and.napx.eq.0) then
     ! Now we open fort.10 unless already opened for BOINC
-    call units_openUnit(unit=10,fileName="fort.10",formatted=.true.,mode="w",err=fErr,recl=8195)
+    call units_openUnit(unit=10,fileName="fort.10",formatted=.true.,mode="rw",err=fErr,recl=8195)
 
 #ifndef STF
     do i=1,ndafi !ndafi = number of files to postprocess (set by fort.3)

--- a/source/mod_meta.f90
+++ b/source/mod_meta.f90
@@ -256,7 +256,7 @@ subroutine meta_crpoint(fileUnit, writeErr, iErro)
   use crcoall
 
   integer, intent(in)    :: fileUnit
-  logical, intent(out)   :: writeErr
+  logical, intent(inout) :: writeErr
   integer, intent(inout) :: iErro
 
   write(fileunit,err=10,iostat=iErro) meta_nRestarts, meta_nPartTurn

--- a/source/scatter.f90
+++ b/source/scatter.f90
@@ -380,7 +380,7 @@ subroutine scatter_crpoint(fileUnit, writeErr, iErro)
   implicit none
 
   integer, intent(in)    :: fileUnit
-  logical, intent(out)   :: writeErr
+  logical, intent(inout) :: writeErr
   integer, intent(inout) :: iErro
 
   integer j

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -2133,7 +2133,7 @@ end subroutine thin6d
 !-----------------------------------------------------------------------
 !  3 February 1999
 !-----------------------------------------------------------------------
-subroutine callcrp()
+subroutine callcrp
 
   use floatPrecision
   use mathlib_bouncer
@@ -2165,19 +2165,19 @@ subroutine callcrp()
   write(91,*,iostat=ierro,err=11) numx,numl
   rewind 91
   if (restart) then
-    write(93,*) 'CALLCRP/CRPOINT bailing out'
-    write(93,*) 'numl, nnuml, numx, numlcr ',numl,nnuml,numx,numlcr
-    endfile (93,iostat=ierro)
-    backspace (93,iostat=ierro)
+    write(93,"(4(a,i0))") "SIXTRACR> CALLCRP/CRPOINT bailing out. numl = ",numl,", nnuml = ",nnuml,","//&
+      " numx = ",numx,", numlcr = ",numlcr
+    endfile(93,iostat=ierro)
+    backspace(93,iostat=ierro)
     return
   else
 #ifndef DEBUG
     if (ncalls.le.20.or.numx.ge.nnuml-20) then
 #endif
-    write(93,*) 'CALLCRP numl, nnuml, numlcr, numx, nwri, numlcp '
-    write(93,*) numl,nnuml,numlcr,numx,nwri,numlcp
-    endfile (93,iostat=ierro)
-    backspace (93,iostat=ierro)
+    write(93,"(6(a,i0))") "SIXTRACR> CALLCRP numl = ",numl,", nnuml = ",nnuml,", numlcr = ",numlcr,", "//&
+     "numx = ",numx,", nwri = ",nwri,", numlcp = ",numlcp
+    endfile(93,iostat=ierro)
+    backspace(93,iostat=ierro)
 #ifndef DEBUG
     endif
 #endif
@@ -2197,8 +2197,8 @@ subroutine callcrp()
   if (checkp) call crpoint
 #endif
   return
-11 write(lout,*) '*** ERROR ***,PROBLEMS WRITING TO FILE # : 91',ierro
-  write(lout,*)'SIXTRACR WRITEBIN IO ERROR on Unit 91'
+11 write(lout,"(a,i0)") "CALLCRP> ERROR Problems writing to file #91, ierro= ",ierro
+  ! write(lout,"(a)")'SIXTRACR WRITEBIN IO ERROR on Unit 91'
   call prror(-1)
 #endif
   return

--- a/source/version.f90
+++ b/source/version.f90
@@ -1,6 +1,7 @@
 module mod_version
   ! Keep data type in sync with 'cr_version' and 'cr_moddate'
   character(len=8),  parameter :: version = "5.0.3"
+  integer,           parameter :: numvers = 50003
   character(len=10), parameter :: moddate = "22.11.2018"
   character(len=40), parameter :: git_revision = SIXTRACK_GIT_REVISION ! Git hash set by CMake
 end module mod_version


### PR DESCRIPTION
This PR fixes two bugs:
* The test for the existence of fort.10 in `abend` did not work as intended when built with nagfor. The attempt to open the file should use `status="old'` to properly error if the file does not exist.
* The `lerror` flag used in `crpoint` in the C/R module was not initialised properly. This is not initialised to `.false.` for each of `fort.95` and `fort.96`, and passed to the module crpoint routines with `intent(inout)`.

In the process, the output and structure of the C/R routines `crpoint` and `crstart` was cleaned up.

The tests now pass with all compilers and `-DCR=ON`, with the exception of the `scatter_collimation` test which is not C/R compatible.