### PR TITLE
Bugs 2018 12 06

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -951,7 +951,6 @@ if(HDF5)
 endif(HDF5)
 
 if(HASHLIB)
-  # ${CMAKE_SOURCE_DIR}/source/md5/md5.h
   set(MD5_SOURCES
     ${CMAKE_SOURCE_DIR}/source/md5/md5.c
     ${CMAKE_SOURCE_DIR}/source/md5/md5interface.c
@@ -959,7 +958,6 @@ if(HASHLIB)
   add_library(md5_lib STATIC  ${MD5_SOURCES})
   target_include_directories(md5_lib PRIVATE ${CMAKE_SOURCE_DIR}/source/md5/)
   set_property(TARGET md5_lib PROPERTY C_STANDARD 99)
-  target_link_libraries(md5_lib roundctl)
   if(32BIT)
     set_target_properties(md5_lib PROPERTIES LINK_FLAGS "-m32")
   endif(32BIT)

--- a/source/mod_fluka.f90
+++ b/source/mod_fluka.f90
@@ -27,7 +27,7 @@ module mod_fluka
   public :: fluka_send_receive
   public :: fluka_send
   public :: fluka_receive
-  public :: fluka_lostpart
+  public :: fluka_shuffleLostParticles
   public :: fluka_set_synch_part
   public :: fluka_init_max_uid
   public :: fluka_is_running
@@ -598,7 +598,7 @@ module mod_fluka
     integer, intent(in) :: j
 
     if(fluka_debug) then
-      write(fluka_log_unit, *) '# fluka_lostpart called with npart (lnapx for SixTrack) = ', tnapx, ', j = ', j
+      write(fluka_log_unit, *) '# fluka_shuffleLostParticles called with napx (lnapx for SixTrack) = ', tnapx, ', j = ', j
       flush(fluka_log_unit)
     end if
 


### PR DESCRIPTION
Two minor bugs fixed.
* HASHLIB flag depended on roundctl, which broke single and quad build
* FLUKA module was still expecting fluka_lostpart to exist. The routine has been renamed.