### PR TITLE
CMake updates BOINC etc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1037,10 +1037,10 @@ if(BOINC AND API)
   find_library(stdc++ STATIC stdc++)
   target_link_libraries(SixTrackLib stdc++ Threads::Threads)
 
-  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    find_library(nsl STATIC nsl)
-    target_link_libraries(SixTrackCR nsl)
-  endif()
+  # if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  #   find_library(nsl STATIC nsl)
+  #   target_link_libraries(SixTrackCR nsl)
+  # endif()
 
   #fix osx linking to the correct c++ stdlib
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1015,34 +1015,26 @@ if(NAFF)
 endif(NAFF)
 
 if(BOINC AND API)
+  find_library(stdc++ STATIC stdc++)
   include_directories(${BOINC_DIR}/api ${BOINC_DIR}/lib ${BOINC_DIR})
 
-  #The fortran interface needs boinc_api_fortran.o building, which does not seem to happen by default
-  #go into the boinc source folder, cd api; make boinc_api_fortran.o
-  add_library(boinc_api_fortran STATIC IMPORTED)
-  set_target_properties(boinc_api_fortran PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/boinc_api_fortran.o)
-  # add_library(boinc_api_fortran STATIC ${BOINC_DIR}/api/boinc_api_fortran.cpp) #Alternative way of building and linking boinc_api_fortran.cpp/.o
-  target_link_libraries(SixTrackLib boinc_api_fortran)
+  add_library(boinc       STATIC IMPORTED)
+  add_library(boinc_api   STATIC IMPORTED)
+  add_library(boinc_api_f STATIC IMPORTED)
 
-  #add the libs
-  add_library(boinc STATIC IMPORTED)
-  set_target_properties(boinc PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/lib/libboinc.a)
+  set_target_properties(boinc       PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/lib/libboinc.a)
+  set_target_properties(boinc_api   PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/libboinc_api.a)
+  set_target_properties(boinc_api_f PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/boinc_api_fortran.o)
 
-  add_library(boinc_api STATIC IMPORTED)
-  set_target_properties(boinc_api PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/libboinc_api.a)
-  target_link_libraries(SixTrackLib boinc_api)
-
-  target_link_libraries(SixTrackLib boinc)
-
-  find_library(stdc++ STATIC stdc++)
-  target_link_libraries(SixTrackLib stdc++ Threads::Threads)
+  target_link_libraries(SixTrackCR boinc_api_f boinc_api boinc stdc++)
+  # target_link_libraries(SixTrackCR Threads::Threads)
 
   # if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   #   find_library(nsl STATIC nsl)
   #   target_link_libraries(SixTrackCR nsl)
   # endif()
 
-  #fix osx linking to the correct c++ stdlib
+  # Fix OSX linking to the correct c++ stdlib
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_library(c++ STATIC c++)
     target_link_libraries(SixTrackLib c++)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1022,7 +1022,7 @@ if(BOINC AND API)
   add_library(boinc_api_fortran STATIC IMPORTED)
   set_target_properties(boinc_api_fortran PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/boinc_api_fortran.o)
   # add_library(boinc_api_fortran STATIC ${BOINC_DIR}/api/boinc_api_fortran.cpp) #Alternative way of building and linking boinc_api_fortran.cpp/.o
-  target_link_libraries(SixTrackCR boinc_api_fortran)
+  target_link_libraries(SixTrackLib boinc_api_fortran)
 
   #add the libs
   add_library(boinc STATIC IMPORTED)
@@ -1030,9 +1030,9 @@ if(BOINC AND API)
 
   add_library(boinc_api STATIC IMPORTED)
   set_target_properties(boinc_api PROPERTIES IMPORTED_LOCATION ${BOINC_DIR}/api/libboinc_api.a)
-  target_link_libraries(SixTrackCR boinc_api)
+  target_link_libraries(SixTrackLib boinc_api)
 
-  target_link_libraries(SixTrackCR boinc)
+  target_link_libraries(SixTrackLib boinc)
 
   find_library(stdc++ STATIC stdc++)
   target_link_libraries(SixTrackLib stdc++ Threads::Threads)
@@ -1045,7 +1045,7 @@ if(BOINC AND API)
   #fix osx linking to the correct c++ stdlib
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_library(c++ STATIC c++)
-    target_link_libraries(SixTrackCR c++)
+    target_link_libraries(SixTrackLib c++)
   endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -162,13 +162,20 @@ end interface
 
   ! ---------------------------------------------------------------------------------------------- !
   errout_status = 0 ! Set to nonzero before calling abend in case of error.
+
+  call units_initUnits
+#ifdef BOINC
+  call boinc_init()
+! call boinc_init_graphics()
+#endif
+#ifdef CR
   lout = 92
-#ifndef CR
+  call units_openUnit(unit=lout,fileName="fort.92",formatted=.true.,mode="rw",err=fErr,status="replace")
+#else
   lout = output_unit
 #endif
 
   call funit_initUnits ! This one has to be first
-  call units_initUnits ! And this one second
   call meta_initialise ! The meta data file.
   call time_initialise ! The time data file. Need to be as early as possible as it sets cpu time 0.
   call alloc_init      ! Initialise mod_alloc
@@ -215,8 +222,6 @@ end interface
 #endif
 #ifdef BOINC
   featList = featList//" BOINC"
-  call boinc_init()
-! call boinc_init_graphics()
 #endif
 #ifdef LIBARCHIVE
   featList = featList//" LIBARCHIVE"
@@ -255,11 +260,6 @@ end interface
 #ifdef BOINC
 611 continue
 #endif
-  ! Very first get rid of any previous partial output
-  inquire(unit=lout, opened=isOpen)
-  if(isOpen) close(lout)
-  call units_openUnit(unit=lout,fileName="fort.92",formatted=.true.,mode="rw",err=fErr,status="replace")
-
   ! Now position the checkpoint/restart logfile=93
   call units_openUnit(unit=93,fileName="fort.93",formatted=.true.,mode="rw",err=fErr)
 606 continue

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -162,20 +162,18 @@ end interface
 
   ! ---------------------------------------------------------------------------------------------- !
   errout_status = 0 ! Set to nonzero before calling abend in case of error.
-
-  call units_initUnits
-#ifdef BOINC
-  call boinc_init()
-! call boinc_init_graphics()
-#endif
 #ifdef CR
   lout = 92
-  call units_openUnit(unit=lout,fileName="fort.92",formatted=.true.,mode="rw",err=fErr,status="replace")
 #else
   lout = output_unit
 #endif
 
+#ifdef BOINC
+  call boinc_init
+! call boinc_init_graphics
+#endif
   call funit_initUnits ! This one has to be first
+  call units_initUnits ! And this one second
   call meta_initialise ! The meta data file.
   call time_initialise ! The time data file. Need to be as early as possible as it sets cpu time 0.
   call alloc_init      ! Initialise mod_alloc
@@ -259,7 +257,13 @@ end interface
 
 #ifdef BOINC
 611 continue
+  ! Goes here after unzip for BOINC
 #endif
+  ! Very first get rid of any previous partial output
+  inquire(unit=lout, opened=isOpen)
+  if(isOpen) close(lout)
+  call units_openUnit(unit=lout,fileName="fort.92",formatted=.true.,mode="rw",err=fErr,status="replace")
+
   ! Now position the checkpoint/restart logfile=93
   call units_openUnit(unit=93,fileName="fort.93",formatted=.true.,mode="rw",err=fErr)
 606 continue

--- a/source/mod_units.f90
+++ b/source/mod_units.f90
@@ -27,13 +27,13 @@ subroutine units_openUnit(unit,fileName,formatted,mode,err,status,recl)
 
   implicit none
 
-  integer,                    intent(in)    :: unit
-  character(len=*),           intent(in)    :: fileName
-  logical,                    intent(in)    :: formatted
-  character(len=*),           intent(in)    :: mode
-  logical,                    intent(inout) :: err
-  character(len=*), optional, intent(in)    :: status
-  integer,          optional, intent(in)    :: recl
+  integer,                    intent(in)  :: unit
+  character(len=*),           intent(in)  :: fileName
+  logical,                    intent(in)  :: formatted
+  character(len=*),           intent(in)  :: mode
+  logical,                    intent(out) :: err
+  character(len=*), optional, intent(in)  :: status
+  integer,          optional, intent(in)  :: recl
 
   type(unitSpec),   allocatable :: tmpUnits(:)
   character(len=:), allocatable :: fFileName, fStatus, fAction, fPosition
@@ -122,36 +122,39 @@ subroutine units_openUnit(unit,fileName,formatted,mode,err,status,recl)
   units_uList(units_nList)%recl      = fRecl
   units_uList(units_nList)%open      = .true.
 
+  err = .false.
   if(formatted) then
     if(fRecl > 0) then
       if(fFio) then
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,round="nearest",recl=fRecl)
+          action=fAction,position=fPosition,round="nearest",recl=fRecl,err=10)
       else
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,recl=fRecl)
+          action=fAction,position=fPosition,recl=fRecl,err=10)
       end if
     else
       if(fFio) then
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,round="nearest")
+          action=fAction,position=fPosition,round="nearest",err=10)
       else
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition)
+          action=fAction,position=fPosition,err=10)
       end if
     end if
   else
     open(unit,file=fFileName,form="unformatted",status=fStatus,iostat=ioStat,&
-      action=fAction,position=fPosition)
+      action=fAction,position=fPosition,err=10)
   endif
 
   if(ioStat /= 0) then
     err = .true.
     write(lout,"(a,i0)") "UNITS> File '"//trim(fFileName)//"' reported iostat = ",ioStat
-  else
-    err = .false.
   end if
   return
+
+10 continue
+  err = .true.
+  write(lout,"(a)") "UNITS> File '"//trim(fFileName)//"' reported an error"
 
 end subroutine units_openUnit
 

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -2186,16 +2186,16 @@ subroutine callcrp
   endif
 #ifdef BOINC
   if (checkp) then
-! Now ALWAYS checkpoint
-! NO, re-instated at user request
+    ! Now ALWAYS checkpoint
+    ! NO, re-instated at user request
+    ! What was the user request?
     call boinc_time_to_checkpoint(timech)
-    if (timech.ne.0) then
+    if (timech /= 0) then
       call crpoint
       call boinc_checkpoint_completed()
     endif
   endif
-#endif
-#ifndef BOINC
+#else
   if (checkp) call crpoint
 #endif
   return


### PR DESCRIPTION
A few tweaks here and there, in CMake and main_cr mainly, while trying to sort out the segfault issues on debian/ubuntu with gcc/gfortran.

This PR also bumps the BOINC API to latest client version, 7.14.2.

Needs testing on Windows, both for changes here, and those from PRs #743 and #732.