### PR TITLE
Release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # SixTrack Changelog
 
-### Version 5.1.0 [11.12.2018] - BOINC Release
+### Version 5.1.1 [13.12.2018] - BOINC Release
+
+**BOINC Specific Changes**
+
+* Updated to use BOINC lib and API 7.14.2.
+
+**Known Issues**
+
+* BOINC with API does not run properly when built on latest Ubuntu LTS and Debian when both the BOINC API and SixTrack is built with the Gnu compiler. Mixing gcc and ifort or nagfor runs fine. This does not seem to be an issue when building on fedora and CentOS. The executables provided for this release are built on CentOS 7.
+
+**Test Suite**
+
+* A test can now be configured to automaticall stop on certain turn numbers using the `CRKILLSWITCH` flag in the `SETTINGS` block. This will help ensuring that tests actually restart from checkpoint data.
+* The test suite can now verify that specified tests actually do restart when building with checkpoint/restart support.
+
+### Version 5.1.0 [11.12.2018] - Release
 
 While this release includes regular bug fixes and changes, the primary focus is on making code improvements that allows for a wider range of studies to be run on BOINC.
 

--- a/lib/buildBoinc.sh
+++ b/lib/buildBoinc.sh
@@ -14,7 +14,7 @@ cd boinc
 if [[ $(uname) == FreeBSD* ]]; then
     MAKE=/usr/local/bin/gmake ./_autosetup -f
 elif [[ $(uname) == OpenBSD* ]]; then
-#These numbers will need updating in the future.
+    # These numbers will need updating in the future.
     AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.15 MAKE=/usr/local/bin/gmake ./_autosetup -f
 elif [[ $(uname) == NetBSD* ]]; then
     MAKE=/usr/pkg/bin/gmake ./_autosetup -f
@@ -26,33 +26,12 @@ fi
 
 ./configure --disable-client --disable-server --disable-manager --disable-boinczip
 
-# This is a terrible hack for building on MinGW, but it works.
-# Line numbers may need to be updated if BOINC is updated.
-if [[ $(uname) == MINGW* ]]; then
-    cd lib
-
-    if [ ! -f "boinc_win.h.bak" ]; then
-        mv boinc_win.h boinc_win.h.bak
-        cat boinc_win.h.bak | head -n27 > boinc_win.h
-        echo "#include \"windows.h\"" >> boinc_win.h
-        cat boinc_win.h.bak | tail -n+28 >> boinc_win.h
-    fi
-
-    if [ ! -f "util.cpp.bak" ]; then
-        mv util.cpp util.cpp.bak
-        cat util.cpp.bak | head -n631 > util.cpp
-        echo "int get_real_executable_path(char* , size_t ) {return ERR_NOT_IMPLEMENTED;}" >> util.cpp
-    fi
-
-    cd ..
-fi
-
 if [[ $(pwd) == /afs/* ]]; then
-    #AFS doesn't like hardlinks between files in different directories and configure doesn't check for this corner case...
+    # AFS doesn't like hardlinks between files in different directories and configure doesn't check for this corner case...
     sed -i 's/\/bin\/ln/cp/g' Makefile
     sed -i 's/\/bin\/ln/cp/g' api/Makefile
     sed -i 's/\/bin\/ln/cp/g' lib/Makefile
-    #AFS doesn't like parallel make
+    # AFS doesn't like parallel make
     make
 else
     # Machines with low memory doesn't like an automatic -j

--- a/source/version.f90
+++ b/source/version.f90
@@ -1,7 +1,7 @@
 module mod_version
   ! Keep data type in sync with 'cr_version' and 'cr_moddate'
-  character(len=8),  parameter :: version = "5.1.0"
-  integer,           parameter :: numvers = 50100
-  character(len=10), parameter :: moddate = "11.12.2018"
+  character(len=8),  parameter :: version = "5.1.1"
+  integer,           parameter :: numvers = 50101
+  character(len=10), parameter :: moddate = "13.12.2018"
   character(len=40), parameter :: git_revision = SIXTRACK_GIT_REVISION ! Git hash set by CMake
 end module mod_version


### PR DESCRIPTION
Version bump and latest Boinc version.
Using latest Boinc fixes most build issues on Windows, but the issue with `windows.h` remains. This PR runs of a branch that fixes this in our Boinc fork.