### PR TITLE
Boinc Sixin.zip fix

### DIFF
--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -166,7 +166,7 @@ subroutine aperture_comnul
   end do
 
   ldmpaper            = .false.
-  aperunit            = 0
+  aperunit            = -1
   aper_filename(1:16) = ' '
   ldmpaperMem         = .false.
   loadunit            = 3 ! default: read aperture markers in fort.3
@@ -217,7 +217,7 @@ end subroutine aperture_comnul
 ! ================================================================================================ !
 subroutine aperture_init
 
-  use mod_units, only: f_open
+  use mod_units, only: f_open, f_requestUnit
   
   implicit none
 
@@ -272,7 +272,8 @@ subroutine aperture_init
     else
 #endif
        
-      inquire(unit=losses_unit, opened=isOpen) ! Was 999
+    call f_requestUnit(losses_filename,losses_unit)
+    inquire(unit=losses_unit, opened=isOpen) ! Was 999
       if(isOpen) then
         write(lout,"(a,i0,a)") "APER> ERROR Unit ",losses_unit," is already open."
         call prror(-1)
@@ -2938,16 +2939,6 @@ end subroutine aper_inputParsingDone
 !  END APERTURE LIMITATIONS PARSING
 ! ================================================================================================ !
 
-subroutine aper_postInput
-
-  use mod_units
-  implicit none
-
-  ! request unit
-  call f_requestUnit(trim(losses_filename),losses_unit)
-
-end subroutine aper_postInput
-
 ! ================================================================================================================================ !
 !  Begin Checkpoint Restart
 ! ================================================================================================================================ !
@@ -2979,7 +2970,7 @@ subroutine aper_crcheck_positionFiles
   use crcoall
   use string_tools
   use mod_common
-  use mod_units, only: f_open, f_close
+  use mod_units, only: f_open, f_close, f_requestUnit
 
   implicit none
 
@@ -2987,10 +2978,11 @@ subroutine aper_crcheck_positionFiles
   logical lerror,lopen,err
   character(len=1024) arecord
 
-  write(93,*) "SIXTRACR CRCHECK REPOSITIONING file of APERTURE LOSSES to apefilepos_cr=",apefilepos_cr
+  call f_requestUnit(losses_filename,losses_unit)
+  write(93,"(a,i0)") "SIXTRACR> CRCHECK REPOSITIONING file of APERTURE LOSSES to apefilepos_cr = ",apefilepos_cr
   flush(93)
 
-  inquire( unit=losses_unit, opened=lopen )
+  inquire(unit=losses_unit, opened=lopen)
   if (.not. lopen) call f_open(unit=losses_unit,file=losses_filename,status='old',formatted=.true.,mode='rw',err=err)
 
   apefilepos = 0

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -218,7 +218,7 @@ end subroutine aperture_comnul
 subroutine aperture_init
 
   use mod_units, only: f_open, f_requestUnit
-  
+
   implicit none
 
 #ifdef HDF5
@@ -259,7 +259,7 @@ subroutine aperture_init
     call h5_createDataSet("losses", h5_aperID, aper_fmtLostPart, aper_setLostPart)
   else
 #endif
-     
+
 #ifdef CR
     if (apefilepos >= 0) then
       ! Expect the file to be opened already, in crcheck
@@ -271,7 +271,7 @@ subroutine aperture_init
       end if
     else
 #endif
-       
+
     call f_requestUnit(losses_filename,losses_unit)
     inquire(unit=losses_unit, opened=isOpen) ! Was 999
       if(isOpen) then
@@ -283,7 +283,7 @@ subroutine aperture_init
 #ifdef CR
       apefilepos=0
 #endif
-    
+
       write(losses_unit,"(a)") "# turn block bezid bez slos "// &
 #ifdef FLUKA
         "fluka_uid fluka_gen fluka_weight "// &
@@ -511,7 +511,7 @@ subroutine aperture_saveLastCoordinates( i, ix, iBack )
   integer i, ix, iBack
   ! temporary variables
   integer j
-  
+
   do j=1,napx
     xLast(1,j) = xv1(j)
     xLast(2,j) = xv2(j)
@@ -2585,7 +2585,7 @@ subroutine aper_parseInputLine(inLine, iLine, iErr)
   real(kind=fPrec) tmplen,tmpflts(3)
   integer          nSplit, i
   logical          spErr, lExist, apeFound, err
-  
+
   call chr_split(inLine, lnSplit, nSplit, spErr)
   if(spErr) then
     write(lout,"(a)") "LIMI> ERROR Failed to parse input line."
@@ -2631,7 +2631,7 @@ subroutine aper_parseInputLine(inLine, iLine, iErr)
     if(nSplit .eq. 3) then
       if(lnSPlit(3) == "MEM") then
         ldmpaperMem=.true.
-      else 
+      else
         write(lout,"(a,a)") "LIMI> ERROR Unknown third argument to PRIN keyword: ",lnSPlit(3)
         iErr = .true.
         return
@@ -2680,7 +2680,7 @@ subroutine aper_parseInputLine(inLine, iLine, iErr)
     write(lout,"(a)") "LIMI> ERROR Dump of aperture cross sections at specific locations are not available yet"
     iErr = .true.
     return
-    
+
     ! A.Mereghetti, 22-03-2018
     ! ask for xsec at specific locations
     ! example input line:        XSEC myCrossSec.dat 12355.78 12356.78 0.1 180

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -328,8 +328,6 @@ end interface
 #endif
 
   ! Open Regular File Units
-  call f_open(unit=2, file="fort.2", formatted=.true., mode="r", err=fErr) ! Should be opened in DATEN
-  call f_open(unit=3, file="fort.3", formatted=.true., mode="r", err=fErr) ! Should be opened in DATEN
   call f_open(unit=7, file="fort.7", formatted=.true., mode="w", err=fErr,recl=303)
   call f_open(unit=9, file="fort.9", formatted=.true., mode="w", err=fErr)
   call f_open(unit=11,file="fort.11",formatted=.true., mode="w", err=fErr)

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -91,8 +91,6 @@ featList = ""
 
   ! Open files
   fErr = .false.
-  call f_open(unit=2,  file="fort.2",  formatted=.true., mode="r", err=fErr)
-  call f_open(unit=3,  file="fort.3",  formatted=.true., mode="r", err=fErr)
   call f_open(unit=12, file="fort.12", formatted=.true., mode="w", err=fErr)
   call f_open(unit=18, file="fort.18", formatted=.true., mode="rw",err=fErr)
   call f_open(unit=19, file="fort.19", formatted=.true., mode="w", err=fErr)

--- a/source/mod_units.f90
+++ b/source/mod_units.f90
@@ -333,7 +333,7 @@ end subroutine f_open
 subroutine f_close(unit)
 
   use, intrinsic :: iso_fortran_env, only : error_unit
-  
+
   integer, intent(in) :: unit
 
   integer i
@@ -409,7 +409,7 @@ subroutine f_writeLog(action,unit,status,file)
   character(len=8)  wAction
   character(len=8)  wStatus
   character(len=64) wFile
-  
+
   if(units_logUnit <= 0) return ! Only write if we have a log file
 
   wAction = action

--- a/source/mod_units.f90
+++ b/source/mod_units.f90
@@ -272,23 +272,23 @@ subroutine f_open(unit,file,formatted,mode,err,status,recl)
     if(fRecl > 0) then
       if(fFio) then
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,round="nearest",recl=fRecl)
+          action=fAction,position=fPosition,round="nearest",recl=fRecl,err=10)
       else
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,recl=fRecl)
+          action=fAction,position=fPosition,recl=fRecl,err=10)
       end if
     else
       if(fFio) then
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition,round="nearest")
+          action=fAction,position=fPosition,round="nearest",err=10)
       else
         open(unit,file=fFileName,form="formatted",status=fStatus,iostat=ioStat,&
-          action=fAction,position=fPosition)
+          action=fAction,position=fPosition,err=10)
       end if
     end if
   else
     open(unit,file=fFileName,form="unformatted",status=fStatus,iostat=ioStat,&
-      action=fAction,position=fPosition)
+      action=fAction,position=fPosition,err=10)
   endif
 
   if(ioStat /= 0) then
@@ -309,6 +309,17 @@ subroutine f_open(unit,file,formatted,mode,err,status,recl)
   end if
   if(present(err)) then
     err = .false.
+  end if
+  return
+
+10 continue
+  call f_writeLog("OPEN",unit,"ERROR",file)
+  if(present(err)) then
+    err = .true.
+    write(error_unit,"(a)") "UNITS> Could not open '"//trim(file)//"'"
+  else
+    write(error_unit,"(a)") "UNITS> ERROR Could not open '"//trim(file)//"'"
+    call prror
   end if
 
 end subroutine f_open

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -236,7 +236,7 @@ subroutine daten
 
   call f_open(unit=3,file="fort.3",formatted=.true.,mode="r",err=fErr)
   if(fErr) then
-    write(lout,"(a)") "INPUT> ERROR Could not open fort.2"
+    write(lout,"(a)") "INPUT> ERROR Could not open fort.3"
     call prror
   end if
 

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -234,7 +234,7 @@ subroutine daten
 ! ================================================================================================ !
 
 90 continue
-  read(3,"(a4,a8,a60)",end=9998,iostat=ierro) cCheck,cPad,iHead
+  read(3,"(a4,a8,a60)",end=9997,iostat=ierro) cCheck,cPad,iHead
   if(ierro > 0) then
     write(lout,"(a)") "INPUT> ERROR Could not read from fort.3"
     call prror(-1)
@@ -957,8 +957,6 @@ subroutine daten
 
   end if
  
-  call aper_postInput
-  
   call elens_postInput
 
   if(idp == 0 .or. ition == 0 .or. nbeam < 1) then
@@ -1238,9 +1236,14 @@ subroutine daten
 !  END OF INPUT PARSING
 ! ================================================================================================ !
 
+9997 continue
+  write(lout,"(a)") "INPUT> ERROR Header could not be read from fort.3"
+  call prror
+  return
+
 9998 continue
   write(lout,"(a,i0,a)") "INPUT> ERROR fort.",nUnit," is missing or empty, or end was reached without an ENDE flag."
-  call prror(-1)
+  call prror
   return
 
 9999 continue
@@ -1257,7 +1260,7 @@ subroutine daten
       write(lout,"(i5,a)") lineNo3-5+i," | "//trim(pLines(i))
     end do
   end if
-  call prror(-1)
+  call prror
   return
 
 end subroutine daten

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -924,7 +924,7 @@ subroutine daten
     call hions_postInput
     gammar = nucm0/e0
     betrel = sqrt((one+gammar)*(one-gammar))
-    
+
     if(nbeam >= 1) then
       parbe14 = (((((-one*crad)*partnum)/four)/pi)/sixin_emitNX)*c1e6
     end if
@@ -956,7 +956,7 @@ subroutine daten
     endif
 
   end if
- 
+
   call elens_postInput
 
   if(idp == 0 .or. ition == 0 .or. nbeam < 1) then


### PR DESCRIPTION
Tests with BOINC build failed due to extraction of Sixin.zip not triggering. Issue resolved.

In the process, I also clarified an error message in daten, moved the opening of fort.2 and fort.3 there, and came across an issue with restarting aperture_losses file when running CR.

Note: file unit variables should never be initialised as 0, because 0 is the error unit. They should always be initialised as -1, which will cause a critical error if uninitialised when writing occurs. I.e. easier to trap.