### PR TITLE
Fixing parsing file of aperture

### DIFF
--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -2518,7 +2518,7 @@ subroutine aper_parseLoadFile(load_file, iLine, iErr)
 
   implicit none
 
-  character(len=16),intent(in)    :: load_file
+  character(len=64),intent(in)    :: load_file
   integer,          intent(in)    :: iLine
   logical,          intent(inout) :: iErr
 
@@ -2580,7 +2580,7 @@ subroutine aper_parseInputLine(inLine, iLine, iErr)
   logical,          intent(inout) :: iErr
 
   character(len=:), allocatable   :: lnSplit(:)
-  character(len=16)               :: load_file
+  character(len=64)               :: load_file
   real(kind=fPrec) tmplen,tmpflts(3)
   integer          nSplit, i
   logical          spErr, lExist, apeFound, err

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -2546,9 +2546,11 @@ subroutine aper_parseLoadFile(load_file, iLine, iErr)
   end if
   lineNo = lineNo + 1
 
-  if(len_trim(unitLine) == 0) goto 10 ! Empty line, ignore
-  if(unitLine(1:1) == "/")    goto 10 ! Comment line, ignore
-  if(unitLine(1:1) == "!")    goto 10 ! Comment line, ignore
+  if(len_trim(unitLine) == 0)  goto 10 ! Empty line, ignore
+  if(unitLine(1:1) == "/")     goto 10 ! Comment line, ignore
+  if(unitLine(1:1) == "!")     goto 10 ! Comment line, ignore
+  if(unitLine(1:4) == "LIMI")  goto 10 ! header from MADX, ignore
+  if(unitLine(1:4) == "NEXT")  goto 10 ! closure by MADX, ignore
 
   call aper_parseInputLine(unitLine, iLine, iErr)
   if(iErr) then
@@ -2666,6 +2668,8 @@ subroutine aper_parseInputLine(inLine, iLine, iErr)
     else
       bktpre = tmplen
     endif
+    lbacktracking=.true.
+    write(lout,"(a)") "LIMI> Backtracking is on."
 
   case("XSEC")
     write(lout,"(a)") "LIMI> ERROR Dump of aperture cross sections at specific locations are not available yet"

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -763,11 +763,10 @@ subroutine daten
   case("LIMI") ! Aperture Limitations
     if(openBlock) then
       lbacktracking = .true.
-      loadunit      = 3
     elseif(closeBlock) then
       call aper_inputParsingDone
     else
-      call aper_inputUnitWrapper(inLine,blockLine,inErr)
+      call aper_parseInputLine(inLine,blockLine,inErr)
       if(inErr) goto 9999
     end if
 


### PR DESCRIPTION
This PR fixes issues with parsing aperture file from `LOAD` statement, so that:
   * any keyword in the `LIMI` block is no longer ignored, as it was the case so far;
   * the code is cleaner.
