### PR TITLE
Pi to numerical_constants

### DIFF
--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -128,12 +128,6 @@ module mod_common
   real(kind=fPrec),  parameter :: ylim       = 4.29_fPrec             ! Used in errf
   real(kind=fPrec),  parameter :: eps_dcum   = c1m6                   ! Tolerance for machine length mismatch [m]
 
-  ! Pi Constants
-  real(kind=fPrec),  save      :: pi2        = half*pi
-  real(kind=fPrec),  save      :: twopi      = two*pi
-  real(kind=fPrec),  save      :: pisqrt     = sqrt(pi)
-  real(kind=fPrec),  save      :: rad        = pi/c180e0
-
   ! Various Flags and Variables
   character(len=80), save      :: toptit(5)  = " "     ! DANGER: If the len changes, CRCHECK will break
   character(len=80), save      :: sixtit     = " "     ! DANGER: If the len changes, CRCHECK will break
@@ -1180,7 +1174,7 @@ module mod_lie_dab
   integer,          save :: nplane(ndim),ista(ndim),idsta(ndim)
   integer,          save :: mx(ndim,nreso),nres
   real(kind=fPrec), save :: epsplane,xplane(ndim)
-  real(kind=fPrec), save :: sta(ndim),dsta(ndim),angle(ndim),rad(ndim)
+  real(kind=fPrec), save :: sta(ndim),dsta(ndim),angle(ndim),radn(ndim)
   real(kind=fPrec), save :: ps(ndim),rads(ndim)
   real(kind=fPrec), save :: xintex(0:20)
 

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -61,6 +61,11 @@ module numerical_constants
   real(kind=fPrec), parameter :: pi         = 3.141592653589793238462643383279502884197169399375105820974_fPrec
   real(kind=fPrec), parameter :: inv_ln2    = 1.442695040888963407359924681001892137426645954152985934135_fPrec
 
+  real(kind=fPrec), parameter :: pi2    = 0.5_fPrec*pi
+  real(kind=fPrec), parameter :: twopi  = 2.0_fPrec*pi
+  real(kind=fPrec), parameter :: pisqrt = sqrt(pi)
+  real(kind=fPrec), parameter :: rad    = pi/180.0_fPrec
+
   real(kind=fPrec), parameter :: pieni  = 1e-38_fPrec
 
   real(kind=fPrec), parameter :: zero   = 0.0_fPrec

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -13,10 +13,10 @@ subroutine daliesix
 
   integer i,mf1,mf2,mf3,mf4,mf5,mfile,nd2,ndim,ndpt,nis,no,nv,damap,a1,a1i,a2,a2i,f,fc,fs,rot,xy,h,hc,hs,h4,df,bb1,bb2,haux
   real tlim,time0,time1,time
-  real(kind=fPrec) angle,coe,rad,x2pi
+  real(kind=fPrec) angle,coe,radn,x2pi
   dimension damap(6),a1(6),a1i(6),a2(6),a2i(6)
   dimension rot(6),xy(6),df(6)
-  dimension angle(3),rad(3)
+  dimension angle(3),radn(3)
 
   save
 
@@ -81,7 +81,7 @@ subroutine daliesix
   call dainv(a1,nv,a1i,nv)
   call dainv(a2,nv,a2i,nv)
   call ctor(f,fc,fs)
-  call gettura(angle,rad)
+  call gettura(angle,radn)
   call taked(xy,1,rot)
   call take(h,2,haux)
   call dasub(h,haux,h4)


### PR DESCRIPTION
Moved the four variables based on pi to numerical_constants and changed them to parameters.

Not sure why this wasn't done when the many definitions of pi were cleaned up.