### PR TITLE
Fixes for 5.2

### DIFF
--- a/source/cheby.f90
+++ b/source/cheby.f90
@@ -81,7 +81,7 @@ subroutine cheby_kick(jcheby)
     ! check that particle is within the domain of chebyshev polynomials
     rr=sqrt(xx**2+yy**2)
     if (rr.gt.cheby_refRadius(cheby_itable(jcheby))) then
-      write(lout,"(a,3(e12.6,1x),a,e12.6)") "CHEBY> ERROR in cheby_kick: particle at position (x,y,r): ",&
+      write(lout,"(a,3(e13.6,1x),a,e13.6)") "CHEBY> ERROR in cheby_kick: particle at position (x,y,r): ",&
         xv1(j), xv2(j), rr,' is outside radial domain of Chebyshev polinomials: ',cheby_refRadius(cheby_itable(jcheby))
       call prror
     end if

--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1755,13 +1755,10 @@ subroutine collimate_start_sample(nsample)
       if (firstrun) then
         write(all_impacts_unit,'(a)') '# 1=name 2=turn 3=s'
         write(all_absorptions_unit,'(a)') '# 1=name 2=turn 3=s'
-        write(FirstImpacts_unit,*)                                                   &
-        '%1=name,2=iturn, 3=icoll, 4=nabs, 5=s_imp[m], 6=s_out[m], ',&
-        '7=x_in(b!)[m], 8=xp_in, 9=y_in, 10=yp_in, ',                &
-        '11=x_out [m], 12=xp_out, 13=y_out, 14=yp_out'
-        write(coll_scatter_unit,*) &
-        "#1=icoll, 2=iturn, 3=np, 4=nabs (1:Nuclear-Inelastic,2:Nuclear-Elastic,3:pp-Elastic,4:Single-Diffractive,5:Coulomb)", &
-        ", 5=dp, 6=dx', 7=dy'"
+        write(FirstImpacts_unit,"(a)") "# 1=name, 2=iturn, 3=icoll, 4=nabs, 5=s_imp[m], 6=s_out[m], "//&
+          "7=x_in(b!)[m], 8=xp_in, 9=y_in, 10=yp_in, 11=x_out [m], 12=xp_out, 13=y_out, 14=yp_out"
+        write(coll_scatter_unit,"(a)") "# 1=icoll, 2=iturn, 3=np, 4=nabs (1:Nuclear-Inelastic,2:Nuclear-Elastic,3:pp-Elastic, "//&
+          "4:Single-Diffractive,5:Coulomb), 5=dp, 6=dx', 7=dy'"
       end if ! if (firstrun) then
 #ifdef HDF5
     end if
@@ -3831,11 +3828,10 @@ subroutine collimate_exit()
   open(unit=betafunctions_unit, file='betafunctions.dat') !was 57
 
   if(dowrite_amplitude) then
-    write(amplitude_unit,*)                                             &
-     &'# 1=ielem 2=name 3=s 4=AX_AV 5=AX_RMS 6=AY_AV 7=AY_RMS',         &
-     &'8=alphax 9=alphay 10=betax 11=betay 12=orbitx',                  &
-     &'13=orbity 14=tdispx 15=tdispy',                                  &
-     &'16=xbob 17=ybob 18=xpbob 19=ypbob'
+    write(amplitude_unit,"(a)")                                         &
+      "# 1=ielem 2=name 3=s 4=AX_AV 5=AX_RMS 6=AY_AV 7=AY_RMS "//       &
+      "8=alphax 9=alphay 10=betax 11=betay 12=orbitx "//                &
+      "13=orbity 14=tdispx 15=tdispy 16=xbob 17=ybob 18=xpbob 19=ypbob"
 
     do i=1,iu
        write(amplitude_unit,'(i4, (1x,a16), 17(1x,e20.13))')             &!hr08
@@ -3852,21 +3848,21 @@ subroutine collimate_exit()
       &xbob(i),ybob(i),xpbob(i),ypbob(i)                                  !hr08
     end do
 
-    write(amplitude2_unit,*)'# 1=ielem 2=name 3=s 4=ORBITX 5=orbity 6=tdispx 7=tdispy 8=xbob 9=ybob 10=xpbob 11=ypbob'
+    write(amplitude2_unit,"(a)") "# 1=ielem 2=name 3=s 4=ORBITX 5=orbity 6=tdispx 7=tdispy 8=xbob 9=ybob 10=xpbob 11=ypbob"
 
     do i=1,iu
       write(amplitude2_unit,'(i4, (1x,a16), 9(1x,e15.7))') i, ename(i), sampl(i), torbx(i), torby(i), tdispx(i), tdispy(i), &
             xbob(i), ybob(i), xpbob(i), ypbob(i)
     end do
 
-    write(betafunctions_unit,*) '# 1=ielem 2=name       3=s             4=TBETAX(m)     5=TBETAY(m)     6=TORBX(mm)', &
-                '    7=TORBY(mm) 8=TORBXP(mrad)   9=TORBYP(mrad)  10=TDISPX(m)  11=MUX()    12=MUY()'
+    write(betafunctions_unit,"(a)") "# 1=ielem 2=name       3=s             4=TBETAX(m)     5=TBETAY(m)     6=TORBX(mm)"// &
+      "    7=TORBY(mm) 8=TORBXP(mrad)   9=TORBYP(mrad)  10=TDISPX(m)  11=MUX()    12=MUY()"
 
 
     do i=1,iu
 !     RB: added printout of closed orbit and angle
       write(betafunctions_unit,'(i5, (1x,a16), 10(1x,e15.7))') i, ename(i), sampl(i), tbetax(i), tbetay(i), torbx(i), torby(i), &
- &    torbxp(i), torbyp(i), tdispx(i), mux(i), muy(i)
+        torbxp(i), torbyp(i), tdispx(i), mux(i), muy(i)
     end do
   endif
 

--- a/test/collimation_k2_fcc_2017_h1_collision/hash.md5.canonical
+++ b/test/collimation_k2_fcc_2017_h1_collision/hash.md5.canonical
@@ -1,11 +1,11 @@
 ec8b671e40cc01e57a709151e03fca49  final_state.dat
 cc12aeb61d5a5571854c8a5e5df91449  all_absorptions.dat
 dcc20be5ada194f6a85268b7628151c9  all_impacts.dat
-9a2cf9c301a49cbecef90416c2abe51e  amplitude.dat
-1bc02f6265685ac29befb66784660282  amplitude2.dat
-0789fe51562bb3e912aeff4734a47864  Coll_Scatter.dat
+d76ff78608c831341453fad210bfd9c8  amplitude.dat
+35a436d16f2858872fd29e4e7e227cc5  amplitude2.dat
+b56c00540245b8ca225dde6889153e99  Coll_Scatter.dat
 741a05525b25c3b23e08fb5c6db7c414  FLUKA_impacts.dat
 0c5e5f62686943c0069d48fc19c4cad5  FLUKA_impacts_all.dat
-c422aa5736d615eeb500f50f8c8992f5  FirstImpacts.dat
+34b613f8d294753da1656bcc5e438050  FirstImpacts.dat
 fb846e04dfdbfaa0b8e2230e5d62e25b  dist0.dat
 9831e6a5b78c1e915011c07607148249  distn.dat


### PR DESCRIPTION
Fixes:
* Kills a warning in cheby.f90 when building with ifort
* Fixes headers of some of the collimation files which were written with format *, and thus looked different between gfortran and ifort. This failed the `collimation_k2_fcc_2017_h1_collision` test.