### PR TITLE
Manual to HTML fixes

### DIFF
--- a/doc/generateForWeb.sh
+++ b/doc/generateForWeb.sh
@@ -2,8 +2,9 @@
 
 #
 # This script generates the files necessary for the /SixTrack/web/docs folder on the website.
-# Requires the latexml package to be installed.
-# Written by Veronica Berglyd Olsen, Feb 2018
+# Requires the latexml package to be installed as well as image magick for figure conversion.
+# Written by Veronica Berglyd Olsen, Feb 2018. Updated 2019-04-08
+# Note: Does not seem to work with latexml 8.3. Please use 8.2.
 #
 
 CURR=$(pwd)
@@ -54,10 +55,12 @@ for FILE in *.tex; do
   sed -i 's/\\arraybackslash//g' $FILE
   sed -i '/\\todo/d' $FILE
   sed -i '/\\pdfbookmark/d' $FILE
+  sed -i '/\\tabulinesep/d' $FILE
 done
 
 # Build HTML
 latexml six.tex | latexmlpost --dest=$OUSERF/manual.html --format=$FORMAT --javascript=$MATHJAX - | tee ../htmlUserManual.log
+HTMEX=$?
 $CURR/cleanupHTML.py $OUSERF
 rm -v $OUSERF/*.html
 echo "<?php header('Location: manual.php'); ?>" > $OUSERF/index.php
@@ -87,6 +90,15 @@ echo ""
 echo "**********"
 echo "*  DONE  *"
 echo "**********"
+
+if [ $HTMEX != 0 ]; then
+  echo ""
+  echo "ERROR during HTML conversion. It may have failed."
+  echo "If the error is in converting figures to png, make sure the line"
+  echo "  <policy domain=\"coder\" rights=\"read|write\" pattern=\"PDF\" />"
+  echo "is set to read|write in /etc/ImageMagick/policy.xml"
+fi
+
 echo ""
 echo "The content of the folder 'html' can now be uploaded to /afs/cern.ch/project/sixtrack/web/docs/"
 echo "RUN: rsync -rvPh html/ /afs/cern.ch/project/sixtrack/docs/"

--- a/doc/generateForWeb.sh
+++ b/doc/generateForWeb.sh
@@ -17,7 +17,8 @@ OPHYS=$CURR/html/physics_full
 OBUILD=$CURR/html/build_full
 
 # LaTeXML Options
-MATHJAX='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML'
+#MATHJAX='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_CHTML'
+MATHJAX=$(locate LaTeXML-maybeMathjax.js)
 FORMAT=html5
 
 mkdir -pv $OUSERF
@@ -34,8 +35,8 @@ echo "*****************************************"
 echo ""
 
 # Make temp directory
-rm -rfv $TUSER
-rsync -avPh $MUSER/ $TUSER
+rm -rf $TUSER
+rsync -aPh $MUSER/ $TUSER
 cd $TUSER
 
 # Build PDF
@@ -59,8 +60,8 @@ for FILE in *.tex; do
 done
 
 # Build HTML
-latexml six.tex | latexmlpost --dest=$OUSERF/manual.html --format=$FORMAT --javascript=$MATHJAX - | tee ../htmlUserManual.log
-HTMEX=$?
+latexml six.tex | latexmlpost --dest=$OUSERF/manual.html --format=$FORMAT --javascript=$MATHJAX -
+HTMEX=@?
 $CURR/cleanupHTML.py $OUSERF
 rm -v $OUSERF/*.html
 echo "<?php header('Location: manual.php'); ?>" > $OUSERF/index.php
@@ -94,9 +95,10 @@ echo "**********"
 if [ $HTMEX != 0 ]; then
   echo ""
   echo "ERROR during HTML conversion. It may have failed."
-  echo "If the error is in converting figures to png, make sure the line"
+  echo "If the error is in converting figures to png, make sure the lines"
+  echo "  <policy domain=\"coder\" rights=\"read|write\" pattern=\"PS\" />"
   echo "  <policy domain=\"coder\" rights=\"read|write\" pattern=\"PDF\" />"
-  echo "is set to read|write in /etc/ImageMagick/policy.xml"
+  echo "are set to read|write in /etc/ImageMagick/policy.xml"
 fi
 
 echo ""

--- a/doc/user_manual/six.tex
+++ b/doc/user_manual/six.tex
@@ -64,14 +64,6 @@
   \endflushleft\normalsize
 }
 
-\newenvironment{description_alligned}[1]
-{\begin{list}{}%
-    {\renewcommand\makelabel[1]{##1:\hfill}%
-      \settowidth\labelwidth{\makelabel{#1}}%
-      \setlength\leftmargin{\labelwidth}
-      \addtolength\leftmargin{\labelsep}}}
-  {\end{list}}
-
 \setcounter{secnumdepth}{3}
 \setcounter{tocdepth}{3}
 \pagestyle{headings}


### PR DESCRIPTION
Just added a bit of extra code to the bash script to capture an Image Magick policy setting that may be wrong, and to kill a few errors from the .tex. The Image Magick setting prevented three figures from being converted to PDF.

Generally: The script does not seem to work with latexml 8.3. It does work with 8.2 still though.