### PR TITLE
Minor fix in String Tools

### DIFF
--- a/doc/user_manual/chIntroduction.tex
+++ b/doc/user_manual/chIntroduction.tex
@@ -160,3 +160,13 @@ When this flag is set, most values read from the file will be printed back with 
 
 In the following chapters, the input structure of SixTrack is discussed in detail.
 To facilitate the use of the program, a list of default values in Appendix~\ref{Default}, the input and output files are described in Appendix~\ref{Files}, and a description of the data structure of the binary data files in Appendix~\ref{Header}.
+
+% ================================================================================================================================ %
+\subsection{Input Values} \label{sec:invals}
+
+\paragraph{Integers} must be entered as plain integers.\\
+Examples \texttt{1, 1e3, 1d3}.
+\paragraph{Floats} can be entered as integers (converted during parsing) and standard Fortran floats.\\
+Examples \texttt{1, 1.0, 1.0e3, 1e3, 1.0d3, 1d3}.
+\paragraph{Strings} can be entered with both single and double quotes, and without quotes if the string contains no spaces or comment characters.
+\paragraph{Flags} accept the following entries: \texttt{.true./.false.}, \texttt{true/false}, \texttt{yes/no}, \texttt{on/off}, and \texttt{1/0}.

--- a/doc/user_manual/chIntroduction.tex
+++ b/doc/user_manual/chIntroduction.tex
@@ -167,6 +167,6 @@ To facilitate the use of the program, a list of default values in Appendix~\ref{
 \paragraph{Integers} must be entered as plain integers.\\
 Examples \texttt{1, 1e3, 1d3}.
 \paragraph{Floats} can be entered as integers (converted during parsing) and standard Fortran floats.\\
-Examples \texttt{1, 1.0, 1.0e3, 1e3, 1.0d3, 1d3}.
+Examples \texttt{1, 1.0, 1.0e3, 1e3, 1.0d3, 1d3, 1.0q3, 1q3}.
 \paragraph{Strings} can be entered with both single and double quotes, and without quotes if the string contains no spaces or comment characters.
-\paragraph{Flags} accept the following entries: \texttt{.true./.false.}, \texttt{true/false}, \texttt{yes/no}, \texttt{on/off}, and \texttt{1/0}.
+\paragraph{Flags} accept the following entries: \texttt{.true./.false.}, \texttt{true/false}, \texttt{yes/no}, \texttt{on/off}, and \texttt{1/0}. These are not case sensitive.

--- a/source/string_tools.f90
+++ b/source/string_tools.f90
@@ -1136,12 +1136,15 @@ subroutine str_toLog(theString, theValue, rErr)
   character(len=:), allocatable   :: tmpString
   integer                         :: readErr
 
-  tmpString = trim(theString%chr)
-  read(tmpString,*,iostat=readErr) theValue
-  if(readErr /= 0) then
-    write (lout,"(a,i0)") "TYPECAST> Failed to cast '"//tmpString//"' to logical width error ",readErr
-    rErr = .true.
-  end if
+  tmpString = chr_toLower(trim(theString%chr))
+  select case(tmpString)
+  case("true",".true.","on","1")
+    theValue = .true.
+  case("false",".false.","off","0")
+    theValue = .false.
+  case default
+    write (lout,"(a)") "TYPECAST> Failed to cast '"//trim(theString)//"' to logical"
+  end select
 
 end subroutine str_toLog
 
@@ -1156,18 +1159,14 @@ subroutine chr_toLog(theString, theValue, rErr)
   character(len=:), allocatable   :: tmpString
   integer                         :: readErr
 
-  tmpString = chr_toUpper(trim(theString))
+  tmpString = chr_toLower(trim(theString))
   select case(tmpString)
-  case("ON")
+  case("true",".true.","on","1")
     theValue = .true.
-  case("OFF")
+  case("false",".false.","off","0")
     theValue = .false.
   case default
-    read(tmpString,*,iostat=readErr) theValue
-    if(readErr /= 0) then
-      write (lout,"(a,i0)") "TYPECAST> Failed to cast '"//tmpString//"' to logical width error ",readErr
-      rErr = .true.
-    end if
+    write (lout,"(a)") "TYPECAST> Failed to cast '"//trim(theString)//"' to logical"
   end select
 
 end subroutine chr_toLog

--- a/source/string_tools.f90
+++ b/source/string_tools.f90
@@ -1144,6 +1144,7 @@ subroutine str_toLog(theString, theValue, rErr)
     theValue = .false.
   case default
     write (lout,"(a)") "TYPECAST> Failed to cast '"//trim(theString)//"' to logical"
+    rErr = .true.
   end select
 
 end subroutine str_toLog
@@ -1167,6 +1168,7 @@ subroutine chr_toLog(theString, theValue, rErr)
     theValue = .false.
   case default
     write (lout,"(a)") "TYPECAST> Failed to cast '"//trim(theString)//"' to logical"
+    rErr = .true.
   end select
 
 end subroutine chr_toLog


### PR DESCRIPTION
The routine to cast strings to logicals was updated in another branch, but never merged.
All of this was in the SIMU block PR. Moved here now.