### PR TITLE
Minor cleanup

### DIFF
--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -910,7 +910,6 @@ module mod_common_main
   integer,          allocatable, save :: iv(:)        ! (npart)
 
   ! Main 3
-  real(kind=fPrec), allocatable, save :: hv(:,:,:,:)   ! (6,2,npart,nblo)
   real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! (6,2,npart,nblo)
   real(kind=fPrec),              save :: tasau(6,6) = zero
   real(kind=fPrec),              save :: qwcs(3)    = zero
@@ -1034,7 +1033,6 @@ subroutine mod_commonmn_allocate_thickarrays
   implicit none
 
   call alloc(ekv,npart,nele,zero,'ekv')
-  call alloc(hv,6,2,npart,nblo,zero,'hv')
   call alloc(bl1v,6,2,npart,nblo,zero,'bl1v')
 
 end subroutine mod_commonmn_allocate_thickarrays
@@ -1049,7 +1047,6 @@ subroutine mod_commonmn_expand_thickarrays(nele_new, npart_new, nblo_new)
   integer,intent(in) :: nele_new, npart_new, nblo_new
 
   call alloc(ekv,npart_new,nele_new,zero,'ekv')
-  call alloc(hv,6,2,npart_new,nblo_new,zero,'hv')
   call alloc(bl1v,6,2,npart_new,nblo_new,zero,'bl1v')
 
 end subroutine mod_commonmn_expand_thickarrays

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -1025,18 +1025,6 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
 
 end subroutine mod_commonmn_expand_arrays
 
-subroutine mod_commonmn_allocate_thickarrays
-
-  use mod_alloc
-  use numerical_constants, only : zero
-
-  implicit none
-
-  call alloc(ekv,npart,nele,zero,'ekv')
-  call alloc(bl1v,6,2,npart,nblo,zero,'bl1v')
-
-end subroutine mod_commonmn_allocate_thickarrays
-
 subroutine mod_commonmn_expand_thickarrays(nele_new, npart_new, nblo_new)
 
   use mod_alloc
@@ -1046,8 +1034,8 @@ subroutine mod_commonmn_expand_thickarrays(nele_new, npart_new, nblo_new)
 
   integer,intent(in) :: nele_new, npart_new, nblo_new
 
-  call alloc(ekv,npart_new,nele_new,zero,'ekv')
-  call alloc(bl1v,6,2,npart_new,nblo_new,zero,'bl1v')
+  call alloc(ekv,     npart_new,nele_new,zero,"ekv")
+  call alloc(bl1v,6,2,npart_new,nblo_new,zero,"bl1v")
 
 end subroutine mod_commonmn_expand_thickarrays
 
@@ -1081,20 +1069,6 @@ module mod_commons
 
 contains
 
-subroutine mod_commons_allocate_thickarrays
-
-  use mod_alloc
-  use numerical_constants, only : zero
-
-  implicit none
-
-  call alloc(al,6,2,npart,nele,zero,'al')
-  call alloc(as,6,2,npart,nele,zero,'as')
-  call alloc(at,6,2,2,nele,zero,'at')
-  call alloc(a2,6,2,2,nele,zero,'a2')
-
-end subroutine mod_commons_allocate_thickarrays
-
 subroutine mod_commons_expand_thickarrays(nele_new, npart_new)
 
   use mod_alloc
@@ -1104,8 +1078,10 @@ subroutine mod_commons_expand_thickarrays(nele_new, npart_new)
 
   integer,intent(in) :: nele_new, npart_new
 
-    call alloc(al,6,2,npart_new,nele_new,zero,'al')
-    call alloc(as,6,2,npart_new,nele_new,zero,'as')
+  call alloc(al,6,2,npart_new,nele_new,zero,"al")
+  call alloc(as,6,2,npart_new,nele_new,zero,"as")
+  call alloc(at,6,2,2,        nele_new,zero,"at")
+  call alloc(a2,6,2,2,        nele_new,zero,"a2")
 
 end subroutine mod_commons_expand_thickarrays
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -862,8 +862,6 @@ module mod_common_main
   real(kind=fPrec),              save :: qwc(3)    = zero
   real(kind=fPrec),              save :: clo0(2)   = zero
   real(kind=fPrec),              save :: clop0(2)  = zero
-  real(kind=fPrec),              save :: eps(2)    = zero
-  real(kind=fPrec),              save :: epsa(2)   = zero
   real(kind=fPrec),              save :: ekk(2)    = zero
   real(kind=fPrec),              save :: cr(mmul)  = zero
   real(kind=fPrec),              save :: ci(mmul)  = zero

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -94,7 +94,7 @@ end interface
   real(kind=fPrec) alf0s1,alf0s2,alf0s3,alf0x2,alf0x3,alf0z2,alf0z3,amp00,bet0s1,bet0s2,bet0s3,     &
     bet0x2,bet0x3,bet0z2,bet0z3,chi,coc,dam1,dchi,dp0,dp00,dp10,dpsic,dps0,dsign,gam0s1,gam0s2,     &
     gam0s3,gam0x1,gam0x2,gam0x3,gam0z1,gam0z2,gam0z3,phag,r0,r0a,rat0,sic,tasia56,tasiar16,tasiar26,&
-    tasiar36,tasiar46,tasiar56,tasiar61,tasiar62,tasiar63,tasiar64,tasiar65,taus,x11,x13,damp
+    tasiar36,tasiar46,tasiar56,tasiar61,tasiar62,tasiar63,tasiar64,tasiar65,taus,x11,x13,damp,eps(2),epsa(2)
   integer idummy(6)
   character(len=4) cpto
 

--- a/source/mainarrays.f90
+++ b/source/mainarrays.f90
@@ -145,11 +145,11 @@ end subroutine expand_arrays
 ! Kicks off the allocation of the thick tracking arrays
 subroutine allocate_thickarrays
   use parpro
-  use mod_common_main, only : mod_commonmn_allocate_thickarrays
-  use mod_commons,  only : mod_commons_allocate_thickarrays
+  use mod_common_main, only : mod_commonmn_expand_thickarrays
+  use mod_commons,     only : mod_commons_expand_thickarrays
   implicit none
-  call mod_commonmn_allocate_thickarrays
-  call mod_commons_allocate_thickarrays
+  call mod_commonmn_expand_thickarrays(nele, npart, nblo)
+  call mod_commons_expand_thickarrays(nele, npart)
 end subroutine allocate_thickarrays
 
 ! Kicks off the allocation of the thick tracking arrays

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -148,8 +148,8 @@ subroutine blocksv
 
 #ifdef FLUKA
   ! Entirely re-initialise to 0.0 hv(...) and bl1v(...) arrays
-  hv(:,:,:)   = zero
-  bl1v(:,:,:) = zero
+  hv(:,:,:)     = zero
+  bl1v(:,:,:,:) = zero
 #endif
   do ia=1,napx
     do k=1,mblo

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -143,20 +143,9 @@ subroutine blocksv
   implicit none
 
   integer ia, ikk, j, jm, k, lkk, mkk
-  real(kind=fPrec) dpoff
-!     integer i,itiono,i1,i2,i3,ia,ia2,iar,iation,ib,ib0,ib1,ib2,ib3,id,&
-!    &idate,ie,ig,ii,ikk,im,imonth,iposc,irecuin,itime,ix,izu,j,j2,jj,  &
-!    &jm,k,kpz,kzz,l,lkk,ll,m,mkk,napxto,ncorruo,ncrr,nd,nd2,ndafi2,    &
-!    &nerror,nlino,nlinoo,nmz,nthinerr
-!     double precision alf0s1,alf0s2,alf0s3,alf0x2,alf0x3,alf0z2,alf0z3,&
-!    &amp00,bet0s1,bet0s2,bet0s3,bet0x2,bet0x3,bet0z2,bet0z3,chi,coc,   &
-!    &dam1,dchi,ddp1,dp0,dp00,dp10,dpoff,dpsic,dps0,dsign,gam0s1,gam0s2,&
-!    &gam0s3,gam0x1,gam0x2,gam0x3,gam0z1,gam0z2,gam0z3,phag,r0,r0a,rat0,&
-!    &rdev,rmean,rsqsum,rsum,sic,tasia56,tasiar16,tasiar26,tasiar36,    &
-!    &tasiar46,tasiar56,tasiar61,tasiar62,tasiar63,tasiar64,tasiar65,   &
-!    &taus,x11,x13
+  real(kind=fPrec) dpoff, hv(6,2,npart,nblo)
 
-save
+  save
 
 #ifdef FLUKA
 !     A.Mereghetti and D.Sinuela Pastor, for the FLUKA Team

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -131,81 +131,63 @@ subroutine sumpos
 end subroutine sumpos
 
 subroutine blocksv
+
   use floatPrecision
   use numerical_constants
-
   use parpro
   use mod_common
   use mod_common_main
   use mod_commons
   use mod_common_track
   use mod_common_da
+
   implicit none
 
   integer ia, ikk, j, jm, k, lkk, mkk
-  real(kind=fPrec) dpoff, hv(6,2,npart,nblo)
-
-  save
+  real(kind=fPrec) dpoff, hv(6,2,nblo)
 
 #ifdef FLUKA
-!     A.Mereghetti and D.Sinuela Pastor, for the FLUKA Team
-!     last modified: 11-06-2014
-!     entirely re-initialise to 0.0 hv(...) and bl1v(...) arrays
-!     inserted in main code by the 'fluka' compilation flag
-  do ia=1,npart
-    do k=1,nblo
+  ! Entirely re-initialise to 0.0 hv(...) and bl1v(...) arrays
+  hv(:,:,:)   = zero
+  bl1v(:,:,:) = zero
+#endif
+  do ia=1,napx
+    do k=1,mblo
+      jm  = mel(k)
+      ikk = mtyp(k,1)
       do lkk=1,2
         do mkk=1,6
-          hv(mkk,lkk,ia,k)=zero
-          bl1v(mkk,lkk,ia,k)=zero
+          dpoff = dpsv(ia)*c1e3
+          if(abs(dpoff) <= pieni) dpoff = one
+          hv(mkk,lkk,1) = al(mkk,lkk,ia,ikk)
+          if(mkk == 5 .or. mkk == 6) then
+            hv(mkk,lkk,1) = hv(mkk,lkk,1)/dpoff
+          end if
+        end do
+      end do
+      if(jm > 1) then
+        do j=2,jm
+          ikk = mtyp(k,j)
+          do lkk=1,2
+            dpoff = dpsv(ia)*c1e3
+            if(abs(dpoff) <= pieni) dpoff = one
+            hv(1,lkk,j) =  hv(1,lkk,j-1)*al(1,lkk,ia,ikk) + hv(3,lkk,j-1)*al(2,lkk,ia,ikk)
+            hv(2,lkk,j) =  hv(2,lkk,j-1)*al(1,lkk,ia,ikk) + hv(4,lkk,j-1)*al(2,lkk,ia,ikk)
+            hv(3,lkk,j) =  hv(1,lkk,j-1)*al(3,lkk,ia,ikk) + hv(3,lkk,j-1)*al(4,lkk,ia,ikk)
+            hv(4,lkk,j) =  hv(2,lkk,j-1)*al(3,lkk,ia,ikk) + hv(4,lkk,j-1)*al(4,lkk,ia,ikk)
+            hv(5,lkk,j) = (hv(5,lkk,j-1)*al(1,lkk,ia,ikk) + hv(6,lkk,j-1)*al(2,lkk,ia,ikk)) + al(5,lkk,ia,ikk)/dpoff
+            hv(6,lkk,j) = (hv(5,lkk,j-1)*al(3,lkk,ia,ikk) + hv(6,lkk,j-1)*al(4,lkk,ia,ikk)) + al(6,lkk,ia,ikk)/dpoff
+          end do
+        end do
+      end if
+      do lkk=1,2
+        do mkk=1,6
+          bl1v(mkk,lkk,ia,k) = hv(mkk,lkk,jm)
         end do
       end do
     end do
   end do
-#endif
-  do 440 k=1,mblo
-    jm=mel(k)
-    ikk=mtyp(k,1)
-    do lkk=1,2
-      do mkk=1,6
-        do ia=1,napx
-          dpoff=dpsv(ia)*c1e3
-          if(abs(dpoff).le.pieni) dpoff=one
-          hv(mkk,lkk,ia,1)=al(mkk,lkk,ia,ikk)
-          if(mkk.eq.5.or.mkk.eq.6) then
-            hv(mkk,lkk,ia,1)=hv(mkk,lkk,ia,1)/dpoff
-          end if
-        end do
-      end do
-    end do
-    if(jm.eq.1) goto 410
-    do j=2,jm
-      ikk=mtyp(k,j)
-      do lkk=1,2
-        do ia=1,napx
-          dpoff=dpsv(ia)*c1e3
-          if(abs(dpoff).le.pieni) dpoff=one
-          hv(1,lkk,ia,j)=hv(1,lkk,ia,j-1)*al(1,lkk,ia,ikk)+ hv(3,lkk,ia,j-1)*al(2,lkk,ia,ikk)
-          hv(2,lkk,ia,j)=hv(2,lkk,ia,j-1)*al(1,lkk,ia,ikk)+ hv(4,lkk,ia,j-1)*al(2,lkk,ia,ikk)
-          hv(3,lkk,ia,j)=hv(1,lkk,ia,j-1)*al(3,lkk,ia,ikk)+ hv(3,lkk,ia,j-1)*al(4,lkk,ia,ikk)
-          hv(4,lkk,ia,j)=hv(2,lkk,ia,j-1)*al(3,lkk,ia,ikk)+ hv(4,lkk,ia,j-1)*al(4,lkk,ia,ikk)
-!hr05         hv(5,lkk,ia,j)=hv(5,lkk,ia,j-1)*al(1,lkk,ia,ikk)+ hv(6,   &
-!hr05&lkk,ia,j-1)*al(2,lkk,ia,ikk)+al(5,lkk,ia,ikk)/dpoff
-          hv(5,lkk,ia,j)=(hv(5,lkk,ia,j-1)*al(1,lkk,ia,ikk)+ hv(6,lkk,ia,j-1)*al(2,lkk,ia,ikk))+al(5,lkk,ia,ikk)/dpoff
-!hr05         hv(6,lkk,ia,j)=hv(5,lkk,ia,j-1)*al(3,lkk,ia,ikk)+ hv(6,   &
-!hr05&lkk,ia,j-1)*al(4,lkk,ia,ikk)+al(6,lkk,ia,ikk)/dpoff
-          hv(6,lkk,ia,j)=(hv(5,lkk,ia,j-1)*al(3,lkk,ia,ikk)+ hv(6,lkk,ia,j-1)*al(4,lkk,ia,ikk))+al(6,lkk,ia,ikk)/dpoff
-        end do
-      end do
-    end do
-410   do lkk=1,2
-      do mkk=1,6
-        do ia=1,napx
-          bl1v(mkk,lkk,ia,k)=hv(mkk,lkk,ia,jm)
-        end do
-      end do
-    end do
-440 continue
+
 end subroutine blocksv
 
 !-----------------------------------------------------------------------


### PR DESCRIPTION
Remove a few global arrays that were only used one place, and removed the allocate thickarrays routines from the common modules as the expand thickarrays routines do the same thing.