### PR TITLE
Move a couple of fast tests to medium tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -493,7 +493,6 @@ set(FAST_TESTS
   chebythin6d
   chebythin6d_DYNK
   chebythin6d_ions
-  chebythin6d_ramp_DYNK
   collimation_db_old
   crabs
   dump_2_all_ele_highprec
@@ -519,7 +518,6 @@ set(FAST_TESTS
   elensidealthin6d_DYNK
   elensidealthin6d_DYNK_ZIPF
   elensidealthin6d_ions
-  elensidealthin6d_ramp_DYNK
   exact
   fcc
   frs_da
@@ -571,9 +569,11 @@ set(MEDIUM_TESTS
   bbe51
   bbe52
   bbe571ib0
+  chebythin6d_ramp_DYNK
   collimation_k2
   dipedge
   distance
+  elensidealthin6d_ramp_DYNK
   eric
   fma
   fma_binary


### PR DESCRIPTION
Moves the chebythin6d_ramp_DYNK and elensidealthin6d_ramp_DYNK tests to medium tests.

They are only over the threshold on circleci, but I'd like to move them anyway. They are run on nightly builds still.