### PR TITLE
Hexadecimal version of pi and pi-related constants

### DIFF
--- a/source/constants.f90
+++ b/source/constants.f90
@@ -59,10 +59,9 @@ module numerical_constants
 
 ! real(kind=fPrec), parameter :: pi      = 3.141592653589793238462643383279502884197169399375105820974_fPrec
 ! real(kind=fPrec), parameter :: inv_ln2 = 1.442695040888963407359924681001892137426645954152985934135_fPrec
-! real(kind=fPrec), parameter :: pi2     = 0.5_fPrec*pi
-! real(kind=fPrec), parameter :: twopi   = 2.0_fPrec*pi
-! real(kind=fPrec), parameter :: pisqrt  = sqrt(pi)
-! real(kind=fPrec), parameter :: rad     = pi/180.0_fPrec
+
+  ! We set the parameters of irrational numbers explicitly to their nearest binary representation
+  ! without depending on rounding from decimal representation. These use decimal round near.
 
 #ifdef SINGLE_MATH
   real(kind=fPrec), parameter :: pi      = transfer(z'40490fdb',1.0_fPrec)
@@ -71,6 +70,8 @@ module numerical_constants
   real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fe2dfc5',1.0_fPrec) ! sqrt(pi)
   real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fb8aa3b',1.0_fPrec) ! 1/log(2)
   real(kind=fPrec), parameter :: rad     = transfer(z'3c8efa35',1.0_fPrec) ! pi/180.0_fPrec
+! real(kind=fPrec), parameter :: pieni   = transfer(z'00800000',1.0_fPrec) ! Smallest normal number
+! real(kind=fPrec), parameter :: pieni   = transfer(z'006CE3EE',1.0_fPrec) ! 1e-38 is subnormal
 #endif
 #ifdef DOUBLE_MATH
   real(kind=fPrec), parameter :: pi      = transfer(z'400921fb54442d18',1.0_fPrec)
@@ -79,6 +80,8 @@ module numerical_constants
   real(kind=fPrec), parameter :: pisqrt  = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
   real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3ff71547652b82fe',1.0_fPrec)
   real(kind=fPrec), parameter :: rad     = transfer(z'3f91df46a2529d39',1.0_fPrec)
+! real(kind=fPrec), parameter :: pieni   = transfer(z'3810000000000000',1.0_fPrec) ! Smalles normal real32
+! real(kind=fPrec), parameter :: pieni   = transfer(z'380B38FB9DAA78E4',1.0_fPrec) ! 1d-38
 #endif
 #ifdef QUAD_MATH
   real(kind=fPrec), parameter :: pi      = transfer(z'4000921fb54442d18469898cc51701b8',1.0_fPrec)
@@ -87,8 +90,12 @@ module numerical_constants
   real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
   real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
   real(kind=fPrec), parameter :: rad     = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
+! real(kind=fPrec), parameter :: pieni   = transfer(z'3F810000000000000000000000000000',1.0_fPrec) ! Smalles normal real32
+! real(kind=fPrec), parameter :: pieni   = transfer(z'3F80B38FB9DAA78E44AB2DCF7A6B1921',1.0_fPrec) ! 1q-38
 #endif
 
+  ! The variable pieni is roughly the smalles normal single precision float vlaue, 
+  ! However, 1e-38 is actually subnormal in 32 bit (0x006ce3ee). Smallest normal is 1.17549435e-38 (0x00800000)
   real(kind=fPrec), parameter :: pieni  = 1e-38_fPrec
 
   real(kind=fPrec), parameter :: zero   = 0.0_fPrec

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -62,6 +62,7 @@ module numerical_constants
 
   ! We set the parameters of irrational numbers explicitly to their nearest binary representation
   ! without depending on rounding from decimal representation. These use decimal round near.
+  ! Small program for checking binary and hex here: https://gist.github.com/vkbo/0e5d0c4b7b1ecb533a0486c79a30f741
 
 #ifdef SINGLE_MATH
   real(kind=fPrec), parameter :: pi      = transfer(z'40490fdb',1.0_fPrec)

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -81,7 +81,7 @@ module numerical_constants
   real(kind=fPrec), parameter :: pisqrt  = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
   real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3ff71547652b82fe',1.0_fPrec)
   real(kind=fPrec), parameter :: rad     = transfer(z'3f91df46a2529d39',1.0_fPrec)
-! real(kind=fPrec), parameter :: pieni   = transfer(z'3810000000000000',1.0_fPrec) ! Smalles normal real32
+! real(kind=fPrec), parameter :: pieni   = transfer(z'3810000000000000',1.0_fPrec) ! Smallest normal real32
 ! real(kind=fPrec), parameter :: pieni   = transfer(z'380B38FB9DAA78E4',1.0_fPrec) ! 1d-38
 #endif
 #ifdef QUAD_MATH
@@ -91,12 +91,13 @@ module numerical_constants
   real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
   real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
   real(kind=fPrec), parameter :: rad     = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
-! real(kind=fPrec), parameter :: pieni   = transfer(z'3F810000000000000000000000000000',1.0_fPrec) ! Smalles normal real32
+! real(kind=fPrec), parameter :: pieni   = transfer(z'3F810000000000000000000000000000',1.0_fPrec) ! Smallest normal real32
 ! real(kind=fPrec), parameter :: pieni   = transfer(z'3F80B38FB9DAA78E44AB2DCF7A6B1921',1.0_fPrec) ! 1q-38
 #endif
 
-  ! The variable pieni is roughly the smalles normal single precision float vlaue, 
+  ! The variable pieni is roughly the smallest normal single precision float value.
   ! However, 1e-38 is actually subnormal in 32 bit (0x006ce3ee). Smallest normal is 1.17549435e-38 (0x00800000)
+  ! This is probably not a good idea for performance in single prec, but changing it makes a difference in postprocessing it seems.
   real(kind=fPrec), parameter :: pieni  = 1e-38_fPrec
 
   real(kind=fPrec), parameter :: zero   = 0.0_fPrec

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -57,41 +57,36 @@ module numerical_constants
 
   implicit none
 
-! real(kind=fPrec), parameter :: eulergamma = 0.577215664901532860606512090082402431042159335939923598805_fPrec
-! real(kind=fPrec), parameter :: pi         = 3.141592653589793238462643383279502884197169399375105820974_fPrec
-! real(kind=fPrec), parameter :: inv_ln2    = 1.442695040888963407359924681001892137426645954152985934135_fPrec
-
-! real(kind=fPrec), parameter :: pi2        = 0.5_fPrec*pi
-! real(kind=fPrec), parameter :: twopi      = 2.0_fPrec*pi
-! real(kind=fPrec), parameter :: pisqrt     = sqrt(pi)
-! real(kind=fPrec), parameter :: rad        = pi/180.0_fPrec
+! real(kind=fPrec), parameter :: pi      = 3.141592653589793238462643383279502884197169399375105820974_fPrec
+! real(kind=fPrec), parameter :: inv_ln2 = 1.442695040888963407359924681001892137426645954152985934135_fPrec
+! real(kind=fPrec), parameter :: pi2     = 0.5_fPrec*pi
+! real(kind=fPrec), parameter :: twopi   = 2.0_fPrec*pi
+! real(kind=fPrec), parameter :: pisqrt  = sqrt(pi)
+! real(kind=fPrec), parameter :: rad     = pi/180.0_fPrec
 
 #ifdef SINGLE_MATH
-  real(kind=fPrec), parameter :: pi         = transfer(z'40490fda',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2        = transfer(z'3fc90fda',1.0_fPrec) ! 0.5_fPrec*pi
-  real(kind=fPrec), parameter :: twopi      = transfer(z'40c90fda',1.0_fPrec) ! 2.0_fPrec*pi
-  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fe2dfc4',1.0_fPrec) ! sqrt(pi)
-  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fb8aa3b',1.0_fPrec) ! 1/log(2)
-  real(kind=fPrec), parameter :: eulergamma = transfer(z'3f13c467',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad        = transfer(z'3c8efa35',1.0_fPrec) ! pi/180.0_fPrec
+  real(kind=fPrec), parameter :: pi      = transfer(z'40490fdb',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2     = transfer(z'3fc90fdb',1.0_fPrec) ! 0.5_fPrec*pi
+  real(kind=fPrec), parameter :: twopi   = transfer(z'40c90fdb',1.0_fPrec) ! 2.0_fPrec*pi
+  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fe2dfc5',1.0_fPrec) ! sqrt(pi)
+  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fb8aa3b',1.0_fPrec) ! 1/log(2)
+  real(kind=fPrec), parameter :: rad     = transfer(z'3c8efa35',1.0_fPrec) ! pi/180.0_fPrec
 #endif
 #ifdef DOUBLE_MATH
-  real(kind=fPrec), parameter :: pi         = transfer(z'400921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2        = transfer(z'3ff921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: twopi      = transfer(z'401921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
-  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3ff71547652b82fe',1.0_fPrec)
-  real(kind=fPrec), parameter :: eulergamma = transfer(z'3fe2788cfc6fb618',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad        = transfer(z'3f91df46a2529d39',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi      = transfer(z'400921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2     = transfer(z'3ff921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: twopi   = transfer(z'401921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
+  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3ff71547652b82fe',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad     = transfer(z'3f91df46a2529d39',1.0_fPrec)
 #endif
 #ifdef QUAD_MATH
-  real(kind=fPrec), parameter :: pi         = transfer(z'4000921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2        = transfer(z'3fff921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: twopi      = transfer(z'4001921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
-  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
-  real(kind=fPrec), parameter :: eulergamma = transfer(z'3ffe2788cfc6fb618f49a37c7f0202a6',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad        = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi      = transfer(z'4000921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2     = transfer(z'3fff921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: twopi   = transfer(z'4001921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
+  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad     = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
 #endif
 
   real(kind=fPrec), parameter :: pieni  = 1e-38_fPrec

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -57,14 +57,42 @@ module numerical_constants
 
   implicit none
 
-  real(kind=fPrec), parameter :: eulergamma = 0.577215664901532860606512090082402431042159335939923598805_fPrec
-  real(kind=fPrec), parameter :: pi         = 3.141592653589793238462643383279502884197169399375105820974_fPrec
-  real(kind=fPrec), parameter :: inv_ln2    = 1.442695040888963407359924681001892137426645954152985934135_fPrec
+! real(kind=fPrec), parameter :: eulergamma = 0.577215664901532860606512090082402431042159335939923598805_fPrec
+! real(kind=fPrec), parameter :: pi         = 3.141592653589793238462643383279502884197169399375105820974_fPrec
+! real(kind=fPrec), parameter :: inv_ln2    = 1.442695040888963407359924681001892137426645954152985934135_fPrec
 
-  real(kind=fPrec), parameter :: pi2    = 0.5_fPrec*pi
-  real(kind=fPrec), parameter :: twopi  = 2.0_fPrec*pi
-  real(kind=fPrec), parameter :: pisqrt = sqrt(pi)
-  real(kind=fPrec), parameter :: rad    = pi/180.0_fPrec
+! real(kind=fPrec), parameter :: pi2        = 0.5_fPrec*pi
+! real(kind=fPrec), parameter :: twopi      = 2.0_fPrec*pi
+! real(kind=fPrec), parameter :: pisqrt     = sqrt(pi)
+! real(kind=fPrec), parameter :: rad        = pi/180.0_fPrec
+
+#ifdef SINGLE_MATH
+  real(kind=fPrec), parameter :: pi         = transfer(z'40490fda',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2        = transfer(z'3fc90fda',1.0_fPrec)
+  real(kind=fPrec), parameter :: twopi      = transfer(z'40c90fda',1.0_fPrec)
+  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fe2dfc4',1.0_fPrec)
+  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fb8aa3b',1.0_fPrec)
+  real(kind=fPrec), parameter :: eulergamma = transfer(z'3f13c467',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad        = transfer(z'3c8efa35',1.0_fPrec)
+#endif
+#ifdef DOUBLE_MATH
+  real(kind=fPrec), parameter :: pi         = transfer(z'400921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2        = transfer(z'3ff921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: twopi      = transfer(z'401921fb54442d18',1.0_fPrec)
+  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
+  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3ff71547652b82fe',1.0_fPrec)
+  real(kind=fPrec), parameter :: eulergamma = transfer(z'3fe2788cfc6fb618',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad        = transfer(z'3f91df46a2529d39',1.0_fPrec)
+#endif
+#ifdef QUAD_MATH
+  real(kind=fPrec), parameter :: pi         = transfer(z'4000921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2        = transfer(z'3fff921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: twopi      = transfer(z'4001921fb54442d18469898cc51701b8',1.0_fPrec)
+  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
+  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
+  real(kind=fPrec), parameter :: eulergamma = transfer(z'3ffe2788cfc6fb618f49a37c7f0202a6',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad        = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
+#endif
 
   real(kind=fPrec), parameter :: pieni  = 1e-38_fPrec
 

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -68,12 +68,12 @@ module numerical_constants
 
 #ifdef SINGLE_MATH
   real(kind=fPrec), parameter :: pi         = transfer(z'40490fda',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2        = transfer(z'3fc90fda',1.0_fPrec)
-  real(kind=fPrec), parameter :: twopi      = transfer(z'40c90fda',1.0_fPrec)
-  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fe2dfc4',1.0_fPrec)
-  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fb8aa3b',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi2        = transfer(z'3fc90fda',1.0_fPrec) ! 0.5_fPrec*pi
+  real(kind=fPrec), parameter :: twopi      = transfer(z'40c90fda',1.0_fPrec) ! 2.0_fPrec*pi
+  real(kind=fPrec), parameter :: pisqrt     = transfer(z'3fe2dfc4',1.0_fPrec) ! sqrt(pi)
+  real(kind=fPrec), parameter :: inv_ln2    = transfer(z'3fb8aa3b',1.0_fPrec) ! 1/log(2)
   real(kind=fPrec), parameter :: eulergamma = transfer(z'3f13c467',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad        = transfer(z'3c8efa35',1.0_fPrec)
+  real(kind=fPrec), parameter :: rad        = transfer(z'3c8efa35',1.0_fPrec) ! pi/180.0_fPrec
 #endif
 #ifdef DOUBLE_MATH
   real(kind=fPrec), parameter :: pi         = transfer(z'400921fb54442d18',1.0_fPrec)

--- a/source/dabnew.f90
+++ b/source/dabnew.f90
@@ -200,7 +200,7 @@ subroutine daini(no,nv,iunit)
       character(len=256) filename
 #endif
 
-      if(eps.le.zero) eps=1.e-38_fPrec
+      if(eps.le.zero) eps=1.e-38_fPrec ! Why is this not pieni?
 !      if(EPS.le.0.d0) eps=1.d-90
       epsmac=c1m7
       if(nv.eq.0) return


### PR DESCRIPTION
Just another small change on my todo list.

I've defined all the constants that are pi-related (and two more) in terms of a correctly truncated binary representation. They are all based on the gfortran casting of the quad precision, and tuned to produce the exact same binary to the size of the mantissa for double and single precision. 

**Changes**
* The double precision one was corrected in the last bit for the `eulergamma` variable (which is the same as stated on wikipedia, but the variable isn't used anywhere in SixTrack currently anyway). 
* All of the single precision variables were corrected on the last bit. That is, setting the values with the full list of decimals tended to round the last bit up for single precision, while the corresponding double precision bit was lower.

**Testing**
* Debian: Passes all fast tests with gfortran, ifort and nagfor.
* Windows10: Passes all fast tests with gfortran for both 64 and 32 bit.

The code used to generate the hex values is this one:
```
program main

  use, intrinsic :: iso_fortran_env

  implicit none

  real(kind=real32),  parameter :: pi32   = 3.1415925_real32
  real(kind=real64),  parameter :: pi64   = 3.141592653589793238462643383279502884197169399375105820974_real64
  real(kind=real128), parameter :: pi128  = 3.141592653589793238462643383279502884197169399375105820974_real128

  real(kind=real32),  parameter :: pi32x  = transfer(z'40490fda',1.0_real32)
  real(kind=real64),  parameter :: pi64x  = transfer(z'400921fb54442d18',1.0_real64)
  real(kind=real128), parameter :: pi128x = transfer(z'4000921fb54442d18469898cc51701b8',1.0_real128)

  write(*,"(a,f10.8,28x,z8.8,33x,b32.32)")    "REAL32  : ",pi32, pi32, pi32
  write(*,"(a,f19.17,19x,z16.16,22x,b64.64)") "REAL64  : ",pi64, pi64, pi64
  write(*,"(a,f36.34,2x,z32.32,2x,b128.128)") "REAL128 : ",pi128,pi128,pi128

  write(*,"(a,f10.8,28x,z8.8,33x,b32.32)")    "REAL32  : ",pi32x, pi32x, pi32x
  write(*,"(a,f19.17,19x,z16.16,22x,b64.64)") "REAL64  : ",pi64x, pi64x, pi64x
  write(*,"(a,f36.34,2x,z32.32,2x,b128.128)") "REAL128 : ",pi128x,pi128x,pi128x

end program main
```

For pi, it outputs this:
```
REAL32  : 3.14159250                            40490FDA                                 01000000010010010000111111011010
REAL64  : 3.14159265358979312                   400921FB54442D18                      0100000000001001001000011111101101010100010001000010110100011000
REAL128 : 3.1415926535897932384626433832795028  4000921FB54442D18469898CC51701B8  01000000000000001001001000011111101101010100010001000010110100011000010001101001100010011000110011000101000101110000000110111000
REAL32  : 3.14159250                            40490FDA                                 01000000010010010000111111011010
REAL64  : 3.14159265358979312                   400921FB54442D18                      0100000000001001001000011111101101010100010001000010110100011000
REAL128 : 3.1415926535897932384626433832795028  4000921FB54442D18469898CC51701B8  01000000000000001001001000011111101101010100010001000010110100011000010001101001100010011000110011000101000101110000000110111000
```