### PR TITLE
Bugfixes 2019-04-25

### DIFF
--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -811,7 +811,7 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
 
   character(len=:), allocatable   :: lnSplit(:)
   character(len=:), allocatable   :: expLine
-  integer nSplit, iDummy
+  integer nSplit, imc, ibidu
   logical spErr
 
   call chr_split(inLine, lnSplit, nSplit, spErr)
@@ -830,19 +830,21 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
       return
     end if
 
+    imc = 1
+
     if(nSplit > 0)  call chr_cast(lnSplit(1), numl,   iErr) ! Number of turns in the forward direction
     if(nSplit > 1)  call chr_cast(lnSplit(2), numlr,  iErr) ! Number of turns in the backward direction
     if(nSplit > 2)  call chr_cast(lnSplit(3), napx,   iErr) ! Number of amplitude variations (i.e. particle pairs)
     if(nSplit > 3)  call chr_cast(lnSplit(4), amp(1), iErr) ! End amplitude
     if(nSplit > 4)  call chr_cast(lnSplit(5), amp0,   iErr) ! Start amplitude
     if(nSplit > 5)  call chr_cast(lnSplit(6), ird,    iErr) ! Ignored
-    if(nSplit > 6)  call chr_cast(lnSplit(7), iDummy, iErr) ! Number of variations of the relative momentum deviation dp/p
+    if(nSplit > 6)  call chr_cast(lnSplit(7), imc,    iErr) ! Number of variations of the relative momentum deviation dp/p
     if(nSplit > 7)  call chr_cast(lnSplit(8), niu(1), iErr) ! Unknown
     if(nSplit > 8)  call chr_cast(lnSplit(9), niu(2), iErr) ! Unknown
     if(nSplit > 9)  call chr_cast(lnSplit(10),numlcp, iErr) ! CR: How often to write checkpointing files
     if(nSplit > 10) call chr_cast(lnSplit(11),numlmax,iErr) ! CR: Maximum amount of turns; default is 1e6
 
-    if(iDummy > 1) then
+    if(imc /= 1) then
       write(lerr,"(a)") "TRAC> ERROR Variations of the relative momentum deviation is no longer supporter. "//&
         "The value imc must be set to 1."
       iErr = .true.
@@ -961,19 +963,19 @@ subroutine sixin_parseInputLineTRAC(inLine, iLine, iErr)
     if(nSplit > 4) call chr_cast(lnSplit(5),nwr(3),  iErr) ! Every nth turn at the flat top a write out of the coordinates
     if(nSplit > 5) call chr_cast(lnSplit(6),nwr(4),  iErr) ! Every nth turn coordinates are written to unit 6.
     if(nSplit > 6) call chr_cast(lnSplit(7),ntwin,   iErr) ! Flag for calculated distance of phase space
-    if(nSplit > 7) call chr_cast(lnSplit(8),iDummy,  iErr) ! No longer in use. Formerly ibidu
+    if(nSplit > 7) call chr_cast(lnSplit(8),ibidu,   iErr) ! No longer in use.
     if(nSplit > 8) call chr_cast(lnSplit(9),iexact,  iErr) ! Switch to enable exact solution of the equation of motion
     if(nSplit > 9) call chr_cast(lnSplit(10),curveff,iErr) ! Switch to include curvatures effect on multipoles..
 
     if(st_debug) then
-      call sixin_echoVal("nde(1)",nde(1),  "TRAC",iLine)
-      call sixin_echoVal("nde(2)",nde(2),  "TRAC",iLine)
-      call sixin_echoVal("nwr(1)",nwr(1),  "TRAC",iLine)
-      call sixin_echoVal("nwr(2)",nwr(2),  "TRAC",iLine)
-      call sixin_echoVal("nwr(3)",nwr(3),  "TRAC",iLine)
-      call sixin_echoVal("nwr(4)",nwr(4),  "TRAC",iLine)
-      call sixin_echoVal("ntwin", ntwin,   "TRAC",iLine)
-      call sixin_echoVal("iexact",iexact,  "TRAC",iLine)
+      call sixin_echoVal("nde(1)", nde(1), "TRAC",iLine)
+      call sixin_echoVal("nde(2)", nde(2), "TRAC",iLine)
+      call sixin_echoVal("nwr(1)", nwr(1), "TRAC",iLine)
+      call sixin_echoVal("nwr(2)", nwr(2), "TRAC",iLine)
+      call sixin_echoVal("nwr(3)", nwr(3), "TRAC",iLine)
+      call sixin_echoVal("nwr(4)", nwr(4), "TRAC",iLine)
+      call sixin_echoVal("ntwin",  ntwin,  "TRAC",iLine)
+      call sixin_echoVal("iexact", iexact, "TRAC",iLine)
       call sixin_echoVal("curveff",curveff,"TRAC",iLine)
     end if
     if(iErr) return

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,10 +43,12 @@ set_tests_properties(CheckBuildManual PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR"
 ## ERROR Tests
 ##
 
-list(APPEND SIXTRACK_ERROR
-  error_init
-  error_trac
-)
+if(NOT BOINC)
+  list(APPEND SIXTRACK_ERROR
+    error_init
+    error_trac
+  )
+endif(NOT BOINC)
 
 ##
 ## Needs checking: thick6dsingles (broken input files -- this test could probably be removed)


### PR DESCRIPTION
This PR fixes a few bugs caught by nightly build.

**Summary**
Most of the errors were related to the error tests failing due to inconsistent output used for diff in CR versions (non-critical). The correction of the `imc` variable check in `TRAC` parsing in PR #847 revealed an existing issue with an uninitialised dummy variable. Only critical if the `imc` variable was not set in the `TRAC` block, and the compiler was not gfortran.

**Fixes**
* Cannot build error tests when BOINC flag is on as there is no initial `fort.3` file. For this to work, the python wrapper needs to make the Sixin.zip files on the fly. It is not really necessary to build the error tests with BOINC, so they are now disabled.
* When running error tests with CR (non-BOINC build) the content of the `fort.91` file was not echoed to stderr. The tests failed due to nothing to compare the canonical to. This has now been fixed.
* Copy to stderr routine in end_sixtrack no longer trims lines for output to stderr. This also failed the diff. To achieve this, the `fort.91` file must be read with the advance flag set to "no".
* The error check on `imc <= 1` in `TRAC` parsing conflicts with the option to omit the parameter entirely. This is resolved by defaulting `imc` to 1. 