### PR TITLE
removing constraint on R1=0.0 in chebyshev maps and elenses

### DIFF
--- a/source/cheby.f90
+++ b/source/cheby.f90
@@ -352,8 +352,8 @@ subroutine cheby_postInput
            " - reference radius [mm]:",cheby_refR(cheby_itable(jj))
       goto 10 
     end if
-    if (cheby_r1(jj)==zero) then
-      write(lerr,"(a)")      "CHEBY> ERROR R1 cannot be zero for the time being!"
+    if (cheby_r1(jj)<zero) then
+      write(lerr,"(a)")      "CHEBY> ERROR R1 cannot be lower than zero!"
       goto 10 
     end if
     if (cheby_I (jj)<=zero) then
@@ -630,7 +630,7 @@ subroutine cheby_kick(i,ix,n)
 
     ! check that particle is within the domain of chebyshev polynomials
     rr=sqrt(xx**2+yy**2)
-    if (rr.ge.cheby_r1(icheby(ix)).and.rr.lt.cheby_r2(icheby(ix))) then ! rr<r1 || rr>=r2 -> no kick from lens
+    if (rr.gt.cheby_r1(icheby(ix)).and.rr.lt.cheby_r2(icheby(ix))) then ! rr<r1 || rr>=r2 -> no kick from lens
       
       ! in case of non-zero tilt angle, rotate coordinates
       if (lrotate) then
@@ -730,7 +730,7 @@ subroutine cheby_potentialMap(iLens,ix)
       ! check that particle is within the domain of chebyshev polynomials
       rr=sqrt(xxr**2+yyr**2)
       inside=0
-      if (rr.ge.cheby_r1(iLens).and.rr.lt.cheby_r2(iLens)) inside=1 ! kick only if rr>=r1 && rr<r2
+      if (rr.gt.cheby_r1(iLens).and.rr.lt.cheby_r2(iLens)) inside=1 ! kick only if rr>=r1 && rr<r2
       ! in case of non-zero tilt angle, rotate coordinates
       if (lrotate) then
         theta = atan2_mb(yyr, xxr)-angle_rad

--- a/source/elens.f90
+++ b/source/elens.f90
@@ -271,8 +271,8 @@ subroutine elens_parseInputLine(inLine, iLine, iErr)
     iErr = .true.
     return
   end if
-  if(elens_r1(ielens(iElem)) <= zero) then
-    write(lerr,"(a)") "ELENS> ERROR R1<=0!"
+  if(elens_r1(ielens(iElem)) < zero) then
+    write(lerr,"(a)") "ELENS> ERROR R1<0!"
     iErr = .true.
     return
   end if


### PR DESCRIPTION
This #PR allows to set R1=0.0 for both elenses and chebyshev maps, even though the fox implementation is still on-going (elens: https://github.com/SixTrack/SixTrack/pull/839, chebyshev maps: https://github.com/SixTrack/SixTrack/pull/849). At least, this PR will allow running full elens studies, even though the closed orbit does not take into account these elements...