### PR TITLE
CR and File Units Bugfixes

### DIFF
--- a/doc/user_manual/apxInputOutput.tex
+++ b/doc/user_manual/apxInputOutput.tex
@@ -44,8 +44,8 @@ The program uses a couple of files for its input and output procedures.
     15 & & \checkmark & Ascii & Vertical FFT spectrum for detailed analysis. Format: ($2 \times F10.6$) \\
     \hline
     16 & \checkmark & & Ascii & External multipole errors. Format: $a16,\ 2 \times \{6 \times (1p,3d23.15),(1p,2d23.15)\}$ \\
-    % \hline
-    % 17 & & \checkmark & Ascii & Additional Map at location of interest \\
+    \hline
+    17 & & \checkmark & Ascii & Additional Map at location of interest \\
     \hline
     18 & & \checkmark & Ascii & One turn map with differential algebra \\
     \hline
@@ -62,6 +62,8 @@ The program uses a couple of files for its input and output procedures.
     24 & & \checkmark & Ascii & Tune-shift in action coordinates \\
     \hline
     25 & & \checkmark & Ascii & Tune-shift in Cartesian coordinates \\
+    \hline
+    26 & & \checkmark & Binary & Binary version of unit 18 \\
     \hline
     27 & & \checkmark & Ascii & Name, hor., ver. misalignment and tilt \\
     \hline
@@ -83,22 +85,18 @@ The program uses a couple of files for its input and output procedures.
     \hline
     90 & & \checkmark & Binary & Tracking Data (singletrackfile) \texttt{singletrackfile.dat} \\
     \hline
-    92 & & \checkmark & Ascii & Checkpoint/Restart only: Program ``standard output'' (lout) \\
-    \hline
-    93 & & \checkmark & Ascii & Checkpoint/Restart only: log file \\
-    \hline
+    % 92 & & \checkmark & Ascii & Checkpoint/Restart only: Program ``standard output'' (lout) \\
+    % \hline
+    % 93 & & \checkmark & Ascii & Checkpoint/Restart only: log file \\
+    % \hline
     % 94 & & \checkmark & Ascii & Checkpoint/Restart only: Temp file for resetting binary tracking data file(s) \\
     % \hline
-    95 & \checkmark & \checkmark & Binary & Checkpoint/restart only: data file 1 \\
-    \hline
-    96 & \checkmark & \checkmark & Binary & Checkpoint/restart only: data file 2 \\
+    % 95 & \checkmark & \checkmark & Binary & Checkpoint/restart only: data file 1 \\
+    % \hline
+    % 96 & \checkmark & \checkmark & Binary & Checkpoint/restart only: data file 2 \\
     % \hline
     % 98 & & \checkmark & Ascii & 6D coordinates at Cavity (\texttt{1p,6(2x,e25.18)}) \\
-    \hline
-    110 & & \checkmark & Binary & Binary version of unit 10 \\
-    \hline
-    111 & & \checkmark & Binary & Binary version of unit 18 \\
-    \hline
+    % \hline
 \end{longtable}
 \end{center}
 

--- a/doc/user_manual/chInitialConditions.tex
+++ b/doc/user_manual/chInitialConditions.tex
@@ -19,7 +19,7 @@ A fine tuning of the initial condition is done with \textit{Initial Coordinates}
     \textbf{Keyword}    & \texttt{TRAC}\index{TRAC} &\\
     \textbf{Data lines} & 3 &\\
     \textbf{Format}     & Line 1: & \texttt{numl numlr napx amp(1) amp0 ird imc} \\
-                        &         & \texttt{niu(1) niu(2) numlcp numlmax} \\
+                        &         & \texttt{niu(1) niu(2) numlcp} \\
                         & Line 2: & \texttt{idy(1) idy(2) idfor irew iclo6} \\
                         & Line 3: & \texttt{nde(1) nde(2) nwr(1) nwr(2) nwr(3) nwr(4)} \\
                         &         & \texttt{ntwin ibidu iexact curveff}
@@ -36,7 +36,7 @@ A fine tuning of the initial condition is done with \textit{Initial Coordinates}
     \texttt{imc}           & integer  & Number of variations of the relative momentum deviation\index{momentum deviations} has been removed. This value must be 1.\\
     \texttt{niu(1),niu(2)} & integer  & Start and stop structure element index for optics calculation. If 0, defaults to the full machine. \\
     \texttt{numlcp}        & integer  & Checkpoint/restart\index{checkpoint/restart} version: How often to write checkpointing files. \\
-    \texttt{numlmax}       & integer  & Checkpoint/restart version: Maximum amount of turns; default is $10^9$. \\
+  % \texttt{numlmax}       & integer  & Checkpoint/restart version: Maximum amount of turns; default is $10^9$. \\
     \texttt{idz(1),idz(2)} & integers & A tracking where one of the transversal motion planes shall be ignored is only possible when all coupling terms are switched off.  The part of the coupling that is due to closed orbit and other effects can be turned off with these switches. \\
                            &          & \texttt{idz(1), idz(2) = 1}: coupling on. \\
                            &          & \texttt{idz(1), idz(2) = 0}: coupling to the horizontal and vertical motion plane respectively switched off. \\

--- a/doc/user_manual/chInitialConditions.tex
+++ b/doc/user_manual/chInitialConditions.tex
@@ -19,7 +19,7 @@ A fine tuning of the initial condition is done with \textit{Initial Coordinates}
     \textbf{Keyword}    & \texttt{TRAC}\index{TRAC} &\\
     \textbf{Data lines} & 3 &\\
     \textbf{Format}     & Line 1: & \texttt{numl numlr napx amp(1) amp0 ird imc} \\
-                        &         & \texttt{niu(1) niu(2) numlcp} \\
+                        &         & \texttt{niu(1) niu(2) numlcp numlmax} \\
                         & Line 2: & \texttt{idy(1) idy(2) idfor irew iclo6} \\
                         & Line 3: & \texttt{nde(1) nde(2) nwr(1) nwr(2) nwr(3) nwr(4)} \\
                         &         & \texttt{ntwin ibidu iexact curveff}
@@ -36,7 +36,7 @@ A fine tuning of the initial condition is done with \textit{Initial Coordinates}
     \texttt{imc}           & integer  & Number of variations of the relative momentum deviation\index{momentum deviations} has been removed. This value must be 1.\\
     \texttt{niu(1),niu(2)} & integer  & Start and stop structure element index for optics calculation. If 0, defaults to the full machine. \\
     \texttt{numlcp}        & integer  & Checkpoint/restart\index{checkpoint/restart} version: How often to write checkpointing files. \\
-  % \texttt{numlmax}       & integer  & Checkpoint/restart version: Maximum amount of turns; default is $10^9$. \\
+    \texttt{numlmax}       & integer  & No longer in use. \\
     \texttt{idz(1),idz(2)} & integers & A tracking where one of the transversal motion planes shall be ignored is only possible when all coupling terms are switched off.  The part of the coupling that is due to closed orbit and other effects can be turned off with these switches. \\
                            &          & \texttt{idz(1), idz(2) = 1}: coupling on. \\
                            &          & \texttt{idz(1), idz(2) = 0}: coupling to the horizontal and vertical motion plane respectively switched off. \\

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -2655,7 +2655,7 @@ subroutine aper_parseLoadFile(load_file, iLine, iErr)
 
 90 continue
   write(lout,"(a,i0,a)") "LIMI> Read ",lineNo," lines from external file."
-  call f_close(loadunit)
+  call f_freeUnit(loadunit)
   return
 
 end subroutine aper_parseLoadFile

--- a/source/beam6d.f90
+++ b/source/beam6d.f90
@@ -144,7 +144,6 @@ subroutine sbc(np,star,cphi,cphi2,nsli,f,ibtyp,ibb,bcu,track,ibbc,mtc)
   do jsli=1,nsli
     do i=1,np
       s=(track(5,i)-star(3,jsli))*half
-      !write(*,*)'JBG - cphi2',cphi2
       sp=s/cphi2
       dum(1)=(bcu(ibb,1)+(two*bcu(ibb,4))*sp)+bcu(ibb,6)*sp**2
       dum(2)=(bcu(ibb,2)+(two*bcu(ibb,9))*sp)+bcu(ibb,10)*sp**2

--- a/source/beamgas.f90
+++ b/source/beamgas.f90
@@ -207,10 +207,6 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
 !      boosted yp event
        bgypdb(choice) = z(2)
        bgEdb(choice) = new4MomCoord(1) ! boosted energy
-! DEBUG:
-!         write(684,*) bgxpdb(choice),bgypdb(choice),bgEdb(choice),      &
-!     &     new4MomCoord
-! END DEBUG
       endif
      endif ! doLorentz
      call rotateMatrix(yv1(j),yv2(j),rotm)
@@ -522,12 +518,6 @@ subroutine lorentzBoost(px,py,ptot,mass)
       new4MomCoord(i)=new4MomCoord(i)+lorentzmatrix(i,j)*oldcoord(j)
     end do
   end do
-!        write(*,*)
-!        write(*,*) "DEBUG, n4M: ", new4MomCoord
-!        write(*,*)
-!        do i=1,4
-!         write(*,*) "DEBUG, lM: ", lorentzmatrix(i,1:4)
-!        enddo
 end subroutine lorentzBoost
 
 !>
@@ -586,7 +576,6 @@ subroutine createLorentzMatrix(E,xp,yp,mass)
   endif
 
   g=one/sqrt(one-b2) ! relativistic gamma for the boost
-  !         write(*,*) "DEBUG, g: ",g, v0, xp,yp,E,mass
 
   lorentzmatrix(1,1)=g /g
 
@@ -607,8 +596,5 @@ subroutine createLorentzMatrix(E,xp,yp,mass)
   lorentzmatrix(3,4) = ((g-1)* b(2)*b(3)*b2inv) /g
   lorentzmatrix(4,3) = (lorentzmatrix(3,4)) /g
 
-!        do i=1,4
-!         write(*,*) "DEBUG,lMAT: ", lorentzmatrix(i,1:4)
-!        enddo
 end subroutine createLorentzMatrix
 

--- a/source/cheby.f90
+++ b/source/cheby.f90
@@ -554,7 +554,7 @@ subroutine parseChebyFile(ifile)
 
 20 continue
 
-  call f_close(fUnit)
+  call f_freeUnit(fUnit)
   if (cheby_refR(ifile)<=zero) then
     write(lerr,"(a)") "CHEBY> ERROR ref lens radius [mm] must be positive."
     goto 30
@@ -748,7 +748,7 @@ subroutine cheby_potentialMap(iLens,ix)
     end do
   end do
 
-  call f_close(fUnit)
+  call f_freeUnit(fUnit)
   
 end subroutine cheby_potentialMap
 

--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -346,10 +346,14 @@ subroutine crcheck
 
     rewind(cr_pntUnit(nPoint))
 
-    write(crlog,"(a)") "CR_CHECK>  * SixTrack version"
+    write(crlog,"(a)") "CR_CHECK>  * Checking header"
     flush(crlog)
-
     read(cr_pntUnit(nPoint),iostat=ioStat) cr_version,cr_moddate
+    if(ioStat /= 0) then
+      write(crlog,"(a)") "CR_CHECK> Corrupt or truncated checkpoint file."
+      flush(crlog)
+      cycle
+    end if
     if(cr_version == " " .or. cr_moddate == " ") then
       write(crlog,"(a)") "CR_CHECK> Unknown SixTrack version. Skipping this file."
       flush(crlog)
@@ -363,7 +367,6 @@ subroutine crcheck
       flush(crlog)
       cycle
     end if
-    if(ioStat /= 0) cycle
 
     write(crlog,"(a)") "CR_CHECK>  * Tracking variables"
     flush(crlog)
@@ -995,7 +998,7 @@ subroutine cr_positionTrackFiles
     ! Second, copy crbinrecs(ia)*(crnapx/2) records of data from temp file to singletrackfile.dat
     rewind(tUnit)
     rewind(90)
-    binrecs94=0
+    binrecs94 = 0
 
     ! Copy header
     do ia=1,crnapxo/2,1
@@ -1020,7 +1023,7 @@ subroutine cr_positionTrackFiles
 
     ! This is not a FLUSH!
     endfile(90,iostat=ierro)
-    backspace (90,iostat=ierro)
+    backspace(90,iostat=ierro)
 #endif
     call f_freeUnit(tUnit)
   else !ELSE for "if(nnuml.ne.crnuml) then" -> here we treat nnuml.eq.crnuml, i.e. the number of turns have not been changed
@@ -1045,8 +1048,8 @@ subroutine cr_positionTrackFiles
         end do
 
         ! This is not a FLUSH!
-        endfile (91-ia,iostat=ierro)
-        backspace (91-ia,iostat=ierro)
+        endfile(91-ia,iostat=ierro)
+        backspace(91-ia,iostat=ierro)
       else ! Number of ecords written to this file < general number of records written
           ! => Particle has been lost before last checkpoint, no need to reposition.
         write(crlog,"(2(a,i0))") "CR_CHECK> Ignoring IA ",ia," on unit ",iau

--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -208,7 +208,7 @@ subroutine cr_killSwitch(iTurn)
   integer, intent(in) :: iTurn
 
   logical killIt, fExist, onKillTurn
-  integer pTurn, nKills, i, iUnit
+  integer pTurn, nKills, i, cUnit, tUnit
 
   killIt = .false.
   onKillTurn = .false.
@@ -222,21 +222,22 @@ subroutine cr_killSwitch(iTurn)
     return
   end if
 
-  call f_requestUnit("crkillswitch.tmp",iUnit)
+  call f_requestUnit("crkillswitch.tmp",cUnit)
+  call f_requestUnit("crrestartme.tmp", tUnit)
 
   inquire(file="crkillswitch.tmp",exist=fExist)
   if(fExist .eqv. .false.) then
-    open(iUnit,file="crkillswitch.tmp",form="unformatted",access="stream",status="replace",action="write")
-    write(iUnit) 0,0
-    flush(iUnit)
-    close(iUnit)
+    call f_open(unit=cUnit,file="crkillswitch.tmp",formatted=.false.,mode="w",access="stream",status="replace")
+    write(cUnit) 0,0
+    flush(cUnit)
+    call f_close(cUnit)
   end if
 
-  open(iUnit,file="crkillswitch.tmp",form="unformatted",access="stream",status="old",action="read")
-  read(iUnit) pTurn,nKills
-  flush(iUnit)
-  close(iUnit)
-  if(st_debug .and. pTurn > 0) then
+  call f_open(unit=cUnit,file="crkillswitch.tmp",formatted=.false.,mode="r",access="stream",status="old")
+  read(cUnit) pTurn,nKills
+  flush(cUnit)
+  call f_close(cUnit)
+  if(pTurn > 0) then
     write(lout, "(a,i0)") "CRKILLSW> Kill switch previously triggered on turn ",pTurn
     write(crlog,"(a,i0)") "CRKILLSW> Kill switch previously triggered on turn ",pTurn
     flush(lout)
@@ -258,15 +259,15 @@ subroutine cr_killSwitch(iTurn)
     flush(lout)
     flush(crlog)
 
-    open(iUnit,file="crrestartme.tmp",form="unformatted",access="stream",status="replace",action="write")
-    write(iUnit) 1
-    flush(iUnit)
-    close(iUnit)
+    call f_open(unit=tUnit,file="crrestartme.tmp",formatted=.false.,mode="w",access="stream",status="replace")
+    write(tUnit) 1
+    flush(tUnit)
+    call f_close(tUnit)
 
-    open(iUnit,file="crkillswitch.tmp",form="unformatted",access="stream",status="replace",action="write")
-    write(iUnit) iTurn,nKills
-    flush(iUnit)
-    close(iUnit)
+    call f_open(unit=cUnit,file="crkillswitch.tmp",formatted=.false.,mode="w",access="stream",status="replace")
+    write(cUnit) iTurn,nKills
+    flush(cUnit)
+    call f_close(cUnit)
     stop
   end if
 

--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -328,7 +328,7 @@ subroutine crcheck
   ! NOT TRUE anymore??? We might be NOT rerun but using a Sixin.zip
 #ifndef BOINC
   if(cr_rerun .eqv. .false.) then
-    write(lerr,"(a)") "CR_CHECK> ERROR Found "//cr_pntFile(1)//"/"//cr_pntFile(2)//" but no "//trim(fort6)
+    write(lerr,"(a)") "CR_CHECK> ERROR Found checkpoint file(s) but no "//trim(fort6)
     call prror
   end if
 #endif
@@ -453,8 +453,7 @@ subroutine crcheck
         ((((as(k,m,j,l),l=1,il),j=1,crnapxo),m=1,2),k=1,6)
       backspace(cr_pntUnit(nPoint),iostat=ioStat)
       if(ioStat /= 0) cycle
-      write(crlog,"(a)") "CR_CHECK> Read "//cr_pntFile(nPoint)//" EXTENDED OK"
-      write(crlog,"(a)") "CR_CHECK> Leaving "//cr_pntFile(1)//" for CRSTART EXTENDED"
+      write(crlog,"(a)") "CR_CHECK>    "//cr_pntFile(nPoint)//" EXTENDED OK"
       flush(crlog)
     end if
 
@@ -467,7 +466,7 @@ subroutine crcheck
   end do
 
   if(noRestart) then
-    write(crlog,"(a)") "CR_CHECK> ERROR Could not read checkpoint files"
+    write(crlog,"(a)") "CR_CHECK> ERROR No complete checkpoint file found"
     flush(crlog)
     goto 200
   end if

--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -1122,7 +1122,7 @@ subroutine cr_copyOut
   nLines = 0
 10 continue
   read(lout,"(a1024)",end=20,err=20,iostat=ioStat,size=lnSize,advance="no") inLine
-  if(ioStat > 0) goto 20 ! End of file (do not use /= 0)
+  if(ioStat > 0) goto 20 ! Do not use /= 0
 
   write(output_unit,"(a)",err=30,iostat=ioStat) inLine(1:lnSize)
   if(ioStat /= 0) goto 30

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -137,14 +137,14 @@ module mod_common
   integer,           save      :: ithick     = 0       ! Thick tracking flag
 
   ! File Names and Units
-  character(len=mFileName), public, save :: fort2   = "fort.2"      ! Name of machine geometry file
-  character(len=mFileName), public, save :: fort3   = "fort.3"      ! Name of main input file
-  character(len=mFileName), public, save :: fort6   = "fort.6"      ! Name of main output file (stdout)
-  character(len=mFileName), public, save :: fort10  = "fort.10"     ! Name of main postprocessing file (text)
-  character(len=mFileName), public, save :: fort110 = "fort.10.bin" ! Name of main postprocessing file (binary)
+  character(len=mFileName), public, save :: fort2   = "fort.2"   ! Name of machine geometry file
+  character(len=mFileName), public, save :: fort3   = "fort.3"   ! Name of main input file
+  character(len=mFileName), public, save :: fort6   = "fort.6"   ! Name of main output file (stdout)
+  character(len=mFileName), public, save :: fort10  = "fort.10"  ! Name of main postprocessing file (text)
+  character(len=mFileName), public, save :: fort110 = "fort.110" ! Name of main postprocessing file (binary)
 
-  integer,                  public, save :: unit10  = -1            ! Unit of main postprocessing file (text)
-  integer,                  public, save :: unit110 = -1            ! Unit of main postprocessing file (binary)
+  integer,                  public, save :: unit10  = -1         ! Unit of main postprocessing file (text)
+  integer,                  public, save :: unit110 = -1         ! Unit of main postprocessing file (binary)
 
   !  GENERAL VARIABLES
   ! ===================

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -137,14 +137,14 @@ module mod_common
   integer,           save      :: ithick     = 0       ! Thick tracking flag
 
   ! File Names and Units
-  character(len=mFileName), public, save :: fort2   = "fort.2"   ! Name of machine geometry file
-  character(len=mFileName), public, save :: fort3   = "fort.3"   ! Name of main input file
-  character(len=mFileName), public, save :: fort6   = "fort.6"   ! Name of main output file (stdout)
-  character(len=mFileName), public, save :: fort10  = "fort.10"  ! Name of main postprocessing file (text)
-  character(len=mFileName), public, save :: fort110 = "fort.110" ! Name of main postprocessing file (binary)
+  character(len=mFileName), public, save :: fort2   = "fort.2"      ! Name of machine geometry file
+  character(len=mFileName), public, save :: fort3   = "fort.3"      ! Name of main input file
+  character(len=mFileName), public, save :: fort6   = "fort.6"      ! Name of main output file (stdout)
+  character(len=mFileName), public, save :: fort10  = "fort.10"     ! Name of main postprocessing file (text)
+  character(len=mFileName), public, save :: fort110 = "fort.10.bin" ! Name of main postprocessing file (binary)
 
-  integer,                  public, save :: unit10  = -1         ! Unit of main postprocessing file (text)
-  integer,                  public, save :: unit110 = -1         ! Unit of main postprocessing file (binary)
+  integer,                  public, save :: unit10  = -1            ! Unit of main postprocessing file (text)
+  integer,                  public, save :: unit110 = -1            ! Unit of main postprocessing file (binary)
 
   !  GENERAL VARIABLES
   ! ===================

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -905,7 +905,6 @@ module mod_common_main
   ! Main 4
   real(kind=fPrec), save :: e0f
   integer,          save :: numx     = 0       ! Checkpoint turn (turn-1)
-  logical,          save :: sythckcr = .false. ! Only used for CR
 
 contains
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -136,10 +136,15 @@ module mod_common
   logical,           save      :: print_dcum = .false. ! Print dcum. Set in the SETTINGS block
   integer,           save      :: ithick     = 0       ! Thick tracking flag
 
-  ! File Names
-  character(len=mFileName), public, save :: fort2 = "fort.2" ! Name of machine geometry file
-  character(len=mFileName), public, save :: fort3 = "fort.3" ! Name of main input file
-  character(len=mFileName), public, save :: fort6 = "fort.6" ! Name of main output file (stdout)
+  ! File Names and Units
+  character(len=mFileName), public, save :: fort2   = "fort.2"   ! Name of machine geometry file
+  character(len=mFileName), public, save :: fort3   = "fort.3"   ! Name of main input file
+  character(len=mFileName), public, save :: fort6   = "fort.6"   ! Name of main output file (stdout)
+  character(len=mFileName), public, save :: fort10  = "fort.10"  ! Name of main postprocessing file (text)
+  character(len=mFileName), public, save :: fort110 = "fort.110" ! Name of main postprocessing file (binary)
+
+  integer,                  public, save :: unit10  = -1         ! Unit of main postprocessing file (text)
+  integer,                  public, save :: unit110 = -1         ! Unit of main postprocessing file (binary)
 
   !  GENERAL VARIABLES
   ! ===================

--- a/source/dabnew.f90
+++ b/source/dabnew.f90
@@ -177,6 +177,7 @@ subroutine daini(no,nv,iunit)
       use mod_lie_dab, only : idao,iscrda,iscrri,rscrri,allvec,eps,epsmac,nda,ndamaxi,nst,nomax,nvmax,  &
         nmmax,nocut,lfi,idall,i1,i2,ie1,ie2,ieo,ia1,ia2,lda,lst,lea,lia,lno,lnv
       use crcoall
+      use mod_units
       implicit none
       integer i,ibase,ic1,ic2,icmax,io1,io2,iout,iunit,j,jd,jj,jjj,jjjj,jl,js,k,n,nn,no,nv
       integer iall(1)
@@ -389,23 +390,7 @@ subroutine daini(no,nv,iunit)
       write(lout,*)'ARRAY SETUP DONE, BEGIN PRINTING'
 
       iout = 32
-#ifdef BOINC
-      call boincrf('DAINI.DAT',filename)
-#ifdef FIO
-      open(iout,file=filename,status='new',round='nearest')
-#else
-      open(iout,file=filename,status='new')
-#endif
-#else
-#ifdef FIO
-      open(iout,file='DAINI.DAT',status='NEW',round='nearest')
-#else
-      open(iout,file='DAINI.DAT',status='NEW')
-#endif
-#endif
-!CRAY OPEN(IOUT,FILE='DAINI',STATUS='UNKNOWN',FORM='FORMATTED')          *CRAY
-!CRAY REWIND IOUT                                                        *CRAY
-
+      call f_open(unit=iout,file="daini.dat",formatted=.true.,mode="rw",status="new")
       write(iout,'(/A/A/)') ' ARRAYS I1 THROUGH I20, IE1,IE2,IEO',' **********************************'
       do i=1,nmmax
         call dancd(ie1(i),ie2(i),jj)

--- a/source/dabnew.f90
+++ b/source/dabnew.f90
@@ -737,13 +737,8 @@ subroutine dadal(idal,l)
           call dadeb(31,'ERR DADAL ',1)
         endif
         if(idal(i).eq.nda) then
-!       deallocate
           nst = idapo(nda) - 1
           nda = nda - 1
-!        else
-!        write(6,'(a10)')daname(i)
-!        write(6,*)' etienne',idal(i),nda
-!        write(6,*) sqrt(-1.d0)
         endif
 
         allvec(idal(i)) = .false.
@@ -1101,12 +1096,6 @@ subroutine dapok(ina,jj,cjj)
 !     DETERMINE IF MONOMIAL TO BE POKED CONFORMS WITH INOA, INVA,NOCUT
 !     ****************************************************************
 !
-!      IF(ICO.GT.INOA.OR.ICV.GT.INVA) THEN
-!         write(6,*)'ERROR IN DAPOK, MONOMIAL NOT ALLOWED FOR ',A
-!         CALL DADEB(31,'ERR DAPOK ',1)
-!      ENDIF
-!      IF(ICO.GT.NOCUT) RETURN
-
       if(illa.ne.0) then ! etienne shit
       iu = ipoa
       iz = ipoa + illa - 1
@@ -1540,7 +1529,6 @@ subroutine daexc(ina,ckon,inb)
 !     THIS SUBROUTINE EXPONENTIATES INE WITH THE CONSTANT CKON
 !
 !-----------------------------------------------------------------------------1
-!        write(6,*) "daexc"
 
       if(ina.eq.inb) then
         call dainf(inc,inoc,invc,ipoc,ilmc,illc)
@@ -3341,7 +3329,6 @@ subroutine mtree(mb,ib,mc,ic)
 
       call dapok(ichk(1),jj,-one)
 
-!     write(6,*)'JL,JV = ',JL,JV(JL)
       do 210 i=1,ib
       call dapek(mb(i),jj,bbijj)
       i1(idapo(mc(i))+nterm-1) = jl
@@ -4567,8 +4554,6 @@ subroutine dapri(ina,iunit)
            endif
          write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))') iout,cc(ipoa+i-1),ioa,(j(iii),iii=1,nvmax)
          write(111) cc(ipoa+i-1)
-!Eric
-!        write(iunit,*) cc(ipoa+i-1)
          write(iunit,'(G21.14)') cc(ipoa+i-1)
          write(111) cc(ipoa+i-1)
  90     continue
@@ -4595,10 +4580,8 @@ subroutine dapri(ina,iunit)
 #endif
           write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))') iout,cc(ii),ioa,(j(iii),iii=1,nvmax)
 !Eric
-         write(111) cc(ii)
+          write(111) cc(ii)
 !ETIENNE
-!Eric
-!         write(iunit,* ) cc(ii)
           write(iunit,'(G21.14)') cc(ii)
           write(111) cc(ii)
           endif

--- a/source/dabnew.f90
+++ b/source/dabnew.f90
@@ -389,21 +389,20 @@ subroutine daini(no,nv,iunit)
 
       write(lout,*)'ARRAY SETUP DONE, BEGIN PRINTING'
 
-      iout = 32
-      call f_open(unit=iout,file="daini.dat",formatted=.true.,mode="rw",status="new")
-      write(iout,'(/A/A/)') ' ARRAYS I1 THROUGH I20, IE1,IE2,IEO',' **********************************'
+      call f_open(unit=32,file="daini.dat",formatted=.true.,mode="rw",status="new")
+      write(32,'(/A/A/)') ' ARRAYS I1 THROUGH I20, IE1,IE2,IEO',' **********************************'
       do i=1,nmmax
         call dancd(ie1(i),ie2(i),jj)
-        write(iout,'(1X,I5,2X,4(5I2,1X),3I6)') i,(jj(jjjj),jjjj=1,lnv),ie1(i),ie2(i),ieo(i)
+        write(32,'(1X,I5,2X,4(5I2,1X),3I6)') i,(jj(jjjj),jjjj=1,lnv),ie1(i),ie2(i),ieo(i)
       end do
 
-      write(iout,'(/A/A/)') ' ARRAYS IA1,IA2',' **************'
+      write(32,'(/A/A/)') ' ARRAYS IA1,IA2',' **************'
 
       do i=0,icmax
-        write(iout,'(3I10)') i,ia1(i),ia2(i)
+        write(32,'(3I10)') i,ia1(i),ia2(i)
       end do
+      call f_close(32)
 
-      return
 end subroutine daini
 
 subroutine daexter
@@ -3364,42 +3363,6 @@ subroutine mtree(mb,ib,mc,ic)
       return
       end
 
-
-subroutine ppushpri(mc,ic,mf,jc,line)
-      use floatPrecision
-      use mod_lie_dab, only : cc,idapo,idall,i1,i2
-      implicit none
-      integer i,ic,iv,jc,jl,jv,mc,mf
-
-      dimension mc(*)
-      character(len=20) line
-      if(mf.le.0) return
-      write(mf,*) 0,0,jc+1,0,line
-
-      do i=1,ic
-        jc=1+jc
-        write(mf,*) jc,jl,jv,cc(idapo(mc(i)))
-      end do
-
-!     xf(i) = cc(idapo(mc(i)))
-!      xm(1) = 1.d0
-      do i=1,idall(mc(1))-1
-        jl = i1(idapo(mc(1))+i)
-        jv = i2(idapo(mc(1))+i)
-!       xx = xm(jl)*xi(jv)
-!       xm(jl+1) = xx
-
-        do iv=1,ic
-          jc=1+jc
-          write(mf,*) jc,jl,jv,cc(idapo(mc(iv))+i)
-!         xf(iv) = xf(iv) + cc(idapo(mc(iv))+i) * xx
-        end do
-      end do
-
-      return
-      end
-
-
 subroutine ppush(mc,ic,xi,xf)
       use floatPrecision
       use numerical_constants
@@ -4521,27 +4484,21 @@ subroutine dapri(ina,iunit)
       if(inva.eq.0) then
          write(iunit,'(A)') '    I  VALUE  '
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
          do i = ipoa,ipoa+illa-1
            write(iunit,'(I6,2X,G21.14)') i-ipoa, cc(i)
            !Eric
-           write(111) cc(i)
+           write(26) cc(i)
          end do
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
       elseif(nomax.eq.1) then
          if(illa.ne.0) write(iunit,'(A)') '    I  COEFFICIENT          ORDER   EXPONENTS'
          if(illa.eq.0) write(iunit,'(A)') '   ALL COMPONENTS ZERO '
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
          do 90 i=1,illa
            do k=1,inva
@@ -4553,14 +4510,12 @@ subroutine dapri(ina,iunit)
              ioa=1
            endif
          write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))') iout,cc(ipoa+i-1),ioa,(j(iii),iii=1,nvmax)
-         write(111) cc(ipoa+i-1)
+         write(26) cc(ipoa+i-1)
          write(iunit,'(G21.14)') cc(ipoa+i-1)
-         write(111) cc(ipoa+i-1)
+         write(26) cc(ipoa+i-1)
  90     continue
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
       else
          if(illa.ne.0) write(iunit,'(A)') '    I  COEFFICIENT          ORDER   EXPONENTS'
@@ -4574,23 +4529,19 @@ subroutine dapri(ina,iunit)
 !ETIENNE
           iout = iout+1
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
           write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))') iout,cc(ii),ioa,(j(iii),iii=1,nvmax)
 !Eric
-          write(111) cc(ii)
+          write(26) cc(ii)
 !ETIENNE
           write(iunit,'(G21.14)') cc(ii)
-          write(111) cc(ii)
+          write(26) cc(ii)
           endif
 !ETIENNE
 !
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
  100      continue
         end do
@@ -4601,7 +4552,7 @@ subroutine dapri(ina,iunit)
       write(iunit,'(A)') '                                      '
 
 !Eric
-      write(111) zero
+      write(26) zero
       return
       end
 
@@ -4640,15 +4591,7 @@ subroutine dapri77(ina,iunit)
       ipoa = idapo(ina)
       ilma = idalm(ina)
       illa = idall(ina)
-!
-!      WRITE(IUNIT,*) INA, ' in dapri ', DANAME(INA)
-!      WRITE(6,*) INA, ' in dapri ', DANAME(INA)
-! 611  WRITE(6,*) ' MORE '
-!        READ(5,*) MORE
-!        IF(MORE.GT.0) THEN
-!        WRITE(6,*) MORE,' ',DANAME(MORE)
-!        GOTO 611
-!        ENDIF
+
       write(iunit,'(/1X,A10,A6,I5,A6,I5,A7,I5/1X,A/)') daname(ina),', NO =',inoa,', NV =',inva,', INA =',ina, &
      &'***********'//'**********************************'
 
@@ -4683,11 +4626,8 @@ subroutine dapri77(ina,iunit)
             end if
 
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
+      call enable_xp()
 #endif
-#endif
-!      WRITE(IUNIT,*) IOA,CC(II),(J(I),I=1,INVA)
       if(abs(cc(ii)).gt.eps) then
       if(eps.gt.1.e-37_fPrec) then
        write(iunit,501) ioa,cc(ii),(j(i),i=1,inva)
@@ -4699,9 +4639,7 @@ subroutine dapri77(ina,iunit)
  503  format(' ', i3,1x,g23.16,1x,100(1x,i2))
  502  format(' ', i5,1x,g23.16,1x,100(1x,i2))
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
       end if
 !ETIENNE
@@ -4715,20 +4653,14 @@ subroutine dapri77(ina,iunit)
 
       if(iout.eq.0) iout=1
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
+      call enable_xp()
 #endif
-#endif
-
       write(iunit,502) -iout,zero,(j(i),i=1,inva)
-
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
+      call disable_xp()
 #endif
-#endif
-      return
-      end
+
+end
 
 
 subroutine dashift(ina,inc,ishift)
@@ -4763,14 +4695,6 @@ subroutine dashift(ina,inc,ishift)
       illa = idall(ina)
       call daall(inb(1),1,'$$DAJUNK$$',inoa,inva)
 
-!      WRITE(IUNIT,*) INA, ' in dapri ', DANAME(INA)
-!      WRITE(6,*) INA, ' in dapri ', DANAME(INA)
-! 611  WRITE(6,*) ' MORE '
-!        READ(5,*) MORE
-!        IF(MORE.GT.0) THEN
-!        WRITE(6,*) MORE,' ',DANAME(MORE)
-!        GOTO 611
-!        ENDIF
       iout = 0
 
 !      DO 100 IOA = 0,INOA
@@ -4796,17 +4720,8 @@ subroutine dashift(ina,inc,ishift)
         iout = iout+1
       endif
 
-!      WRITE(IUNIT,*) IOA,CC(II),(J(I),I=1,INVA)
       if(abs(cc(ii)).gt.eps) then
       if(eps.gt.1.e-37_fPrec) then
-#ifdef CRLIBM
-!                                                 call enable_xp()
-#endif
-!       write(iunit,501) ioa,cc(ii),(j(i),i=1,inva)
-#ifdef CRLIBM
-!                                                 call disable_xp()
-#endif
-!      write(111) cc(ii)
        ich=1
        do ik=1,ishift
          if(j(ik).ne.0) ich=0
@@ -4821,14 +4736,6 @@ subroutine dashift(ina,inc,ishift)
        endif
        call dapok(inb(1),jd,cc(ii))
       else
-#ifdef CRLIBM
-!                                                 call enable_xp()
-#endif
-!       write(iunit,503) ioa,cc(ii),(j(i),i=1,inva)
-#ifdef CRLIBM
-!                                                 call disable_xp()
-#endif
-!       write(111) c(ii)
         ich=1
         do ik=1,ishift
           if(j(ik).ne.0) ich=0
@@ -4928,7 +4835,7 @@ subroutine darea(ina,iunit)
       call disable_xp()
 #endif
 !Eric
-      read(111) c
+      read(26) c
 !
       if(ii.eq.0) goto 20
 !ETIENNE
@@ -4938,7 +4845,7 @@ subroutine darea(ina,iunit)
 !Eric
       read(iunit,'(G21.14)') c
 !Eric
-      read(111) c
+      read(26) c
 #ifdef CRLIBM
       call disable_xp()
 #endif
@@ -5426,7 +5333,7 @@ subroutine datra(idif,ina,inc)
       idall(inc) = ic - ipoc + 1
       if(idall(inc).gt.idalm(inc)) then
          write(lout,*)'ERROR IN DADTRA'
-         call dadeb(111,'ERR DADTRA',1)
+         call dadeb(26,'ERR DADTRA',1)
       endif
 
       return
@@ -6113,11 +6020,7 @@ subroutine daprimax(ina,iunit)
 
       if(ina.lt.1.or.ina.gt.nda) then
          write(lout,*)'ERROR IN DAPRI, INA = ',ina
-#ifdef CR
-      call abend('                                                  ')
-#else
-         stop
-#endif
+         call prror
       endif
 
       inoa = idano(ina)
@@ -6131,17 +6034,13 @@ subroutine daprimax(ina,iunit)
 
       if(inva.eq.0) then
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
          do i = ipoa,ipoa+illa-1
            write(iunit,'(I6,2X,G21.14)') i-ipoa, cc(i)
          end do
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
       elseif(nomax.eq.1) then
          do 90 i=1,illa
@@ -6151,17 +6050,13 @@ subroutine daprimax(ina,iunit)
              ioa=1
            endif
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
          write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))')                 &
      &iout,cc(ipoa+i-1),ioa,(j(iii),iii=1,nvmax)
          write(iunit,*) cc(ipoa+i-1)
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
  90      continue
       else
@@ -6175,18 +6070,14 @@ subroutine daprimax(ina,iunit)
 !ETIENNE
           iout = iout+1
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call enable_xp()
-#endif
+      call enable_xp()
 #endif
           write(iunit,'(I6,2X,G21.14,I5,4X,18(2I2,1X))')                &
      &iout,cc(ii),ioa,(j(iii),iii=1,nvmax)
 !ETIENNE
           write(iunit,*) cc(ii)
 #ifdef CRLIBM
-#ifndef LF95
-                                                  call disable_xp()
-#endif
+      call disable_xp()
 #endif
           endif
 !ETIENNE
@@ -6382,7 +6273,7 @@ subroutine daorder(ina,iunit,jx,invo,nchop)
 #ifdef CRLIBM
 #ifndef LF95
                                                   call disable_xp()
-      read(111) c
+      read(26) c
 #endif
 #endif
 
@@ -6401,7 +6292,7 @@ subroutine daorder(ina,iunit,jx,invo,nchop)
                                                   call disable_xp()
 #endif
 #endif
-      read(111) c
+      read(26) c
 
       do jh=1,invo
         j(jh)=jt(jx(jh))
@@ -6513,7 +6404,7 @@ subroutine datrash(idif,ina,inc)
       idall(inc) = ic - ipoc + 1
       if(idall(inc).gt.idalm(inc)) then
          write(lout,*)'ERROR IN DATRASH '
-         call dadeb(111,'ERR DATRAS',1)
+         call dadeb(26,'ERR DATRAS',1)
       endif
 !
       return

--- a/source/dynk.f90
+++ b/source/dynk.f90
@@ -841,7 +841,7 @@ subroutine dynk_parseFUN(inLine, iErr)
       ! Reading the FIR/IIR file without CRLIBM
       read(tmpUnit,"(a)",iostat=ioStat) fLine
       if(ioStat /= 0) then ! EOF
-        write(lerr,"(a)") "DYNK> ERROR FUN:FIR/IIR Unexpected when reading file '"//trim(dynk_cData(dynk_ncData))//"'"
+        write(lerr,"(a)") "DYNK> ERROR FUN:FIR/IIR Unexpected EOF when reading file '"//trim(dynk_cData(dynk_ncData))//"'"
         iErr = .true.
         return
       end if

--- a/source/dynk.f90
+++ b/source/dynk.f90
@@ -584,8 +584,8 @@ subroutine dynk_parseFUN(inLine, iErr)
       end if
 
       ! DYNK PIPE does not support the CR version, so BOINC support (call boincrf()) isn't needed
-      open(unit=dynk_iData(dynk_niData),file=dynk_cData(dynk_ncData-2),action="read",iostat=ioStat,status="old")
-      if(ioStat /= 0) then
+      call f_open(unit=dynk_iData(dynk_niData),file=dynk_cData(dynk_ncData-2),formatted=.true.,mode="r",err=fErr,status="old")
+      if(fErr) then
         write(lerr,"(a,i0)") "DYNK> ERROR FUN:PIPE Could not open file '"//trim(dynk_cData(dynk_ncData-2))//"' stat = ",ioStat
         iErr = .true.
         return
@@ -605,8 +605,8 @@ subroutine dynk_parseFUN(inLine, iErr)
       end if
 
       ! DYNK PIPE does not support the CR version, so BOINC support (call boincrf()) isn't needed
-      open(unit=dynk_iData(dynk_niData+1),file=dynk_cData(dynk_ncData-1),action="write",iostat=ioStat,status="old")
-      if(ioStat /= 0) then
+      call f_open(unit=dynk_iData(dynk_niData+1),file=dynk_cData(dynk_ncData-1),formatted=.true.,mode="w",err=fErr,status="old")
+      if(fErr) then
         write(lerr,"(a)") "DYNK> ERROR FUN:PIPE Could not open file '"//trim(dynk_cData(dynk_ncData-1))//"' stat = ",ioStat
         iErr = .true.
         return

--- a/source/elens.f90
+++ b/source/elens.f90
@@ -576,7 +576,7 @@ subroutine parseRadialProfile(ifile)
 
 20 continue
 
-  call f_close(fUnit)
+  call f_freeUnit(fUnit)
   write(lout,"(a,i0,a)") "ELENS> ...acquired ",elens_radial_profile_nPoints(ifile),"points."
 
   if(st_quiet < 2) then

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -79,8 +79,7 @@ subroutine abend(endMsg)
   write(crlog,"(a)") "ABEND_CR> Closing files"
   flush(crlog)
 
-  ! Calling close to be very safe.......96 calls to abend
-  ! Easier than adding the call on every abend
+  ! Calling close to be very safe
   call closeUnits
 
 #ifdef BOINC
@@ -89,11 +88,11 @@ subroutine abend(endMsg)
   write(crlog,"(a)") "ABEND_CR> Checking fort.10"
   flush(crlog)
 
-  call f_open(unit=10,file="fort.10",formatted=.true.,mode="r",err=fErr,status="old",recl=8195)
+  call f_open(unit=unit10,file=fort10,formatted=.true.,mode="r",err=fErr,status="old",recl=8195)
   if(fErr) goto 11
 
   ! Now we try and read fort.10 i.e. is it empty?
-  read(10,"(a1024)",end=11,err=11,iostat=ierro) inLine
+  read(unit10,"(a1024)",end=11,err=11,iostat=ierro) inLine
   ! Seems to be OK
   goto 12
 
@@ -107,8 +106,8 @@ subroutine abend(endMsg)
   ! Make sure it is closed properly before we re-open for dummy write
   ! inquire(10,opened=fOpen)
   ! if(fOpen) close(10)
-  call f_close(10)
-  call f_open(unit=10,file="fort.10",formatted=.true.,mode="w",err=fErr,status="unknown",recl=8195)
+  call f_close(unit10)
+  call f_open(unit=unit10,file=fort10,formatted=.true.,mode="w",err=fErr,status="unknown",recl=8195)
 
   sumda(:) = zero
   call time_timerCheck(time1)
@@ -130,7 +129,7 @@ subroutine abend(endMsg)
   write(crlog,"(2(a,i0))") "ABEND_CR> Writing fort.10, lines ",napxo,"/",napx
   flush(crlog)
   do j=1,napxo ! Must the dummy file really be napxo times the same dummy line?
-    write(10,"(a)",iostat=ierro) outLine(1:60*26)
+    write(unit10,"(a)",iostat=ierro) outLine(1:60*26)
   end do
   if(ierro /= 0) then
     write(lerr,"(a,i0)") "ABEND> ERROR Problems writing to fort.10. ierro = ",ierro

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -128,7 +128,7 @@ subroutine abend(endMsg)
   if(napxo == 0) napxo = napx
   write(crlog,"(2(a,i0))") "ABEND_CR> Writing fort.10, lines ",napxo,"/",napx
   flush(crlog)
-  do j=1,napxo ! Must the dummy file really be napxo times the same dummy line?
+  do j=1,napxo,2 ! Must the dummy file really be napxo times the same dummy line?
     write(unit10,"(a)",iostat=ierro) outLine(1:60*26)
   end do
   if(ierro /= 0) then

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -149,7 +149,7 @@ subroutine abend(endMsg)
 
 #ifdef BOINC
   call boinc_finish(errout) ! This call does not return
-#else
+#endif
   if(errout /= 0) then
     ! Don't write to stderr, it breaks the error tests.
     write(output_unit,"(a,i0)") "ABEND> ERROR Stopping with error ",errout
@@ -157,7 +157,6 @@ subroutine abend(endMsg)
   else
     stop
   end if
-#endif
 
 end subroutine abend
 

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -88,6 +88,7 @@ subroutine abend(endMsg)
   write(crlog,"(a)") "ABEND_CR> Checking fort.10"
   flush(crlog)
 
+  ! The safest way to check if a file exists is to try to open it and catch the fail
   call f_open(unit=unit10,file=fort10,formatted=.true.,mode="r",err=fErr,status="old",recl=8195)
   if(fErr) goto 11
 
@@ -98,14 +99,10 @@ subroutine abend(endMsg)
 
 11 continue
   ! Now we try and write a fort.10
-  ! We put some CPU for Igor, a version, and turn number 0
-  ! call f_open(unit=10,file="fort.10",formatted=.true.,mode="w",err=fErr,status="unknown",recl=8195)
   write(crlog,"(a)") "ABEND_CR> Writing dummy fort.10"
   flush(crlog)
 
   ! Make sure it is closed properly before we re-open for dummy write
-  ! inquire(10,opened=fOpen)
-  ! if(fOpen) close(10)
   call f_close(unit10)
   call f_open(unit=unit10,file=fort10,formatted=.true.,mode="w",err=fErr,status="unknown",recl=8195)
 

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -89,6 +89,7 @@ subroutine abend(endMsg)
   flush(crlog)
 
   ! The safest way to check if a file exists is to try to open it and catch the fail
+  call f_requestUnit(fort10,unit10) ! Make sure this is actually set
   call f_open(unit=unit10,file=fort10,formatted=.true.,mode="r",err=fErr,status="old",recl=8195)
   if(fErr) goto 11
 
@@ -164,7 +165,7 @@ end subroutine abend
 !  K. Sjobak, V.K. Berglyd Olsen, BE-ABP-HSS
 !  Created:   2017-06
 !  Rewritten: 2019-04-15 (VKBO)
-!  Updated:   2019-05-02
+!  Updated:   2019-05-03
 !  Subroutine to copy the last lines from a file to stderr
 !  It is mainly used just before exiting SixTrack in case there was an error.
 !  This is useful since STDERR is often returned from batch systems and BOINC.
@@ -184,7 +185,7 @@ subroutine copyToStdErr(fUnit,fName,maxLines)
 
   integer i, bufIdx, bufMax, lnSize, ioStat, szBuf(maxLines)
   logical isOpen, fErr
-  character(len=256) inLine, inBuf(maxLines)
+  character(len=1024) inLine, inBuf(maxLines)
 
   inquire(unit=fUnit,opened=isOpen)
   if(isOpen) then
@@ -198,8 +199,8 @@ subroutine copyToStdErr(fUnit,fName,maxLines)
   bufIdx = 0
   bufMax = 0
 10 continue
-  read(fUnit,"(a256)",end=20,err=20,iostat=ioStat,size=lnSize,advance="no") inLine
-  if(ioStat > 0) goto 20 ! End of file (do not use /= 0)
+  read(fUnit,"(a1024)",end=20,err=20,iostat=ioStat,size=lnSize,advance="no") inLine
+  if(ioStat > 0) goto 20 ! Do not use /= 0
   bufIdx = bufIdx + 1
   if(bufIdx > maxLines) bufIdx = 1
   if(bufIdx > bufMax)   bufMax = bufIdx

--- a/source/fma.f90
+++ b/source/fma.f90
@@ -693,6 +693,7 @@ subroutine fma_postpr
         if(fma_writeNormDUMP .and. .not.(dumpfmt(j) == 7 .or. dumpfmt(j) == 8) .and. .not.hasNormDumped(j)) then
           ! filename NORM_* (normalised particle amplitudes)
           call f_close(tmpUnit)
+          call f_freeUnit(tmpUnit)
           hasNormDumped(j) = .true.
         end if
 

--- a/source/fma.f90
+++ b/source/fma.f90
@@ -171,15 +171,15 @@ subroutine fma_postpr
   real(kind=fPrec), allocatable :: epsnxyzv(:,:,:)
 
 #ifdef NAFF
-interface
-  real(c_double) function tunenaff(x,xp,maxn,plane_idx,norm_flag, fft_naff) bind(c)
-    use, intrinsic :: iso_c_binding
-    implicit none
-    real(c_double), intent(in), dimension(1) :: x,xp
-    integer(c_int), intent(in), value :: maxn, plane_idx, norm_flag
-    real(c_double), intent(in), value :: fft_naff
-  end function tunenaff
-end interface
+  interface
+    real(c_double) function tunenaff(x,xp,maxn,plane_idx,norm_flag, fft_naff) bind(c)
+      use, intrinsic :: iso_c_binding
+      implicit none
+      real(c_double), intent(in), dimension(1) :: x,xp
+      integer(c_int), intent(in), value :: maxn, plane_idx, norm_flag
+      real(c_double), intent(in), value :: fft_naff
+    end function tunenaff
+  end interface
 #endif
 
   ! need to pass a single dimension array to naff,
@@ -628,20 +628,7 @@ end interface
 
 #ifdef NAFF
             case("NAFF")
-              ! write(lout,*) "DBG", fma_nturn(i),l
-              ! write(lout,*) "DBG", nxyzv(l,1,2*(m-1)+1), nxyzv(l,1,2*m)
-              !
-              ! write(lout,*) size(xyzv(l,fma_first(i):fma_last(i),2*(m-1)+1))
-              ! write(lout,*) size(xyzv(l,fma_first(i):fma_last(i),2*m))
-
-              flush(lout)  ! F2003 does specify a FLUSH statement.
-              ! However NAFF should NOT be chatty...
-
-              ! do n=1,fma_nturn(i)
-              !    write(*,*) n, nxyzv(l,n,2*(m-1)+1), nxyzv(l,n,2*m)
-              ! enddo
-              ! write(*,*) ""
-
+              flush(lout)
               ! Copy the relevant contents of the arrays
               ! into a new temporary array with stride=1
               ! for passing to C++.

--- a/source/lielib.f90
+++ b/source/lielib.f90
@@ -1456,7 +1456,6 @@ subroutine flofacg(xy,h,epsone)
       call dacmud(h,-one,t)
       call expflod(t,xy,x,eps,nrmax)
       call dalind(x,one,v,-one,t)
-! write(20,*) "$$$$$$$$$$$$$$",k,"$$$$$$$$$$$$$$$$$$$$"
 ! call daprid(t,1,1,20)
        if(xn.lt.epsone) then
             if(idpr.ge.0) write(lout,*) "xn quadratic",xn
@@ -1666,7 +1665,6 @@ subroutine mapnormf(x,ft,a2,a1,xy,h,nord,isi)
       call initpert(st,angle,radn)
       call simil(a2i,xy,a2,xy)
       call dacopd(xy,a2i)
-!        write(6,*) 'Entering orderflo'
       call orderflo(h,ft,xy,angle,radn)
       do ij=1,nd-ndc
         p(ij)=angle(ij)
@@ -1835,7 +1833,6 @@ subroutine orderflo(h,ft,x,ang,ra)
       call facflod(h,x,v,2,k-1,-one,-1)
 ! EXTRACTING K TH DEGREE OF V ----> W
       call taked(v,k,w)
-!  write(16,*) "$$$$$$$$  K  $$$$$$$$$$", k
 ! W = EXP(B5) + ...
        call dacopd(w,b5)
 !      CALL INTD(W,B5,-1.D0)
@@ -2904,11 +2901,6 @@ subroutine movearou(rt)
       ic=0
       xrold=1000000000.0_fPrec
       call movemul(rt,s,rto,xr)
-! write(6,*) xr,xrold
-!  do i=1,6
-!       write(6,'(6(1x,1pe12.5))') (RTO(i,j),j=1,6)
-!  enddo
-!  PAUSE
       if(xr.lt.xrold) then
         xrold=xr
       endif
@@ -4042,7 +4034,6 @@ subroutine sympl3(m)
             qp = qp + m(lq,jq)*m(kp,jp) - m(lq,jp)*m(kp,jq)
             pp = pp + m(lp,jq)*m(kp,jp) - m(lp,jp)*m(kp,jq)
   300     continue
-!         write(6,*) qq,pq,qp,pp
           do 400 i=1,2*n
             m(kq,i) = m(kq,i) - qq*m(lp,i) + pq*m(lq,i)
             m(kp,i) = m(kp,i) - qp*m(lp,i) + pp*m(lq,i)
@@ -4053,7 +4044,6 @@ subroutine sympl3(m)
           jq = jp-1
           qp = qp + m(kq,jq)*m(kp,jp) - m(kq,jp)*m(kp,jq)
   500   continue
-!       write(6,*) qp
         do 600 i=1,2*n
           m(kp,i) = m(kp,i)/qp
   600   continue

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1416,18 +1416,18 @@ program maincr
       iposc = iposc+1
 #ifdef STF
 #ifdef CR
-      call postpr(ia,nnuml)
       write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
       flush(crlog)
+      call postpr(ia,nnuml)
 #else
       call postpr(ia)
 #endif
 #else
-      ia2 = 91-(ia+1)/2
+      ia2 = 91-(ia+1)/2 ! Track file unit number if not STF
 #ifdef CR
-      call postpr(ia2,nnuml)
       write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",ia2,", turns: ",nnuml
       flush(crlog)
+      call postpr(ia2,nnuml)
 #else
       call postpr(ia2)
 #endif
@@ -1450,17 +1450,17 @@ program maincr
       if(ia > ndafi) exit
 #ifdef STF
 #ifdef CR
-      call postpr(ia,nnuml)
       write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
       flush(crlog)
+      call postpr(ia,nnuml)
 #else
       call postpr(ia)
 #endif
 #else
 #ifdef CR
-      call postpr(91-ia,nnuml)
       write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-i),", turns: ",nnuml
       flush(crlog)
+      call postpr(91-ia,nnuml)
 #else
       call postpr(91-ia)
 #endif

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -307,7 +307,7 @@ program maincr
 #ifndef CR
       call postpr(91-i)
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit = ",(91-i),", nnuml = ",nnuml
+      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-i),", turns: ",nnuml
       flush(crlog)
       call postpr(91-i,nnuml)
 #endif
@@ -321,7 +321,7 @@ program maincr
 #ifndef CR
       call postpr(i)
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Particle = ",i,", nnuml = ",nnuml
+      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",i,",",(i+1),", turns: ",nnuml
       flush(crlog)
       call postpr(i,nnuml)
 #endif
@@ -1406,7 +1406,7 @@ program maincr
 #ifndef CR
       call postpr(91-ia2) ! Postprocess file "fort.(91-ia2)"
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit = ",(91-ia2),", nnuml = ",nnuml
+      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-ia2),", turns: ",nnuml
       flush(crlog)
       call postpr(91-ia2,nnuml)
 #endif
@@ -1423,7 +1423,7 @@ program maincr
 #ifndef CR
       call postpr(91-ia)
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit = ",(91-i),", nnuml = ",nnuml
+      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-i),", turns: ",nnuml
       flush(crlog)
       call postpr(91-ia,nnuml)
 #endif
@@ -1439,7 +1439,7 @@ program maincr
 #ifndef CR
       call postpr(ia) ! Postprocess particle ia (and ia+1 if ntwin=2)
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Particle = ",ia,", nnuml = ",nnuml
+      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
       flush(crlog)
       call postpr(ia,nnuml)
 #endif
@@ -1456,7 +1456,7 @@ program maincr
 #ifndef CR
       call postpr(ia)
 #else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Particle = ",ia,", nnuml = ",nnuml
+      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
       flush(crlog)
       call postpr(ia,nnuml)
 #endif

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -298,10 +298,10 @@ program maincr
 
   ! Postprocessing is on, but there are no particles
   if(ipos == 1 .and. napx == 0) then
-    ! Now we open fort.10 unless already opened for BOINC
-    call f_open(unit=10, file="fort.10", formatted=.true., mode="rw",err=fErr,recl=8195)
-    call f_open(unit=110,file="fort.110",formatted=.false.,mode="w", err=fErr)
-
+    call f_requestUnit(fort10, unit10)
+    call f_requestUnit(fort110,unit110)
+    call f_open(unit=unit10, file=fort10, formatted=.true., mode="rw",err=fErr,status="replace",recl=8195)
+    call f_open(unit=unit110,file=fort110,formatted=.false.,mode="rw",err=fErr,status="replace")
 #ifndef STF
     do i=1,ndafi !ndafi = number of files to postprocess (set by fort.3)
 #ifndef CR
@@ -329,10 +329,11 @@ program maincr
 #endif
 
     call sumpos
+    call f_close(unit10)
+    call f_close(unit110)
     goto 520 ! Jump to after particle&optics initialization, and also after tracking.
-  end if !if(ipos.eq.1.and.napx.eq.0)
+  end if
 #endif
-! END ifndef FLUKA
 
   do i=1,20
     fake(1,i)=zero
@@ -1393,77 +1394,83 @@ program maincr
   ! Dump the final state of the particle arrays
   call part_writeState(1)
 
-#ifndef FLUKA
-#ifndef STF
+#ifdef FLUKA
+
+  ! A.Mereghetti, for the FLUKA Team
+  ! last modified: 28-05-2014
+  ! collect a couple of goto statements, sending code flow
+  !   to different plotting points, which are not actually
+  !   inserted
+  490 continue
+  520 continue
+    call fluka_close
+
+#else
+
   iposc = 0
   if(ipos == 1) then ! Variable IPOS=1 -> postprocessing block present in fort.3
-    ! Open fort.10 unless already opened for BOINC
-    call f_open(unit=10, file="fort.10", formatted=.true., mode="rw",err=fErr,recl=8195)
-    call f_open(unit=110,file="fort.110",formatted=.false.,mode="w", err=fErr)
+    call f_requestUnit(fort10, unit10)
+    call f_requestUnit(fort110,unit110)
+    call f_open(unit=unit10, file=fort10, formatted=.true., mode="rw",err=fErr,status="replace",recl=8195)
+    call f_open(unit=unit110,file=fort110,formatted=.false.,mode="rw",err=fErr,status="replace")
     do ia=1,napxo,2
-      ia2=(ia+1)/2
-      iposc=iposc+1
-#ifndef CR
-      call postpr(91-ia2) ! Postprocess file "fort.(91-ia2)"
-#else
-      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-ia2),", turns: ",nnuml
+      iposc = iposc+1
+#ifdef STF
+#ifdef CR
+      call postpr(ia,nnuml)
+      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
       flush(crlog)
-      call postpr(91-ia2,nnuml)
+#else
+      call postpr(ia)
+#endif
+#else
+      ia2 = 91-(ia+1)/2
+#ifdef CR
+      call postpr(ia2,nnuml)
+      write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",ia2,", turns: ",nnuml
+      flush(crlog)
+#else
+      call postpr(ia2)
+#endif
 #endif
     end do
     if(iposc >= 1) call sumpos
-  end if ! END if(ipos.eq.1)
+    call f_close(unit10)
+    call f_close(unit110)
+  end if
   goto 520 ! Done postprocessing
 
-490 continue ! GOTO here if(napx <= 0) (skipping tracking)
+  490 continue ! GOTO here if(napx <= 0) (skipping tracking)
   if(ipos == 1) then
+    call f_requestUnit(fort10, unit10)
+    call f_requestUnit(fort110,unit110)
+    call f_open(unit=unit10, file=fort10, formatted=.true., mode="rw",err=fErr,status="replace",recl=8195)
+    call f_open(unit=unit110,file=fort110,formatted=.false.,mode="rw",err=fErr,status="replace")
     ndafi2 = ndafi
     do ia=1,ndafi2
       if(ia > ndafi) exit
-#ifndef CR
-      call postpr(91-ia)
+#ifdef STF
+#ifdef CR
+      call postpr(ia,nnuml)
+      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
+      flush(crlog)
 #else
+      call postpr(ia)
+#endif
+#else
+#ifdef CR
+      call postpr(91-ia,nnuml)
       write(crlog,"(2(a,i0))") "SIXTRACR> Calling POSTPR Unit: ",(91-i),", turns: ",nnuml
       flush(crlog)
-      call postpr(91-ia,nnuml)
+#else
+      call postpr(91-ia)
+#endif
 #endif
     end do
     if(ndafi >= 1) call sumpos
+    call f_close(unit10)
+    call f_close(unit110)
   end if
-#else
-  ! IFDEF STF
-  iposc=0
-  if(ipos == 1) then ! Variable IPOS=1 -> postprocessing block present in fort.3
-    do ia=1,napxo,2
-      iposc=iposc+1
-#ifndef CR
-      call postpr(ia) ! Postprocess particle ia (and ia+1 if ntwin=2)
-#else
-      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
-      flush(crlog)
-      call postpr(ia,nnuml)
-#endif
-    end do
-    if(iposc >= 1) call sumpos
-  end if
-  goto 520 ! Done postprocessing
-
-490 continue ! GOTO here if(napx <= 0) (skipping tracking)
-  if(ipos == 1) then
-    ndafi2=ndafi
-    do ia=1,(2*ndafi2),2
-      if(ia > ndafi) exit
-#ifndef CR
-      call postpr(ia)
-#else
-      write(crlog,"(3(a,i0))") "SIXTRACR> Calling POSTPR Particles: ",ia,",",(ia+1),", turns: ",nnuml
-      flush(crlog)
-      call postpr(ia,nnuml)
-#endif
-    end do
-    if(ndafi >= 1) call sumpos
-  end if
-#endif
 
 ! ---------------------------------------------------------------------------- !
 !  DONE POSTPROCESSING (POSTPR)
@@ -1483,17 +1490,7 @@ program maincr
   endif
 #endif
 
-#ifdef FLUKA
-  ! A.Mereghetti, for the FLUKA Team
-  ! last modified: 28-05-2014
-  ! collect a couple of goto statements, sending code flow
-  !   to different plotting points, which are not actually
-  !   inserted
-490 continue
-520 continue
-  call fluka_close
-#endif
-  call ffield_mod_end()
+call ffield_mod_end()
 
   time3=0.
   call time_timerCheck(time3)

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -186,6 +186,7 @@ program maincr
   call f_open(unit=19,file="fort.19",formatted=.true., mode="rw",err=fErr) ! DA file
   call f_open(unit=20,file="fort.20",formatted=.true., mode="w", err=fErr) ! DA file
   call f_open(unit=21,file="fort.21",formatted=.true., mode="w", err=fErr) ! DA file
+  call f_open(unit=26,file="fort.26",formatted=.false.,mode="rw",err=fErr) ! DA file
   call f_open(unit=31,file="fort.31",formatted=.true., mode="w", err=fErr)
 
 #ifdef STF
@@ -198,8 +199,6 @@ program maincr
     call f_open(unit=i,file=tmpFile,formatted=.false.,mode="rw",err=fErr)
   end do
 #endif
-
-  call f_open(unit=111,file="fort.111",formatted=.false.,mode="rw",err=fErr) ! DA file, binary
 
   call time_timeStamp(time_afterFileUnits)
 

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -98,18 +98,17 @@ program mainda
 
   ! Open files
   fErr = .false.
-  call f_open(unit=12,file="fort.12",formatted=.true.,mode="w", err=fErr)
-  call f_open(unit=17,file="fort.17",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=18,file="fort.18",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=19,file="fort.19",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=20,file="fort.20",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=21,file="fort.21",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=22,file="fort.22",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=23,file="fort.23",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=24,file="fort.24",formatted=.true.,mode="rw",err=fErr) ! DA Files
-  call f_open(unit=25,file="fort.25",formatted=.true.,mode="rw",err=fErr) ! DA Files
-
-  call f_open(unit=111,file="fort.111",formatted=.false.,mode="rw",err=fErr)
+  call f_open(unit=12,file="fort.12",formatted=.true., mode="w", err=fErr)
+  call f_open(unit=17,file="fort.17",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=18,file="fort.18",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=19,file="fort.19",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=20,file="fort.20",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=21,file="fort.21",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=22,file="fort.22",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=23,file="fort.23",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=24,file="fort.24",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=25,file="fort.25",formatted=.true., mode="rw",err=fErr) ! DA Files
+  call f_open(unit=26,file="fort.26",formatted=.false.,mode="rw",err=fErr) ! DA Files
 
   call time_timeStamp(time_afterFileUnits)
 

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -109,7 +109,6 @@ program mainda
   call f_open(unit=24,file="fort.24",formatted=.true.,mode="rw",err=fErr) ! DA Files
   call f_open(unit=25,file="fort.25",formatted=.true.,mode="rw",err=fErr) ! DA Files
 
-  call f_open(unit=110,file="fort.110",formatted=.false.,mode="w", err=fErr)
   call f_open(unit=111,file="fort.111",formatted=.false.,mode="rw",err=fErr)
 
   call time_timeStamp(time_afterFileUnits)

--- a/source/mod_ffield_aux.f90
+++ b/source/mod_ffield_aux.f90
@@ -294,7 +294,7 @@ contains
     use numerical_constants, only : zero, c1e12, c1m12
     use crcoall,             only : lout, lerr
     use parpro,              only : mInputLn
-    use mod_units,           only : f_open, f_close
+    use mod_units,           only : f_open, f_freeUnit
     use string_tools,        only : chr_split, chr_cast
 
     implicit none
@@ -378,7 +378,7 @@ contains
 
     ! Close file
     ! ---------------------------------------------------------------------------------------------- !
-    call f_close(lun)
+    call f_freeUnit(lun)
 
   end subroutine ReadExpMax
 

--- a/source/mod_geometry.f90
+++ b/source/mod_geometry.f90
@@ -800,7 +800,7 @@ subroutine geom_calcDcum
     write(outUnit,fmtC) iu+1,tmpE,-1,tmpE,dcum(iu+1),elpos(iu+1),delS
 
     flush(outUnit)
-    call f_close(outUnit)
+    call f_freeUnit(outUnit)
   end if
 
 end subroutine geom_calcDcum

--- a/source/mod_meta.f90
+++ b/source/mod_meta.f90
@@ -86,9 +86,9 @@ subroutine meta_finalise
   call f_requestUnit("crkillswitch.tmp",tmpUnit)
   inquire(file="crkillswitch.tmp",exist=fExist)
   if(fExist) then
-    open(tmpUnit,file="crkillswitch.tmp",form="unformatted",access="stream",status="old",action="read")
+    call f_open(unit=tmpUnit,file="crkillswitch.tmp",formatted=.false.,mode="r",access="stream",status="old")
     read(tmpUnit) nCRKills1,nCRKills2
-    close(tmpUnit)
+    call f_close(tmpUnit)
   end if
 
   call meta_write("SymplecticityDeviation",   meta_sympCheck)

--- a/source/mod_particles.f90
+++ b/source/mod_particles.f90
@@ -261,7 +261,7 @@ subroutine part_writeState(theState)
       write(fileUnit)  int(     iDummy, kind=int32) ! Pad to n x 64 bit
     end do
 
-    call f_close(fileUnit)
+    call f_freeUnit(fileUnit)
 
   else
 
@@ -301,7 +301,7 @@ subroutine part_writeState(theState)
       end if
     end do
 
-    call f_close(fileUnit)
+    call f_freeUnit(fileUnit)
 
   end if
 

--- a/source/mod_units.f90
+++ b/source/mod_units.f90
@@ -71,7 +71,8 @@ end subroutine f_initUnits
 ! ================================================================================================ !
 !  Request New File Units
 !  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Last modified: 2018-12-13
+!  Created: 2018-12-13
+!  Updated: 2018-12-13
 !  Send in a file name, and get a unit back. If the has already been assigned a unit, this is
 !  returned. Otherwise, a new unit is selected.
 ! ================================================================================================ !
@@ -134,7 +135,8 @@ end subroutine f_requestUnit
 ! ================================================================================================ !
 !  Get Existing File Units
 !  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Last modified: 2018-12-13
+!  Created: 2018-12-13
+!  Updated: 2019-05-02
 !  Will search through the record for a filename, and return its unit. -1 if it is not assigned.
 ! ================================================================================================ !
 subroutine f_getUnit(file,unit)
@@ -159,7 +161,8 @@ end subroutine f_getUnit
 ! ================================================================================================ !
 !  Open a File
 !  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Last modified: 2018-12-13
+!  Created: 2018-12-13
+!  Updated: 2019-05-02
 !  This is a wrapper for Fortran open that also handles all the various build options.
 !  The parameters are:
 !   - unit      :: The unit number. Either a previously assigned one, or a fixed unit
@@ -355,7 +358,8 @@ end subroutine f_open
 ! ================================================================================================ !
 !  Close File Units
 !  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Last modified: 2018-12-13
+!  Created: 2018-12-13
+!  Updated: 2018-12-13
 !  Preferred method for closing file as it keeps the record up to date
 ! ================================================================================================ !
 subroutine f_close(unit)
@@ -391,6 +395,42 @@ subroutine f_close(unit)
   end if
 
 end subroutine f_close
+
+! ================================================================================================ !
+!  Free File Units
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Created: 2019-05-02
+!  Updated: 2019-05-02
+!  Free a file unit so that it can be assigned again. This implies close.
+! ================================================================================================ !
+subroutine f_freeUnit(unit)
+
+  use crcoall
+
+  integer, intent(in) :: unit
+
+  integer i
+  logical isOpen
+
+  if(unit < units_minUnit .or. unit > units_maxUnit) then
+    write(lerr,"(3(a,i0),a)") "UNITS> ERROR Unit ",unit," is out of range ",units_minUnit,":",units_maxUnit," in f_close"
+    call prror
+  end if
+
+  inquire(unit=unit, opened=isOpen)
+  if(isOpen) then
+    call f_close(unit)
+  end if
+
+  call f_writeLog("FREE",unit,"FREED",units_uList(unit)%file)
+
+  units_uList(unit)%file  = " "
+  units_uList(unit)%mode  = " "
+  units_uList(unit)%taken = .false.
+  units_uList(unit)%open  = .false.
+  units_uList(unit)%fixed = .true.
+
+end subroutine f_freeUnit
 
 ! ================================================================================================ !
 !  Flush Single or All File Units

--- a/source/postprocessing.f90
+++ b/source/postprocessing.f90
@@ -14,6 +14,9 @@ subroutine postpr(arg1,arg2)
 !-----------------------------------------------------------------------
 !  POST PROCESSING
 !
+!  The variabe arg1 sets posi for STF builds and nfile otherwise.
+!  The variable arg2 sets nnuml for CR builds, and is 0 otherwise
+!
 !  NFILE   :  FILE UNIT (non-STF) -- always fixed to 90 for STF version.
 !  POSI    :  PARTICLE NUMBER
 !             (the first particle in pair if ntwin=2, i.e. it is a  pair).

--- a/source/postprocessing.f90
+++ b/source/postprocessing.f90
@@ -10,19 +10,7 @@ module postprocessing
 
 contains
 
-#ifdef STF
-#ifdef CR
-subroutine postpr(posi,nnuml)
-#else
-subroutine postpr(posi)
-#endif
-#else
-#ifdef CR
-subroutine postpr(nfile,nnuml)
-#else
-subroutine postpr(nfile)
-#endif
-#endif
+subroutine postpr(arg1,arg2)
 !-----------------------------------------------------------------------
 !  POST PROCESSING
 !
@@ -39,11 +27,12 @@ subroutine postpr(nfile)
       use string_tools
       use mod_version
       use mod_time
+      use mod_units
       use mod_common_main, only : nnumxv
       use mod_common, only : dpscor,sigcor,icode,idam,its6d,dphix,dphiz,qx0,qz0,&
         dres,dfft,cma1,cma2,nstart,nstop,iskip,iconv,imad,ipos,iav,iwg,ivox,    &
         ivoz,ires,ifh,toptit,kwtype,itf,icr,idis,icow,istw,iffw,nprint,ndafi,   &
-        chromc,tlim,trtime
+        chromc,tlim,trtime,fort10,fort110,unit10,unit110
 #ifdef ROOT
       use root_output
 #endif
@@ -51,6 +40,9 @@ subroutine postpr(nfile)
       use checkpoint_restart
 #endif
       implicit none
+
+      integer,           intent(in) :: arg1
+      integer, optional, intent(in) :: arg2
 
       integer i,i1,i11,i2,i3,ia,ia0,iaa,iab,iap6,iapx,iapz,ich,idnt,    &
      &ierro,idummy,if1,if2,ife,ife2,ifipa,ifp,ii,ilapa,ilyap,im1,im1s,  &
@@ -99,7 +91,7 @@ subroutine postpr(nfile)
       character(len=11) hvs
       character(len=8192) ch
       character(len=25) ch1
-      integer errno,l1,l2
+      integer errno,l1,l2,nnuml
       logical rErr
       dimension tle(nlya),dle(nlya)
       dimension wgh(nlya),biav(nlya),slope(nlya),varlea(nlya)
@@ -113,11 +105,20 @@ subroutine postpr(nfile)
       dimension x(2,6),cloau(6),di0au(4)
       dimension qwc(3),clo(3),clop(3),di0(2),dip0(2)
       dimension ta(6,6),txyz(6),txyz2(6),xyzv(6),xyzv2(6),rbeta(6)
-#ifdef CR
-      integer nnuml
-#endif
       integer itot,ttot
       save
+
+      if(present(arg2)) then
+        nnuml = arg2
+      else
+        nnuml = 0
+      end if
+#ifdef STF
+      posi = arg1
+#else
+      nfile = arg1
+#endif
+
 !----------------------------------------------------------------------
 !--TIME START
       pieni2=c1m8
@@ -2158,34 +2159,25 @@ subroutine postpr(nfile)
 
 !--WRITE DATA FOR THE SUMMARY OF THE POSTPROCESSING ON FILE # 10
 ! We should really write fort.10 in BINARY!
-      write(110,iostat=ierro) (sumda(i),i=1,60)
-      if(ierro.ne.0) then
-        write(lout,*)
-        write(lout,*) '*** ERROR ***,PROBLEMS WRITING TO FILE 110'
-        write(lout,*) 'ERROR CODE : ',ierro
-        write(lout,*)
-      endif
+      write(unit110,iostat=ierro) (sumda(i),i=1,60)
+      if(ierro /= 0) then
+        write(lerr,"(a,i0)") "POSTPR> ERROR Problems writing to "//trim(fort110)//". iostat = ",ierro
+      end if
 #ifndef CRLIBM
       write(ch,*,iostat=ierro) (sumda(i),i=1,60)
-      do ich=8192,1,-1
-        if(ch(ich:ich).ne.' ') goto 700
-      enddo
- 700  write(10,'(a)',iostat=ierro) ch(:ich)
+      write(unit10,"(a)",iostat=ierro) trim(ch)
 #else
       l1=1
       do i=1,60
         call chr_fromReal(sumda(i),ch1,19,2,rErr)
-        ch(l1:l1+25)=' '//ch1(1:25)
+        ch(l1:l1+25) = " "//ch1(1:25)
         l1=l1+26
-      enddo
-      write(10,'(a)',iostat=ierro) ch(1:l1-1)
+      end do
+      write(unit10,"(a)",iostat=ierro) ch(1:l1-1)
 #endif
-      if(ierro.ne.0) then
-        write(lout,*)
-        write(lout,*)'*** ERROR ***,PROBLEMS WRITING TO FILE 10'
-        write(lout,*) 'ERROR CODE : ',ierro
-        write(lout,*)
-      endif
+      if(ierro /= 0) then
+        write(lerr,"(a,i0)") "POSTPR> ERROR Problems writing to "//trim(fort10)//". iostat = ",ierro
+      end if
 !--CALCULATION THE INVARIANCES OF THE 4D TRANSVERSAL MOTION
       do 420 i=1,ninv
         if(invx(i).gt.0) then
@@ -2589,9 +2581,9 @@ subroutine postpr(nfile)
 ! Now we let abend handle the fort.10......
 ! It will write 0d0 plus CPU time and turn number
 ! But we empty it as before (if we crash in abend???)
-      rewind(10)
-      endfile(10,iostat=ierro)
-      close(10)
+      rewind(unit10)
+      endfile(unit10,iostat=ierro)
+      call f_close(unit10)
       write(lerr,"(a)") "SIXTRACR> ERROR POSTPR"
       call prror
 #endif
@@ -2600,28 +2592,25 @@ subroutine postpr(nfile)
 !--WRITE DATA FOR THE SUMMARY OF THE POSTPROCESSING ON FILE # 10
 !-- Will almost all be zeros but we now have napxto and ttime
 ! We should really write fort.10 in BINARY!
-      write(110,iostat=ierro) (sumda(i),i=1,60)
-      if(ierro.ne.0) then
+      write(unit110,iostat=ierro) (sumda(i),i=1,60)
+      if(ierro /= 0) then
         write(lerr,"(a,i0)") "POSTPR> ERROR Problems writing to file 110. Error code ",ierro
       endif
 #ifndef CRLIBM
       write(ch,*,iostat=ierro) (sumda(i),i=1,60)
-      do ich=8192,1,-1
-        if(ch(ich:ich).ne.' ') goto 707
-      enddo
- 707  write(10,'(a)',iostat=ierro) ch(:ich)
+      write(unit10,"(a)",iostat=ierro) trim(ch)
 #else
       l1=1
       do i=1,60
         call chr_fromReal(sumda(i),ch1,19,2,rErr)
-        ch(l1:l1+25)=' '//ch1(1:25)
+        ch(l1:l1+25) = " "//ch1(1:25)
         l1=l1+26
       enddo
-      write(10,'(a)',iostat=ierro) ch(1:l1-1)
+      write(unit10,"(a)",iostat=ierro) ch(1:l1-1)
 #endif
-      if(ierro.ne.0) then
-        write(lerr,"(a,i0)") "POSTPR> ERROR Problems writing to file 10. Error code ",ierro
-      endif
+      if(ierro /= 0) then
+        write(lerr,"(a,i0)") "POSTPR> ERROR Problems writing to "//trim(fort10)//". iostat = ",ierro
+      end if
 !--REWIND USED FILES
   560 rewind nfile
       if(nprint == 1) then

--- a/source/ranlux.f90
+++ b/source/ranlux.f90
@@ -125,9 +125,7 @@ subroutine ranlux(rvec,lenv)
          in24 = 0
          kount = 0
          mkount = 0
-!         WRITE(6,'(A,I2,A,I4)')  ' RANLUX DEFAULT LUXURY LEVEL =  ',
-!     &        LUXLEV,'      p =',LP
-            twom24 = 1.
+         twom24 = 1.
          do 25 i= 1, 24
             twom24 = twom24 * 0.5
          k = jseed/53668

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -179,7 +179,7 @@ subroutine umlauda
     mfile=18
 !Eric
     rewind mfile
-    rewind 111
+    rewind 26
 !ERIC HERE
     call daread(damap,nvar,mfile,one)
     call mapnorm(damap,f,aa2,a1,xy,h,nord1)
@@ -1474,7 +1474,7 @@ subroutine umlauda
   if(iqmodc.eq.2.or.iqmodc.eq.4.or.ilin.ge.2) then
     rewind 18
 !Eric
-    rewind 111
+    rewind 26
     call daprid(damap,1,nvar,18)
   endif
 !--now do the output

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -648,12 +648,7 @@ subroutine umlauda
 
         if (.not.beam_expfile_open) then
           call f_requestUnit("beam_expert.txt",expertUnit)
-#ifdef BOINC
-          call boincrf("beam_expert.txt",filename)
-          open(expertUnit,file=filename,status="replace",action="write")
-#else
-          open(expertUnit,file="beam_expert.txt",status="replace",action="write")
-#endif
+          call f_open(unit=expertUnit,file="beam_expert.txt",formatted=.true.,mode="w",status="replace")
           beam_expfile_open = .true.
           !This line will be a comment if copy-pasted into fort.3
           write(expertUnit,"(a,g13.6,a,g13.6,a,g13.6,a)") "/ ******* USING emitx=",emitx,", emity=",emity,", emitz=",emitz," ******"

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -987,7 +987,6 @@ subroutine umlauda
     if(kzz.eq.26) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i) ! JBG change of variables for misal calculations
@@ -995,7 +994,6 @@ subroutine umlauda
 #include "include/alignf.f90"
 !FOX  CRABAMP2=ED(IX)*ZZ0 ;
 
-!       write(*,*) crabamp, EJF1, EJF0,clight, "HELLO"
     crabfreq=ek(ix)*c1e3 !JBG Input in MHz changed to kHz
     crabpht2=crabph2(ix)
 !FOX  KCRABDA=(SIGMDA/(CLIGHT*(E0F/E0))
@@ -1024,7 +1022,6 @@ subroutine umlauda
       if(kzz.eq.-26) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i) ! JBG change of variables for misal calculations
@@ -1058,7 +1055,6 @@ subroutine umlauda
       if(kzz.eq.27) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)
@@ -1093,7 +1089,6 @@ subroutine umlauda
       if(kzz.eq.-27) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)
@@ -1127,7 +1122,6 @@ subroutine umlauda
       if(kzz.eq.28) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)
@@ -1166,7 +1160,6 @@ subroutine umlauda
       if(kzz.eq.-28) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -68,7 +68,7 @@ subroutine daliesix
   call etallnom(hs,1,'HS        ')
   call etallnom(df,nd2,'DF        ')
   rewind mfile
-  rewind 111
+  rewind 26
   rewind mf1
   rewind mf2
   rewind mf3
@@ -213,7 +213,7 @@ subroutine mydaini(ncase,nnord,nnvar,nndim,nnvar2,nnord1)
   ! tune variation
   if(ncase.eq.2) call umlauda
   rewind 18
-  rewind 111
+  rewind 26
 
   ! main map calculation
   if(ncase.eq.3) call runda
@@ -282,7 +282,7 @@ subroutine runcav
   call darea(dpda1,18)
   rewind 18
 !Eric
-    rewind 111
+  rewind 26
   if(ition.ne.0) then
   e0f=sqrt(e0**2-nucm0**2)                                             !hr08
 !FOX  DPDA=DPDA1*C1M3 ;

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -1238,7 +1238,6 @@ subroutine runda
       if(kzz.eq.-26) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i) ! JBG change of variables for misal calculations
@@ -1269,7 +1268,6 @@ subroutine runda
       if(kzz.eq.27) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)
@@ -1301,7 +1299,6 @@ subroutine runda
       if(kzz.eq.-27) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)
@@ -1332,7 +1329,6 @@ subroutine runda
       if(kzz.eq.28) then
         ! JBG bypass this element if 4D/5D case
         if(iclo6.eq.0) then
-!                write(*,*)'Bypassing RF mult 4D or 5D case'
             goto 440
         endif
       xs=xsi(i)

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -6416,9 +6416,6 @@ subroutine phasad(dpp,qwc)
         end if
         if(kzz.eq.0.or.kzz.eq.20.or.kzz.eq.22) goto 450
         if(kzz.eq.15) goto 450
-! JBG RF CC Multipoles to 450
-!        if(kzz.eq.26.or.kzz.eq.27.or.kzz.eq.28) write(*,*)'out'
-!        if(kzz.eq.26.or.kzz.eq.27.or.kzz.eq.28) goto 450
         dyy1=zero
         dyy2=zero
         if(iorg.lt.0) mzu(k)=izu
@@ -7278,9 +7275,6 @@ subroutine umlauf(dpp,ium,ierr)
     end if
     if(kzz.eq.0.or.kzz.eq.20.or.kzz.eq.22) goto 350
     if(kzz.eq.15) goto 350
-! JBG RF CC Multipoles to 350
-!        if(kzz.eq.26.or.kzz.eq.27.or.kzz.eq.28) write(*,*)'out'
-!        if(kzz.eq.26.or.kzz.eq.27.or.kzz.eq.28) goto 350
     if(iorg.lt.0) mzu(k)=izu
     izu=mzu(k)+1
     ekk=(sm(ix)+zfz(izu)*ek(ix))/(one+dpp)

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -20,7 +20,7 @@ subroutine sumpos
   character(len=:), allocatable :: lnSplit(:)
   character(len=mInputLn)       :: inLine
   real(kind=fPrec) d(60), dlost
-  integer nSplit, ioStat, lineNo, i, j, unit10
+  integer nSplit, ioStat, lineNo, i, j
   logical spErr, fErr
 
   rewind(unit10)

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -11,6 +11,8 @@ subroutine sumpos
   use crcoall
   use parpro
   use string_tools
+  use mod_units
+  use mod_common, only : fort10, unit10
 
   implicit none
 
@@ -18,28 +20,26 @@ subroutine sumpos
   character(len=:), allocatable :: lnSplit(:)
   character(len=mInputLn)       :: inLine
   real(kind=fPrec) d(60), dlost
-  integer nSplit, ioStat, lineNo, i, j
+  integer nSplit, ioStat, lineNo, i, j, unit10
   logical spErr, fErr
 
-  save
-
-  rewind 10
+  rewind(unit10)
   lineNo = 0
   do i=1,1000
-    read(10,"(a)",end=20,iostat=ioStat) inLine
+    read(unit10,"(a)",end=20,iostat=ioStat) inLine
     if(ioStat /= 0) then
-      write(lerr,"(a,i0)") "SUMPOS> ERROR Failed to read line from 'fort.10'. iostat = ",ioStat
-      call prror(-1)
+      write(lerr,"(a,i0)") "SUMPOS> ERROR Failed to read line from '"//trim(fort10)//"'. iostat = ",ioStat
+      call prror
     end if
 
     call chr_split(inLine, lnSplit, nSplit, spErr)
     if(spErr) then
-      write(lerr,"(a)") "SUMPOS> ERROR Failed to parse line from 'fort.10'"
-      call prror(-1)
+      write(lerr,"(a)") "SUMPOS> ERROR Failed to parse line from '"//trim(fort10)//"'"
+      call prror
     end if
     if(nSplit > 60) then
-      write(lerr,"(a,i0)") "SUMPOS> ERROR Too many elements on a single line of 'fort.10'. Max is 60, got ",nSplit
-      call prror(-1)
+      write(lerr,"(a,i0)") "SUMPOS> ERROR Too many elements on a single line of '"//trim(fort10)//"'. Max is 60, got ",nSplit
+      call prror
     end if
     lineNo = lineNo+1
 
@@ -61,26 +61,26 @@ subroutine sumpos
     write(lout,10010) nint(dlost),d(3),d(5),d(7),d(9),d(10),d(11),d(12),nint(d(16)),nint(d(18)),    &
       d(19),d(21),ch,d(4),d(6),d(8),d(13),nint(d(17)),d(20),d(25),d(14),d(15)
   end do
-  20 continue
-  rewind 10
 
+  20 continue
+  rewind(unit10)
   lineNo = 0
   write(lout,10020)
   do i=1,1000
-    read(10,"(a)",end=40,iostat=ioStat) inLine
+    read(unit10,"(a)",end=40,iostat=ioStat) inLine
     if(ioStat /= 0) then
-      write(lerr,"(a,i0)") "SUMPOS> ERROR Failed to read line from 'fort.10'. iostat = ",ioStat
-      call prror(-1)
+      write(lerr,"(a,i0)") "SUMPOS> ERROR Failed to read line from '"//trim(fort10)//"'. iostat = ",ioStat
+      call prror
     end if
 
     call chr_split(inLine, lnSplit, nSplit, spErr)
     if(spErr) then
-      write(lerr,"(a)") "SUMPOS> ERROR Failed to parse line from 'fort.10'"
-      call prror(-1)
+      write(lerr,"(a)") "SUMPOS> ERROR Failed to parse line from '"//trim(fort10)//"'"
+      call prror
     end if
     if(nSplit > 60) then
-      write(lerr,"(a,i0)") "SUMPOS> ERROR Too many elements on a single line of 'fort.10'. Max is 60, got ",nSplit
-      call prror(-1)
+      write(lerr,"(a,i0)") "SUMPOS> ERROR Too many elements on a single line of '"//trim(fort10)//"'. Max is 60, got ",nSplit
+      call prror
     end if
     lineNo = lineNo+1
 

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -1865,9 +1865,6 @@ subroutine synuthck
 
   save
 
-#ifdef CR
-  sythckcr = .true.
-#endif
   do j=1,napx
     dpd(j)  = one+dpsv(j)
     dpsq(j) = sqrt(dpd(j))

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -1331,7 +1331,6 @@ subroutine thin6d(nthinerr)
           !Ralph drift length is stracki
           !bez(ix) is name of drift
           totals=totals+stracki
-          !          write(*,*) 'ralph> Drift, total length: ', stracki,totals
 
           !________________________________________________________________________
           !++  If we have a collimator then...

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,12 +43,12 @@ set_tests_properties(CheckBuildManual PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR"
 ## ERROR Tests
 ##
 
-if(NOT BOINC)
+if(NOT CR)
   list(APPEND SIXTRACK_ERROR
     error_init
     error_trac
   )
-endif(NOT BOINC)
+endif(NOT CR)
 
 ##
 ## Needs checking: thick6dsingles (broken input files -- this test could probably be removed)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,6 +41,7 @@ set_tests_properties(CheckBuildManual PROPERTIES FAIL_REGULAR_EXPRESSION "ERROR"
 
 ##
 ## ERROR Tests
+## Only run for non-CR version as CR version doesn't write directly to stderr
 ##
 
 if(NOT CR)


### PR DESCRIPTION
This PR fixes a few bugs and issues with file units

* The previous PR caused an issue in restarting thick tracking simulations. There was a problem loading the small thick arrays. Since we anyway only have 3 left (down from 38) I just moved them to be loaded with all the other particle arrays. This simplified the logic of loading the two big rank 4 thick matrices.
* One of the FMA tests also broke on previous PR. Unclear why it was related, but probably by accident as more file units are now dynamically allocated and we triggered an error where unit 110 was allocated before the binary prostprocessing file on unit 110 was opened. Consequently, the binary postpr data would be tagged onto a random other file. This postpr files now have dynamically assigned units as well.
* This triggered a change in the file units module. We now check that a given unit is not attempted opened on two different file names. This is actually done a few places with temporary files, so I added a routine to free up units. Files can still share units as long as the unit is freed between each open. Freeing a unit forces a flush and close.
* To avoid this happening again, I went through the DA code and cleared out unit 111 as well. Unit 26 was free, so the read/writes are now on unit 26 instead. Unit 111 was a binary version of unit 18, but cannot simply be removed as it is used as a read/write buffer.
* When looking through the very convoluted logic of all the temporary DA files, I cleared out a bit of commented out debugging code that was cluttering my grep.
* Also freed up unit 94, which was used as a temp buffer while repositioning tracking files. It now uses an assigned unit.