### PR TITLE
Make the error tests work when the supporting library is symlinked in

### DIFF
--- a/test/error_init/errorTests.py
+++ b/test/error_init/errorTests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
-import sys
+import sys, os
+#Otherwise it will look in the symlinked path for imports
+sys.path.append(os.getcwd())
 from errorTestTools import *
 
 exCode = runTests({

--- a/test/error_trac/errorTests.py
+++ b/test/error_trac/errorTests.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
-import sys
+import sys, os
+#Otherwise it will look in the symlinked path for imports
+sys.path.append(os.getcwd())
 from errorTestTools import *
 
 exCode = runTests({


### PR DESCRIPTION
Running the error tests fails when compiling SixTrack as `./cmake_six BUILD_TESTING", since when running a symlinked python script it looks for modules in the folder the script is symlinked from, not in the working directory.