### PR TITLE
Even More Bugfixes for 5.2.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -638,7 +638,7 @@ elseif(Fortran_COMPILER_NAME MATCHES "ifort.*")
 
   set(IFORT ON)
   set(CMAKE_Fortran_FLAGS_RELEASE "-fp-model source -fp-model strict -fp-model no-except -O3 -no-fma -std15 -assume realloc-lhs")
-  set(CMAKE_Fortran_FLAGS_DEBUG   "-fp-model source -fp-model strict -fp-model no-except -O0 -g -no-fma -std15 -assume realloc-lhs")
+  set(CMAKE_Fortran_FLAGS_DEBUG   "-fp-model source -fp-model strict -fp-model no-except -O0 -g -traceback -check bounds -no-fma -std15 -assume realloc-lhs")
   set(PREPRO_EXEC  ${CMAKE_Fortran_COMPILER})
   set(PREPRO_FLAGS -I${CMAKE_SOURCE_DIR}/source/include -fpp -E -P)
 

--- a/source/aperture.f90
+++ b/source/aperture.f90
@@ -503,12 +503,12 @@ subroutine aperture_backTrackingInit
   if( ix.lt.0 ) then
     write(lerr,"(a)") "APER> ERROR Impossible to properly initialise backtracking:"
     write(lerr,"(a)") "APER>       first element of lattice structure is not a single element"
-    call prror(-1)
+    call prror
   end if
   if( kape(ix).eq.0 ) then
     write(lerr,"(a)") "APER> ERROR Impossible to properly initialise backtracking:"
     write(lerr,"(a)") "APER>       first element of lattice structure is not assigned an aperture profile"
-    call prror(-1)
+    call prror
   end if
 
   call aperture_saveLastCoordinates( i, ix, -1 )
@@ -1380,7 +1380,7 @@ subroutine contour_aperture_markers( itElUp, itElDw, lInsUp )
       call dump_aperture_header( lout )
       call dump_aperture_marker( lout, ixApeUp, iElUp )
       call dump_aperture_marker( lout, ixApeDw, iElDw )
-      call prror(-1)
+      call prror
     end if
   end if
 
@@ -1458,7 +1458,7 @@ subroutine contour_aperture_marker( iEl, lInsUp )
     end if
   else if( ixEl.le.0 ) then
     write(lerr,"(a,i0,a)") "APER> ERROR Lattice element at: i=",iEl," is NOT a SINGLE ELEMENT."
-    call prror(-1)
+    call prror
   end if
 
 ! echo
@@ -1493,7 +1493,7 @@ subroutine contour_aperture_marker( iEl, lInsUp )
   call find_closest_aperture(iSrcUp,.true.,iApeUp,ixApeUp,lApeUp)
   if( iApeUp.eq.-1 .and. ixApeUp.eq.-1 ) then
     write(lerr,"(a)") "APER> ERROR Could not find upstream marker"
-    call prror(-1)
+    call prror
   end if
 ! - get closest downstream aperture marker
 ! NB: no risk of overflow, as first/last element in lattice
@@ -1502,7 +1502,7 @@ subroutine contour_aperture_marker( iEl, lInsUp )
   call find_closest_aperture(iSrcDw,.false.,iApeDw,ixApeDw,lApeDw)
   if( iApeDw.eq.-1 .and. ixApeDw.eq.-1 ) then
     write(lerr,"(a)") "APER> ERROR Could not find downstream marker"
-    call prror(-1)
+    call prror
   end if
 ! - echo found apertures
   call dump_aperture_header( lout )
@@ -1578,7 +1578,7 @@ subroutine contour_aperture_marker( iEl, lInsUp )
     else
 !     this should never happen
       write(lerr,"(a)") "APER> ERROR in aperture auto assignment."
-      call prror(-1)
+      call prror
     end if
   end if
 
@@ -1799,7 +1799,7 @@ subroutine dump_aperture_model
   ix=ic(i)-nblo
   if( kape(ix).eq.0 ) then
     write(lerr,"(a)") "APER> ERROR First element of lattice structure is not assigned any aperture type"
-    call prror(-1)
+    call prror
   end if
   call dump_aperture_marker( aperunit, ix, i )
   iOld=i
@@ -1886,7 +1886,7 @@ subroutine dump_aperture_model_hdf5
   ix = ic(i)-nblo
   if(kape(ix) == 0) then
     write(lerr,"(a)") "APER> ERROR First element of lattice structure is not assigned any aperture type"
-    call prror(-1)
+    call prror
   end if
   call dump_aperture_hdf5(bez(ix), kape(ix), dcum(i), ape(1:9,ix), modelSet, .false.)
   iOld  = i
@@ -2118,31 +2118,31 @@ subroutine dump_aperture_xsecs
      if(lopen) then
         write(lerr,"(a,i0)")"APER> ERROR Dump_aperture_xsecs. Could not open file unit '"//trim(xsec_filename(ixsec))//&
           "' with unit ",xsecunit(ixsec)
-        call prror(-1)
+        call prror
      end if
      call f_open(unit=xsecunit(ixsec),file=xsec_filename(ixsec),formatted=.true.,mode='w',err=err)
      if(ierro .ne. 0) then
         write(lerr,"(2(a,i0))") "APER> ERROR Opening file '"//trim(xsec_filename(ixsec))//&
           "' on unit # ",xsecunit(ixsec),", iostat = ",ierro
-        call prror(-1)
+        call prror
      end if
 
      ! loop over s-locations
      sLoc=sLocMin(ixsec)
      do while(sLoc.le.sLocMax(ixsec))
         call geom_findElemAtLoc( sLoc, .true., iEl, ixEl, lfound )
-        if(.not.lfound) call prror(-1)
+        if(.not.lfound) call prror
         ! get upstream aperture marker
         call find_closest_aperture(iEl,.true.,iApeUp,ixApeUp,lApeUp)
         if( iApeUp.eq.-1 .and. ixApeUp.eq.-1 ) then
            write(lerr,"(a)") "APER> ERROR Could not find upstream aperture marker"
-           call prror(-1)
+           call prror
         end if
         ! get downstream aperture marker
         call find_closest_aperture(iEl,.false.,iApeDw,ixApeDw,lApeDw)
         if( iApeDw.eq.-1 .and. ixApeDw.eq.-1 ) then
            write(lerr,"(a)") "APER> ERROR Could not find downstream aperture marker"
-           call prror(-1)
+           call prror
         end if
         ! interpolate and get aperture at desired location
         call interp_aperture( iApeUp, ixApeUp, iApeDw, ixApeDw, itmpape, tmpape, sLoc )
@@ -2635,7 +2635,7 @@ subroutine aper_parseLoadFile(load_file, iLine, iErr)
   read(loadunit,"(a)",end=90,iostat=iErro) unitLine
   if(iErro > 0) then
     write(lerr,"(a,i0)") "LIMI> ERROR Could not read from unit ",loadunit
-    call prror(-1)
+    call prror
   end if
   lineNo = lineNo + 1
 

--- a/source/bdex.f90
+++ b/source/bdex.f90
@@ -519,7 +519,7 @@ subroutine bdex_track(i,ix,n)
 
   else
     write(lerr,"(a,i0,a)") "BDEX> ERROR elementAction = ",bdex_elementAction(i)," not understood."
-    call prror(-1)
+    call prror
   endif
 
 end subroutine bdex_track

--- a/source/beam6d.f90
+++ b/source/beam6d.f90
@@ -43,7 +43,7 @@ subroutine beamint(np,track,param,sigzs,bcu,ibb,ne,ibtyp,ibbc,mtc)
     phi2=phi               !Note - phi2 is not a free parameter anymore
   else
     write(lerr,"(a,i0,a)") "ERROR beamint: beam_expflag was ",beam_expflag," expected 0 or 1. This is a BUG!"
-    call prror(-1)
+    call prror
   end if
 
   sphi=sin_mb(phi)
@@ -545,5 +545,5 @@ real(kind=fPrec) function gauinv(p0)
 
 900  write(lout,910) p0
 910  format(' (FUNC.GAUINV) INVALID INPUT ARGUMENT ',1pd20.13)
-  call prror(-1)
+  call prror
 end function gauinv

--- a/source/beam6d_fox.f90
+++ b/source/beam6d_fox.f90
@@ -42,7 +42,7 @@ subroutine beaminf(track,param,sigzs,bcu,ibb,ne,ibbc)
       phi2=phi               !Note - phi2 is not a free parameter anymore
   else
       write(lerr,"(a,i0,a)") "ERROR beaminf: beam_expflag was ",beam_expflag," expected 0 or 1. This is a BUG!"
-      call prror(-1)
+      call prror
   endif
   sphi=sin_mb(phi)
   sphi2=sin_mb(phi2)

--- a/source/beamgas.f90
+++ b/source/beamgas.f90
@@ -115,7 +115,7 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
 
   if(pressID.eq.0) then
     write(lerr,"(a,e15.7)") "BEAMGAS> ERROR Couldn't find pressure marker at ",totals
-    call prror(-1)
+    call prror
   end if
 
   doLorentz=0
@@ -200,7 +200,7 @@ subroutine beamGas( myix, mysecondary, totals, myenom, ipart ,turn, el_idx )
        write(lerr,"(a,e15.7)") "BEAMGAS>  * bgiddb(choice) = ",bgiddb(choice)
        write(lerr,"(a,e15.7)") "BEAMGAS>  * totMomentum    = ",totMomentum
        write(lerr,"(a,e15.7)") "BEAMGAS>  * new4MomCoord   = ",new4MomCoord
-        call prror(-1)
+        call prror
       else
 !      boosted xp event
        bgxpdb(choice) = z(1)
@@ -347,7 +347,7 @@ subroutine beamGasInit(myenom)
       j=j+1
       if (j>bgmaxx) then
         write(lerr,"(a)") "BEAMGAS> ERROR Too many pressure markers!"
-        call prror(-1)
+        call prror
       endif
     else if (filereaderror.lt.0) then
       ! means that end of file is reached
@@ -389,7 +389,7 @@ subroutine beamGasInit(myenom)
      if (previousEvent.gt.dpmjetevents) exit
      if (numberOfEvents.gt.(bgmaxx-1)) then
      write(lerr,"(a)") "BEAMGAS> ERROR Too many dpmjet events!"
-     call prror(-1)
+     call prror
   endif
   enddo
 ! number of lines in dpmjet - 1
@@ -400,7 +400,7 @@ subroutine beamGasInit(myenom)
   if (numberOfEvents.gt.npart) then
      write(lerr,"(2(a,i0))") "BEAMGAS> ERROR There were too many trackable events. Maximum for this run is ",npart,&
       " you generated ",numberOfEvents
-     call prror(-1)
+     call prror
   endif
 
   write(lout,"(a,i0)") "BEAMGAS> This is job number: ", njobthis

--- a/source/cheby.f90
+++ b/source/cheby.f90
@@ -322,7 +322,7 @@ subroutine cheby_postInput
     if(.not. exist) then
       write(lerr,"(a)") "CHEBY> ERROR Problems with file with coefficients for Chebyshev polynominals: ", &
             trim(cheby_filename(jj))
-      call prror(-1)
+      call prror
     end if
     call parseChebyFile(jj)
   end do
@@ -433,7 +433,7 @@ subroutine cheby_postInput
 
 10 continue
    write(lout,"(a,i0,a)") "CHEBY>       concerned lens #", jj," - name: '"//trim(bez(kk))//"'"
-   call prror(-1)
+   call prror
    
 end subroutine cheby_postInput
 
@@ -591,7 +591,7 @@ subroutine parseChebyFile(ifile)
   end do
 40 continue
   write(lerr,"(a)") "CHEBY> ERROR while parsing file "//trim(cheby_filename(ifile))
-  call prror(-1)
+  call prror
 
 end subroutine parseChebyFile
 
@@ -688,7 +688,7 @@ subroutine cheby_potentialMap(iLens,ix)
   call f_open(unit=fUnit,file=cheby_mapFileName(iLens),mode='w',err=err,formatted=.true.,status="replace")
   if(err) then
     write(lerr,"(a)") "CHEBY> ERROR Failed to open file."
-    call prror(-1)
+    call prror
   end if
  
   ! rotation angle

--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -90,7 +90,7 @@ contains
 ! ================================================================================================ !
 subroutine cr_fileInit
 
-  use, intrinsic :: iso_fortran_env, only : output_unit, error_unit
+  use, intrinsic :: iso_fortran_env, only : output_unit
 
   use mod_units
   use mod_common, only : fort6
@@ -564,7 +564,7 @@ subroutine crpoint
   use mod_settings
   use numerical_constants
 
-  use dynk,      only : dynk_enabled,dynk_getvalue,dynk_fSets_cr,dynk_cSets_unique,dynk_nSets_unique,dynk_filePos,dynk_crpoint
+  use dynk,      only : dynk_enabled,dynk_getvalue,dynk_fSets_cr,dynk_cSets_unique,dynk_nSets_unique,dynk_crpoint
   use dump,      only : dump_crpoint
   use aperture,  only : aper_crpoint,limifound
   use scatter,   only : scatter_active, scatter_crpoint

--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1013,7 +1013,7 @@ subroutine collimate_init()
     write(lerr,"(a)") "COLL> ERROR All emittances should be normalized. "//&
       "first put emittance for distribtion generation, then for collimator position etc. units in [mm*mrad]."
     write(lerr,"(a)") "COLL> ERROR EXAMPLE: 2.5 2.5 3.5 3.5"
-    call prror(-1)
+    call prror
   end if
 
 !++  Calculate the gammas
@@ -1191,7 +1191,7 @@ subroutine collimate_init()
                         myemitx0_dist, myemity0_dist, myenom, myx, myxp, myy, myyp, myp, mys, enerror, bunchlength)
     case default
       write(lerr,"(a)") "COLL> ERROR Review your distribution parameters!"
-      call prror(-1)
+      call prror
     end select
   end if
 
@@ -2420,7 +2420,7 @@ subroutine collimate_do_collimator(stracki)
       beamsize2 = sqrt(betay2 * myemity0_collgap)
     else
       write(lout,*) "attempting to use a halo not purely in the horizontal or vertical plane with pencil_dist=3 - abort."
-      call prror(-1)
+      call prror
     end if
 
 !   calculate offset from tilt of positive and negative jaws, at start and end
@@ -3068,7 +3068,7 @@ subroutine collimate_end_collimator()
         write(lout,*) "Error in collimate_end_collimator"
         write(lout,*) "Particle cannot be both absorbed and not absorbed."
         write(lout,*) part_abs_pos (j),  part_abs_turn(j)
-        call prror(-1)
+        call prror
       end if
 
 !GRD THIS LOOP MUST NOT BE WRITTEN INTO THE "IF(FIRSTRUN)" LOOP !!!!!
@@ -3231,7 +3231,7 @@ subroutine collimate_end_collimator()
         if(part_impact(j).lt.-half) then
           write(lout,*) 'ERR>  Found invalid impact parameter!', part_impact(j)
           write(outlun,*) 'ERR>  Invalid impact parameter!', part_impact(j)
-          call prror(-1)
+          call prror
         end if
 
         n_impact = n_impact + 1
@@ -4510,7 +4510,7 @@ subroutine collimate2(c_material, c_length, c_rotation,           &
     write(lout,*) 'ERR>  In subroutine collimate2:'
     write(lout,*) 'ERR>  Material "', c_material, '" not found.'
     write(lout,*) 'ERR>  Check your CollDB! Stopping now.'
-    call prror(-1)
+    call prror
   end if
 
   length  = c_length
@@ -4765,7 +4765,7 @@ subroutine collimate2(c_material, c_length, c_rotation,           &
       s = (-one*x) / xp
       if(s.le.0) then
         write(lout,*) 'S.LE.0 -> This should not happen'
-        call prror(-1)
+        call prror
       end if
 
       if(s .lt. length) then
@@ -5145,7 +5145,7 @@ subroutine collimaterhic(c_material, c_length, c_rotation,        &
   save
 !=======================================================================
   write(lerr,"(a)") "COLL> ERROR collimateRHIC is no longer supported!"
-  call prror(-1)
+  call prror
 end subroutine collimaterhic
 !
 !-----GRD-----GRD-----GRD-----GRD-----GRD-----GRD-----GRD-----GRD-----GRD-----
@@ -6277,7 +6277,7 @@ subroutine makedis_coll(myalphax, myalphay, mybetax, mybetay,  myemitx0, myemity
 ! nominal bunches centered in the aperture - can't apply rejection sampling. return with error
          else if( mynex.eq.zero.and.myney.eq.zero ) then
            write(lout,*) "Stop in makedis_coll. attempting to use halo type 3 with Gaussian dist. "
-           call prror(-1)
+           call prror
          else
            write(lout,*) "Error - beam parameters not correctly set!"
          end if
@@ -6511,7 +6511,7 @@ subroutine readdis(filename_dis,myx,myxp,myy,myyp,myp,mys)
  20   continue
 
   write(lout,"(a)") "COLL> I/O Error on Unit 53 in subroutine readdis"
-  call prror(-1)
+  call prror
 
 end subroutine readdis
 
@@ -6565,7 +6565,7 @@ subroutine readdis_norm(filename_dis,  myalphax, myalphay, mybetax, mybetay, &
     write(lerr,"(a)") "COLL> distribution in normalized coordinates for  "
     write(lerr,"(a)") "COLL> collimation the closed orbit is needed for a"
     write(lerr,"(a)") "COLL> correct TAS matrix for coordinate transform."
-    call prror(-1)
+    call prror
   endif
 
   write(lout,"(a)") "COLL> Reading input bunch from file '"//filename_dis//"'"
@@ -6690,7 +6690,7 @@ subroutine readdis_norm(filename_dis,  myalphax, myalphay, mybetax, mybetay, &
 
 20 continue
    write(lout,"(a)") "COLL> I/O Error on Unit 53 in subroutine readdis"
-   call prror(-1)
+   call prror
 
 end subroutine readdis_norm
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -151,7 +151,6 @@ module mod_common
 
   ! Error Variables
   integer,          save :: ierro      = 0
-  integer,          save :: errout     = 0    ! Used in prror and abend
 
   ! Loop Variables
   integer,          save :: iu         = 0    ! Number of entries in the accelerator

--- a/source/dabnew.f90
+++ b/source/dabnew.f90
@@ -4997,7 +4997,7 @@ subroutine dadeb(iunit,c,istop)
 #ifdef CR
       call abend('                                                  ')
 #else
-      call prror(-1)
+      call prror
 #endif
 end subroutine dadeb
 

--- a/source/dump.f90
+++ b/source/dump.f90
@@ -419,7 +419,7 @@ subroutine dump_initialise
       if (.not.lopen) then
         write(lerr,"(2(a,i0),a)") "DUMP> ERROR The unit ",dumpunit(i)," has dumpfilepos = ", dumpfilepos(i), " >= 0, "//&
           "but the file is NOT open. This is probably a bug."
-        call prror(-1)
+        call prror
       end if
       cycle ! Everything OK, don't try to open the files again.
     end if
@@ -433,7 +433,7 @@ subroutine dump_initialise
           if (ldump(j) .and. (dump_fname(j) == dump_fname(i))) then
             write(lerr,"(2(a,i0))") "DUMP> ERROR Output filename '"//trim(dump_fname(i))//&
               "' is used by two DUMPS, but output units differ: ",dumpunit(i)," vs ",dumpunit(j)
-            call prror(-1)
+            call prror
           end if
         end do
         if (dumpfmt(i) == 3 .or. dumpfmt(i) == 8 .or. dumpfmt(i) == 101) then ! Binary dump
@@ -459,17 +459,17 @@ subroutine dump_initialise
             if (dumpunit(j) == dumpunit(i)) then
               if (dumpfmt(j) /= dumpfmt(i)) then
                 write(lerr,"(a,i0,a)") "DUMP> ERROR Output unit ",dumpunit(i)," used by two DUMPS, formats are not the same."
-                call prror(-1)
+                call prror
               else if (j == 0) then
                 write(lerr,"(a,i0,a)") "DUMP> ERROR Output unit ",dumpunit(i)," used by two DUMPS, one of which is ALL"
-                call prror(-1)
+                call prror
               else if (j == -1) then
                 write(lerr,"(a,i0,a)") "DUMP> ERROR Output unit ",dumpunit(i)," used by two DUMPS, one of which is StartDUMP"
-                call prror(-1)
+                call prror
               else if (dump_fname(j) /= dump_fname(i)) then
                 write(lerr,"(a,i0,a)") "DUMP> ERROR Output unit ",dumpunit(i)," used by two DUMPS, but filenames differ: '"//&
                   trim(dump_fname(i)),"' vs '",trim(dump_fname(j)),"'"
-                call prror(-1)
+                call prror
               else
                 ! Everything is fine
                 lopen = .true.
@@ -488,7 +488,7 @@ subroutine dump_initialise
           write(lerr,"(a,i0,a)") "DUMP> ERROR Unit ",dumpunit(i)," is already open, but not by DUMP. Please pick another unit!"
           write(lerr,"(a)")      "DUMP> Note: This check is not watertight as other parts of the program may later open the "
           write(lerr,"(a)")      "DUMP>       same unit. Althernatively, the unit can be specified as -1 and a unit is assigned."
-          call prror(-1)
+          call prror
         end if
       end if
 
@@ -609,12 +609,12 @@ subroutine dump_initialise
         if (dumptas(i,1,1) == zero .and. dumptas(i,1,2) == zero .and. &
             dumptas(i,1,3) == zero .and. dumptas(i,1,4) == zero) then
           write(lerr,"(a)") "DUMP> ERROR The normalization matrix appears to not be set. Did you forget to put a 6D LINE block?"
-          call prror(-1)
+          call prror
         end if
         if(idp == 0 .or. ition == 0) then ! We're in the 4D case
           if(i /= -1) then ! Not at StartDUMP
             write(lerr,"(a)") "DUMP> ERROR in normalized DUMP: 4D only supported for StartDUMP!"
-            call prror(-1)
+            call prror
           end if
         end if
       end if ! END if normalized dump
@@ -1750,7 +1750,7 @@ call h5_finaliseWrite(dump_hdf5DataSet(ix))
   ! ------------------------------------------------------------------ !
   else
     write(lerr,"(a,i0,a)") "DUMP> ERROR Format ",fmt," not understood for file '"//trim(dump_fname(i))//"'"
-    call prror(-1)
+    call prror
   end if
 
   call time_stopClock(time_clockDUMP)

--- a/source/elens.f90
+++ b/source/elens.f90
@@ -593,7 +593,7 @@ subroutine parseRadialProfile(ifile)
 
 30 continue
   write(lerr,"(a,i0,a)") "ELENS> ERROR ",iErr," while parsing file "//trim(elens_radial_filename(ifile))
-  call prror(-1)
+  call prror
 
 end subroutine parseRadialProfile
 

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -134,14 +134,17 @@ subroutine abend(endMsg)
   write(crlog,"(a)") "ABEND_CR> Stop: "//trim(endMsg)
   call f_close(crlog)
 
-#ifdef BOINC
-  call boinc_finish(errout) ! This call does not return
-#endif
   if(endMsg == "ERROR") then
+#ifdef BOINC
+    call boinc_finish(1)
+#endif
     ! Don't write to stderr, it breaks the error tests.
-    write(output_unit,"(a,i0)") "ABEND> ERROR Stopping with error ",errout
+    write(output_unit,"(a)") "ABEND> Stop: "//trim(endMsg)
     stop 1
   else
+#ifdef BOINC
+    call boinc_finish(0)
+#endif
     stop
   end if
 

--- a/source/end_sixtrack.f90
+++ b/source/end_sixtrack.f90
@@ -3,27 +3,14 @@
 !  Last modified: 2018-06-25
 ! =================================================================================================
 
-subroutine prror(ier)
+subroutine prror
 
   use crcoall
-  use mod_common, only : errout
 #ifdef FLUKA
   use mod_fluka
 #endif
 
   implicit none
-
-  integer, optional, intent(in) :: ier
-
-#ifdef FLUKA
-  integer fluka_con
-#endif
-
-  if(present(ier)) then
-    errout = ier
-  else
-    errout = -1
-  end if
 
   ! These should not go to lerr
   write(lout,"(a)") ""
@@ -150,7 +137,7 @@ subroutine abend(endMsg)
 #ifdef BOINC
   call boinc_finish(errout) ! This call does not return
 #endif
-  if(errout /= 0) then
+  if(endMsg == "ERROR") then
     ! Don't write to stderr, it breaks the error tests.
     write(output_unit,"(a,i0)") "ABEND> ERROR Stopping with error ",errout
     stop 1

--- a/source/fluka.f90
+++ b/source/fluka.f90
@@ -111,7 +111,7 @@ subroutine check_coupling_integrity
       if ( lerror ) then
         write(lout,*) ' at least one inconsistency in flagging elements'
         write(lout,*) '    for coupling: please check carefully...'
-        call prror(-1)
+        call prror
       endif
 
 !     au revoir:
@@ -156,7 +156,7 @@ subroutine check_coupling_start_point()
         write(lerr,"(a,i0)") "FLUKA>       The actual lattice starting point should be outside a FLUKA insergion region"
         write(lerr,"(a,i0)") "FLUKA>       Please update your lattice structure or set the GO in a sensible position"
         iInside=fluka_geo_index(ix)
-        call prror(-1)
+        call prror
         exit
       elseif ( fluka_type(ix).eq.FLUKA_ENTRY .or. fluka_type(ix).eq.FLUKA_ELEMENT ) then
         write(lout,"(a)") ""
@@ -243,7 +243,7 @@ subroutine kernel_fluka_element( nturn, i, ix )
       if (ret.eq.-1) then
          write(lout,*)'[Fluka] Error in Fluka communication in kernel_fluka_element...'
          write(fluka_log_unit,*)'# Error in Fluka communication in kernel_fluka_element...'
-         call prror(-1)
+         call prror
       end if
 
       nnuc1 = 0                 ! hisix: number of nucleons leaving the collimato
@@ -396,7 +396,7 @@ subroutine kernel_fluka_entrance( nturn, i, ix )
       if (ret.eq.-1) then
          write(lout,*)'[Fluka] Error in Fluka communication in kernel_fluka_entrance...'
          write(fluka_log_unit,*)'# Error in Fluka communication in kernel_fluka_entrance...'
-         call prror(-1)
+         call prror
       end if
 
 !     au revoir:
@@ -455,7 +455,7 @@ subroutine kernel_fluka_exit( nturn, i, ix )
       if (ret.eq.-1) then
          write(lout,*)'[Fluka] Error in Fluka communication in kernel_fluka_exit...'
          write(fluka_log_unit,*)'# Error in Fluka communication in kernel_fluka_exit...'
-         call prror(-1)
+         call prror
       end if
 
       nnuc1 = 0                 ! hisix: number of nucleons leaving the collimator

--- a/source/fma.f90
+++ b/source/fma.f90
@@ -212,7 +212,7 @@ subroutine fma_postpr
   call f_open(unit=fmaUnit,file="fma_sixtrack",formatted=.true.,mode="w",err=fErr,status="replace")
   if(fErr) then
     write(lerr, "(a)") "FMA> ERROR Cannot open file 'fma_sixtrack' for writing."
-    call prror(-1)
+    call prror
   end if
 
   if(idp == 0 .or. ition == 0) then
@@ -239,7 +239,7 @@ subroutine fma_postpr
         if(.not.(dumpfmt(j) == 2 .or. dumpfmt(j) == 3 .or. &
                  dumpfmt(j) == 7 .or. dumpfmt(j) == 8)) then
           write(lerr,"(a)") "FMA> ERROR Input file has wrong format. Choose format 2, 3, 7 or 8 in DUMP block."
-          call prror(-1)
+          call prror
         end if
 
         ! Open dump file for reading, resume to original position before exiting the subroutine
@@ -248,24 +248,24 @@ subroutine fma_postpr
           call f_close(dumpunit(j))
         else ! File has to be open if nothing went wrong
           write(lerr,"(a)") "FMA> ERROR Expected file '"//trim(dump_fname(j))//"' to be open."
-          call prror(-1)
+          call prror
         end if
 
         if(dumpfmt(j) == 2 .or. dumpfmt(j) == 7) then
           call f_open(unit=dumpunit(j),file=dump_fname(j),formatted=.true.,mode="r",err=fErr,status="old")
           if(fErr) then
             write(lerr,"(a,i0,a)") "FMA> ERROR Opening file 'NORM_"//trim(dump_fname(j))//"' (dumpfmt=",dumpfmt(j),")"
-            call prror(-1)
+            call prror
           end if
         else if(dumpfmt(j) == 3 .or. dumpfmt(j) == 8) then
           call f_open(unit=dumpunit(j),file=dump_fname(j),formatted=.false.,mode="r",err=fErr,status="old")
           if(fErr) then
             write(lerr,"(a,i0,a)") "FMA> ERROR Opening file 'NORM_"//trim(dump_fname(j))//"' (dumpfmt=",dumpfmt(j),")"
-            call prror(-1)
+            call prror
           end if
         else
           write(lerr,"(a,i0,a)") "FMA> ERROR Got dumpfmt = ",dumpfmt(j),", but expected 2,3,7 or 8."
-          call prror(-1)
+          call prror
         end if
 
         ! Define first/last turn for FMA
@@ -288,7 +288,7 @@ subroutine fma_postpr
         if(fma_first(i) < dumpfirst(j)) then
           write(lerr,"(2(a,i0))") "FMA> ERROR First turn in FMA block is smaller than first turn in DUMP block: "//&
             "fma_first = ",fma_first(i)," < dumpfirst = ",dumpfirst(j)
-          call prror(-1)
+          call prror
         end if
 
         ! Now check last turn
@@ -296,7 +296,7 @@ subroutine fma_postpr
         if(fma_last(i) <= 0) then
           write(lerr,"(a,i0)") "FMA> ERROR Last turn in FMA block must be -1 or a positive integer, "//&
             "but fma_last = ",fma_last(i)
-          call prror(-1)
+          call prror
         end if
 
         ! If fma_last >0 check that fma_last < dump_last
@@ -304,7 +304,7 @@ subroutine fma_postpr
           if(fma_last(i) > numl) then
             write(lerr,"(2(a,i0))") "FMA> ERROR Last turn in FMA block is larger than number of turns tracked. "//&
               " fma_last = ",fma_last(i)," > turns tracked = ",numl
-            call prror(-1)
+            call prror
           end if
         else
           if(fma_last(i) > dumplast(j)) then
@@ -321,7 +321,7 @@ subroutine fma_postpr
         if(fma_nturn(i) > fma_nturn_max) then
           write(lerr,"(a,i0,a,i0,a)") "FMA> ERROR Only ",fma_nturn_max," turns allowed for fma, but ",fma_nturn(i)," used."
           write(lerr,"(a,i0)")        "FMA>       -> reset fma_nturn_max > ",fma_nturn_max
-          call prror(-1)
+          call prror
         end if
 
         ! Now we can start reading in the file
@@ -331,14 +331,14 @@ subroutine fma_postpr
             read(dumpunit(j),"(a)",iostat=ierro) ch
             if(ierro /= 0) then
               write(lerr,"(a)") "FMA> ERROR Reading file '"//trim(dump_fname(j))//"'"
-              call prror(-1)
+              call prror
             end if
             ch1=adjustl(trim(ch))
             if(ch1(1:1) /= "#") exit
             if(counter > 500) then
               write(lerr,"(a)") "FMA> ERROR Something is wrong with your dumpfile '"//trim(dump_fname(j))//&
                 "'> Found more than 500 header lines."
-              call prror(-1)
+              call prror
             end if
             counter = counter+1
           end do
@@ -351,7 +351,7 @@ subroutine fma_postpr
             ! For format 7 and 8, the particles are already normalised by the DUMP block
             write(lerr,"(a,i0)") "FMA> ERROR For FMA #",i
             write(lerr,"(a)")    "FMA>       Cannot do FMA on physical coordinates if normalised DUMP is used (format 7 or 8)"
-            call prror(-1)
+            call prror
           end if
         else ! Reading physical coordinates
           if(fma_norm_flag(i) == 1 ) then
@@ -359,12 +359,12 @@ subroutine fma_postpr
             if(dumptas(j,1,1) == zero .and. dumptas(j,1,2) == zero .and. &
                 dumptas(j,1,3) == zero .and. dumptas(j,1,4) == zero) then
               write(lerr,"(a)") "FMA> ERROR The normalisation matrix appears to not be set? Did you forget to put a 6D LINE block?"
-              call prror(-1)
+              call prror
             end if
             if(idp == 0 .or. ition == 0) then ! We're in the 4D case
               if(j /= -1) then ! Not at StartDUMP
                 write(lerr,"(a)") "FMA> ERROR normalised coordinates: 4D only supported for StartDUMP."
-                call prror(-1)
+                call prror
               end if
             end if
           end if
@@ -378,7 +378,7 @@ subroutine fma_postpr
           call f_open(unit=tmpUnit,file="NORM_"//dump_fname(j),formatted=.true.,mode="w",err=fErr,status="replace")
           if(fErr) then
             write(lerr,"(a)") "FMA> ERROR Opening file 'NORM_"//trim(dump_fname(j))//"'"
-            call prror(-1)
+            call prror
           end if
 
           ! Write the file headers
@@ -427,7 +427,7 @@ subroutine fma_postpr
 
         ! Read in particle amplitudes a(part,turn), x,xp,y,yp,sigma,dE/E [mm,mrad,mm,mrad,mm,1]
         ! TODO: This logic breaks apart if there are particle losses;
-        !  it is checked for, but it only triggers a "call prror(-1)".
+        !  it is checked for, but it only triggers a "call prror".
 
         ! If normalization within FMA, we now have to always write the full NORM_* file
         ! Otherwise  one would overwrite the NORM_* file constantly if different FMAs are done
@@ -449,7 +449,7 @@ subroutine fma_postpr
               if(spErr) then
                 write(lerr,"(a,i0,a)") "FMA> ERROR Failed to parse line from file '"//trim(dump_fname(j))//&
                   "' (dumpfmt = ",dumpfmt(j),")"
-                call prror(-1)
+                call prror
               end if
               if(nSplit > 0) call chr_cast(lnSplit(1), id,          cErr)
               if(nSplit > 1) call chr_cast(lnSplit(2), thisturn,    cErr)
@@ -467,7 +467,7 @@ subroutine fma_postpr
               if(ierro /= 0) then
                 write(lerr,"(a,i0,a)") "FMA> ERROR Failed to parse line from file '"//trim(dump_fname(j))//&
                   "' (dumpfmt = ",dumpfmt(j),")"
-                call prror(-1)
+                call prror
               end if
             end if
 
@@ -483,7 +483,7 @@ subroutine fma_postpr
               write(lerr,"(2(a,i0))") "FMA>       Got turn ",thisturn," and particle ID ",id
               write(lerr,"(a)")       "FMA>       Reading probably got unsynchronized because of particle losses,"//&
                 " which is currently not handled in FMA."
-              call prror(-1)
+              call prror
             end if
 
             ! Normalization
@@ -653,7 +653,7 @@ subroutine fma_postpr
             case default
               write(lerr,"(a)") "FMA> ERROR Method '"//trim(fma_method(i))//&
                 "' not known. Note that the method name must be in capital letters."
-              call prror(-1)
+              call prror
             end select
 
             ! mode 3 rotates anticlockwise, mode 1 and 2 rotate clockwise -> synchroton tune is negative,
@@ -703,13 +703,13 @@ subroutine fma_postpr
           call f_open(unit=dumpunit(j),file=dump_fname(j),formatted=.true.,mode="rw+",err=fErr)
           if(fErr) then
             write(lerr,"(a,i0,a)") "FMA> ERROR Resuming file '"//trim(dump_fname(j))//"' (dumpfmt = ",dumpfmt(j),")"
-            call prror(-1)
+            call prror
           end if
         elseif (dumpfmt(j).eq.3 .or. dumpfmt(j).eq.8) then !BINARY
           call f_open(unit=dumpunit(j),file=dump_fname(j),formatted=.false.,mode="rw+",err=fErr)
           if(fErr) then
             write(lerr,"(a,i0,a)") "FMA> ERROR Resuming file '"//trim(dump_fname(j))//"' (dumpfmt = ",dumpfmt(j),")"
-            call prror(-1)
+            call prror
           end if
         end if
       end if ! END: if fma_fname(i) matches dump_fname(j)
@@ -721,7 +721,7 @@ subroutine fma_postpr
     if(.not. fExist) then ! if no dumpfile has been found, raise error and abort
       write(lerr,"(a)") "FMA> ERROR DUMP file '"//trim(fma_fname(i))//&
         "' does not exist. Please check that filenames in FMA block agree with the ones in the DUMP block."
-      call prror(-1)
+      call prror
     end if
 
   end do ! END: loop over fma files

--- a/source/hdf5_output.f90
+++ b/source/hdf5_output.f90
@@ -431,7 +431,7 @@ subroutine h5_initHDF5
   call h5pset_preserve_f(h5_plistID, .true., h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to initialise Fortran HDF5."
-    call prror(-1)
+    call prror
   end if
   write(lout,"(a)") "HDF5> Fortran HDF5 initialised."
 
@@ -449,7 +449,7 @@ subroutine h5_openFile
 
   if(.not. h5_isActive) then
     write(lerr,"(a)") "HDF5> ERROR HDF5 file open called, but HDF5 is not active. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   inquire(file=h5_fileName%chr, exist=doesExist)
@@ -459,14 +459,14 @@ subroutine h5_openFile
       call h5fcreate_f(h5_fileName%chr, H5F_ACC_TRUNC_F, h5_fileID, h5_fileError)
       if(h5_fileError < 0) then
         write(lerr,"(a)") "HDF5> ERROR Failed to open HDF5 file '"//h5_fileName//"'."
-        call prror(-1)
+        call prror
       end if
       write(lout,"(a)") "HDF5> Truncated HDF5 file '"//h5_fileName//"'."
     else
       call h5fopen_f(h5_fileName%chr, H5F_ACC_RDWR_F, h5_fileID, h5_fileError)
       if(h5_fileError < 0) then
         write(lerr,"(3a)") "HDF5> ERROR Failed to open HDF5 file '",h5_fileName%chr,"'."
-        call prror(-1)
+        call prror
       end if
       write(lout,"(a)") "HDF5> Opened HDF5 file '"//h5_fileName//"'."
     end if
@@ -474,7 +474,7 @@ subroutine h5_openFile
     call h5fcreate_f(h5_fileName%chr, H5F_ACC_EXCL_F, h5_fileID, h5_fileError)
     if(h5_fileError < 0) then
       write(lerr,"(a)") "HDF5> ERROR Failed to create HDF5 file '"//h5_fileName//"'."
-      call prror(-1)
+      call prror
     end if
     write(lout,"(a)") "HDF5> Created HDF5 file '"//h5_fileName//"'."
   end if
@@ -486,7 +486,7 @@ subroutine h5_openFile
     if(h5_fileError < 0) then
       write(lerr,"(a)") "HDF5> ERROR Failed to create root group '"//h5_rootPath//"'."
       write(lerr,"(a)") "HDF5> ERROR   If you are writing to an existing file, the root group must be unique."
-      call prror(-1)
+      call prror
     end if
     write(lout,"(a)") "HDF5> Created root group '"//h5_rootPath//"'."
   else
@@ -580,14 +580,14 @@ subroutine h5_closeHDF5
   call h5fclose_f(h5_fileID, h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to close HDF5 file."
-    call prror(-1)
+    call prror
   end if
 
   ! This cleans up everything left over
   call h5close_f(h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to close Fortran HDF5."
-    call prror(-1)
+    call prror
   end if
 
   write(lout,"(a)") "HDF5> Closed HDF5 file."
@@ -603,13 +603,13 @@ subroutine h5_initForAperture
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Block initialisation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   call h5gcreate_f(h5_rootID, h5_aperGroup, h5_aperID, h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create aperture group '"//h5_aperGroup//"'."
-    call prror(-1)
+    call prror
   end if
   if(h5_debugOn) then
     write(lout,"(a)") "HDF5> DEBUG Group created for APERTURE."
@@ -621,13 +621,13 @@ subroutine h5_initForCollimation
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Block initialisation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   call h5gcreate_f(h5_rootID, h5_collGroup, h5_collID, h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create collimation group '"//h5_collGroup//"'."
-    call prror(-1)
+    call prror
   end if
   if(h5_debugOn) then
     write(lout,"(a)") "HDF5> DEBUG Group created for COLLIMATION."
@@ -639,13 +639,13 @@ subroutine h5_initForDump
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Block initialisation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   call h5gcreate_f(h5_rootID, h5_dumpGroup, h5_dumpID, h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create dump group '"//h5_dumpGroup//"'."
-    call prror(-1)
+    call prror
   end if
   if(h5_debugOn) then
     write(lout,"(a)") "HDF5> DEBUG Group created for DUMP."
@@ -657,13 +657,13 @@ subroutine h5_initForScatter
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Block initialisation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   call h5gcreate_f(h5_rootID, h5_scatGroup, h5_scatID, h5_fileError)
   if(h5_fileError < 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create scatter group '"//h5_scatGroup//"'."
-    call prror(-1)
+    call prror
   end if
   if(h5_debugOn) then
     write(lout,"(a)") "HDF5> DEBUG Group created for SCATTER."
@@ -692,21 +692,21 @@ subroutine h5_createFormat(formatName, setFields, fmtID)
 
   if(.not. h5_isActive) then
     write(lerr,"(a)") "HDF5> ERROR HDF5 routine called, but HDF5 is not active. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   ! Check inputs
   if(len(formatName) == 0) then
     write(lerr,"(a)") "HDF5> ERROR Empty format name given. This is a bug."
-    call prror(-1)
+    call prror
   end if
   if(allocated(setFields) .eqv. .false.) then
     write(lerr,"(a)") "HDF5> ERROR Fields array not allocated. This is a bug."
-    call prror(-1)
+    call prror
   end if
   if(size(setFields) == 0) then
     write(lerr,"(a)") "HDF5> ERROR Fields array empty. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   ! First, extend the h5_fmtList array
@@ -778,7 +778,7 @@ subroutine h5_createFormat(formatName, setFields, fmtID)
 
   if(h5_dataError /= 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create compund data record '"//formatName//"'"
-    call prror(-1)
+    call prror
   end if
 
   ! Save the Resulting HDF5 DataType
@@ -821,7 +821,7 @@ subroutine h5_createDataSet(setName, groupID, fmtID, setID, chunckSize)
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Dataset creation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   ! First, extend the h5_setList array
@@ -856,7 +856,7 @@ subroutine h5_createDataSet(setName, groupID, fmtID, setID, chunckSize)
   call h5pset_chunk_f(propID, 1, spaceSize, h5_dataError)
   if(h5_dataError /= 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to set chunck size for '"//cleanName//"'"
-    call prror(-1)
+    call prror
   end if
   if(h5_gzipLevel > -1) then
     call h5pset_deflate_f(propID, h5_gzipLevel, h5_dataError)
@@ -867,7 +867,7 @@ subroutine h5_createDataSet(setName, groupID, fmtID, setID, chunckSize)
   call h5dcreate_f(groupID, cleanName, dtypeID, spaceID, dataID, h5_dataError, propID)
   if(h5_dataError /= 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to create dataset '"//cleanName//"'"
-    call prror(-1)
+    call prror
   end if
 
   call h5sclose_f(spaceID, h5_dataError)
@@ -914,7 +914,7 @@ subroutine h5_createBuffer(bufName, fmtID, setID, bufSize)
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Buffer creation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   ! First, extend the h5_setList array
@@ -1166,7 +1166,7 @@ subroutine h5_prepareWrite(setID, appendSize)
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Dataset operation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   oldSize(1) = h5_setList(setID-h5_setOff)%records
@@ -1184,7 +1184,7 @@ subroutine h5_prepareWrite(setID, appendSize)
 
   if(h5_dataError /= 0) then
     write(lerr,"(a)") "HDF5> ERROR Failed to extend dataset '"//h5_setList(setID-h5_setOff)%name//"'"
-    call prror(-1)
+    call prror
   end if
 
   h5_setList(setID-h5_setOff)%records = newSize(1)
@@ -1208,7 +1208,7 @@ subroutine h5_finaliseWrite(setID)
 
   if(.not. h5_isReady) then
     write(lerr,"(a)") "HDF5> ERROR Dataset operation requested, but no HDF5 file is open. This is a bug."
-    call prror(-1)
+    call prror
   end if
 
   call h5dclose_f(h5_setList(setID-h5_setOff)%dataID,  h5_dataError)

--- a/source/include/beams1.f90
+++ b/source/include/beams1.f90
@@ -14,7 +14,7 @@
                 if(nbeaux(imbb(i)).eq.2.or.nbeaux(imbb(i)).eq.3) then
                   write(lerr,"(a)") "BEAMBEAM> ERROR At each interaction point the beam must be either "//&
                     "round or elliptical for all particles"
-                  call prror(-1)
+                  call prror
                 else
                   nbeaux(imbb(i))=1
                   sigman2(1,imbb(i))=sigman(1,imbb(i))**2
@@ -25,7 +25,7 @@
                 if(nbeaux(imbb(i)).eq.1.or.nbeaux(imbb(i)).eq.3) then
                   write(lerr,"(a)") "BEAMBEAM> ERROR At each interaction point the beam must be either "//&
                     "round or elliptical for all particles"
-                  call prror(-1)
+                  call prror
                 else
                   nbeaux(imbb(i))=2
                   sigman2(1,imbb(i))=sigman(1,imbb(i))**2
@@ -39,7 +39,7 @@
                 if(nbeaux(imbb(i)).eq.1.or.nbeaux(imbb(i)).eq.2) then
                   write(lerr,"(a)") "BEAMBEAM> ERROR At each interaction point the beam must be either "//&
                     "round or elliptical for all particles"
-                  call prror(-1)
+                  call prror
                 else
                   nbeaux(imbb(i))=3
                   sigman2(1,imbb(i))=sigman(1,imbb(i))**2

--- a/source/include/wirekick.f90
+++ b/source/include/wirekick.f90
@@ -49,7 +49,7 @@
      &'be either 1 or -1! Did you define all wires in the WIRE block?', &
      &'bez(',ix,') = ',bez(ix),                                         &
      &'wire_flagco(',ix,') = ',wire_flagco(ix)
-        call prror(-1)
+        call prror
       endif
 
 

--- a/source/lielib.f90
+++ b/source/lielib.f90
@@ -48,7 +48,7 @@ subroutine lieinit(no1,nv1,nd1,ndpt1,iref1,nis)
               ndt=nd2
               if(ndpt.ne.nd2-1) then
                 write(lout,*) ' LETHAL ERROR IN LIEINIT'
-                call prror(-1)
+                call prror
               endif
             endif
        endif
@@ -3026,7 +3026,7 @@ subroutine initpert(st,ang,ra)
       if(nres.ge.nreso) then
        write(lout,*) ' NRESO IN LIELIB TOO SMALL '
        write(lout,'(a)') "ERROR 999 in initpert"
-       call prror(-1)
+       call prror
       endif
       elseif(iref.eq.0) then
       nres=0

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -463,7 +463,7 @@ program maincr
         nlin=nlin+1
         if(nlin.gt.nele) then
           write(lerr,"(a)") "MAINCR> ERROR Too many elements for linear optics write-out"
-          call prror(-1)
+          call prror
         end if
         bezl(nlin)=bez(i)
       end if
@@ -869,7 +869,7 @@ program maincr
     if(fluka_con == -1) then
       write(lerr,"(a)") "FLUKA> ERROR Fluka is expected to run but it is NOT actually the case"
       write(fluka_log_unit,*) "# Fluka is expected to run but it is NOT actually the case"
-      call prror(-1)
+      call prror
     end if
     write(lout,"(a)") "FLUKA> Initializing FlukaIO interface ..."
     write(fluka_log_unit,*) "# Initializing FlukaIO interface ..."
@@ -877,7 +877,7 @@ program maincr
     if(fluka_con == -1) then
       write(lerr,"(a)") "FLUKA> ERROR Cannot connect to Fluka server"
       write(fluka_log_unit,*) "# Error connecting to Fluka server"
-      call prror(-1)
+      call prror
     endif
     write(lout,"(a)") "FLUKA> Successfully connected to Fluka server"
     write(fluka_log_unit,*) "# Successfully connected to Fluka server"
@@ -901,7 +901,7 @@ program maincr
     if(iclo6 /= 0) then
       write(lerr,"(a,i0)") "MAINCR> ERROR Doing 4D tracking but iclo6 = ",iclo6
       write(lerr,"(a)")    "MAINCR>       Expected iclo6 = 0 for 4D tracking."
-      call prror(-1)
+      call prror
     end if
   else
     ! 6D tracking
@@ -913,7 +913,7 @@ program maincr
     if(iclo6 == 0) then
       write(lerr,"(a,i0)") "MAINCR> ERROR Doing 6D tracking but iclo6 = ",iclo6
       write(lerr,"(a)")    "MAINCR>       Expected iclo6 <> 0 for 6D tracking."
-      call prror(-1)
+      call prror
     end if
   end if
 
@@ -1175,7 +1175,7 @@ program maincr
     if(fluka_con < 0) then
       write(lerr,"(a,i0,a)") "FLUKA> ERROR Failed to send napx ",napx," to fluka "
       write(fluka_log_unit, *) "# failed to send napx to fluka ",napx
-      call prror(-1)
+      call prror
     end if
 
     write(lout,"(a)") "FLUKA> Sending napx successful"
@@ -1200,7 +1200,7 @@ program maincr
     if(fluka_con < 0) then
       write(lerr,"(a)") "FLUKA> ERROR Failed to update the reference particle"
       write(fluka_log_unit,*) "# failed to update ref particle"
-      call prror(-1)
+      call prror
     end if
 
     write(lout,"(a)") "FLUKA> Updating the reference particle successful"

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -148,7 +148,7 @@ program mainda
   if (ithick.eq.1) call allocate_thickarrays
   if(nord <= 0 .or. nvar <= 0) then
     write(lerr,"(a)") "MAINDA> ERROR Order and number of variables have to be larger than 0 to calculate a differential algebra map"
-    call prror(-1)
+    call prror
   end if
   if(ithick.eq.1) write(lout,10020)
   if(ithick.eq.0) write(lout,10030)
@@ -198,7 +198,7 @@ program mainda
         nlin=nlin+1
         if(nlin.gt.nele) then
           write(lerr,"(a)") "MAINDA> ERROR Too many elements for linear optics write-out"
-          call prror(-1)
+          call prror
         end if
         bezl(nlin)=bez(i)
       end if
@@ -455,7 +455,7 @@ program mainda
     if(ithick == 1) call envars(1,dps(1),rv)
   else
     write(lerr,"(a)") "MAINDA> ERROR Zero or negative energy does not make much sense."
-    call prror(-1)
+    call prror
   end if
   if(numl.eq.0.or.numlr.ne.0) then
     write(lout,10070)

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -83,10 +83,6 @@ program mainda
   featList = featList//" FIO"
 #endif
 
-  ! Set to nonzero before calling abend in case of error.
-  ! If prror is called, it will be set internally.
-  errout = 0
-
 #ifndef CR
   lout=output_unit
 #endif

--- a/source/matrix_inv.f90
+++ b/source/matrix_inv.f90
@@ -164,7 +164,7 @@ subroutine kermtr(ercode,log,mflag,rflag)
   end do
   write(lout,1000)  ercode
   write(lout,"(a)") "KERNLIB> Library Error"
-  call prror(-1)
+  call prror
   return
 
 21 continue
@@ -334,7 +334,7 @@ subroutine f010pr(name,n,idim,k,kprnt)
   end if
   if(.not. rflag) then
     write(lerr,"(a)") "KERNLIB> ERROR F010PR: "//name
-    call prror(-1)
+    call prror
   end if
   return
 
@@ -834,7 +834,7 @@ subroutine tmprnt(name,n,idim,k)
   endif
   if(.not. rflag) then
     write(lerr,"(a)") "KERNLIB> ERROR TMPRNT: "//name
-    call prror(-1)
+    call prror
   endif
   return
 1001 format(7x,' parameter error in subroutine ',a6,' (n.lt.1 or idim.lt.n).',5x,'n =',i4,5x,'idim =',i4,'.')

--- a/source/mod_dist.f90
+++ b/source/mod_dist.f90
@@ -193,18 +193,18 @@ subroutine dist_readDist
 
 19 continue
   write(lerr,"(a)") "DIST> ERROR Opening file '"//trim(dist_readFile)//"'"
-  call prror(-1)
+  call prror
   return
 
 20 continue
   write(lerr,"(a,i0)") "DIST> ERROR Reading particles from line ",ln
-  call prror(-1)
+  call prror
   return
 
 30 continue
   if(j == 0) then
     write(lerr,"(a)") "DIST> ERROR Reading particles. No particles read from file."
-    call prror(-1)
+    call prror
     return
   end if
 
@@ -265,7 +265,7 @@ subroutine dist_finaliseDist
           mtc(j) = one
         else
           write(lerr,"(a)") "DIST> ERROR Mass and/or charge mismatch with relation to sync particle"
-          call prror(-1)
+          call prror
         end if
       end if
 
@@ -324,7 +324,7 @@ subroutine dist_echoDist
 
 19 continue
   write(lerr,"(a)") "DIST> ERROR Opening file '"//trim(dist_echoFile)//"'"
-  call prror(-1)
+  call prror
   return
 
 end subroutine dist_echoDist

--- a/source/mod_ffield.f90
+++ b/source/mod_ffield.f90
@@ -679,13 +679,13 @@ contains
 !        Ldpsv2   = oidpsv(ffj)*oidpsv(ffj);
 
 !  <<<<<<< IN
-  	!   - Initial repositionning (AntiDrift)
+    !   - Initial repositionning (AntiDrift)
         x_tp=x-(LoutQ*oidpsv(ffj))*px;
         y_tp=y-(LoutQ*oidpsv(ffj))*py;
         x=x_tp;   y=y_tp;
 !  <<<<<<< IN
 
-  	!   - Compute Fringe Field using asymplectic Map (Lie2)
+    !   - Compute Fringe Field using asymplectic Map (Lie2)
         call ffTable(iFile)%Lie2(x,px,y,py,zb,oidpsv(ffj))
 
 !  <<<<<<< IN

--- a/source/mod_ffield_aux.f90
+++ b/source/mod_ffield_aux.f90
@@ -820,13 +820,13 @@ contains
 
     ! Check size vectors xpow and ypow   (Prevent SIGFPE)
     ! ---------------------------------------------------------------------------------------------- !
-    log_tmp=abs(log10_mb(x))
+    log_tmp=abs(log10_mb(abs(x)))
     if (log_tmp*(this%n)>230) then
       this%max_i=230/log_tmp-1
     else
       this%max_i=this%n
     endif
-    log_tmp=abs(log10_mb(y))
+    log_tmp=abs(log10_mb(abs(y)))
     if (log_tmp*(this%m)>230) then
       this%max_j=230/log_tmp-1
     else

--- a/source/mod_fluc.f90
+++ b/source/mod_fluc.f90
@@ -285,7 +285,7 @@ subroutine fluc_readFort8
     write(lerr,"(a)")       "FLUC>       You either have a non-existing element somewhere in the file,"
     write(lerr,"(a)")       "FLUC>       or too many references to the same element name."
     write(lerr,"(2(a,i0))") "FLUC>       Found ",(nAlign-1)," elements out of ",fluc_nAlign
-    call prror(-1)
+    call prror
   end if
 
   write(lout,"(a,i0,a)") "FLUC> Read ",fluc_nAlign," values from fort.8"
@@ -294,7 +294,7 @@ subroutine fluc_readFort8
 
 30 continue
   write(lerr,"(a,i0,a)") "FLUC> ERROR fort.8:",lineNo," '"//trim(inLine)//"'"
-  call prror(-1)
+  call prror
 
 end subroutine fluc_readFort8
 
@@ -435,7 +435,7 @@ subroutine fluc_readFort16
     write(lerr,"(a)")       "FLUC>       You either have a non-existing element somewhere in the file,"
     write(lerr,"(a)")       "FLUC>       or too many references to the same element name."
     write(lerr,"(2(a,i0))") "FLUC>       Found ",(nExt-1)," elements out of ",fluc_nExt
-    call prror(-1)
+    call prror
   end if
 
   write(lout,"(a,i0,a)") "FLUC> Read ",fluc_nExt," values from fort.16"
@@ -444,7 +444,7 @@ subroutine fluc_readFort16
 
 30 continue
   write(lerr,"(a,i0,a)") "FLUC> ERROR fort.16:",lineNo," '"//trim(inLine)//"'"
-  call prror(-1)
+  call prror
 
 end subroutine fluc_readFort16
 
@@ -558,7 +558,7 @@ subroutine fluc_readFort30
     write(lerr,"(a)")       "FLUC>       You either have a non-existing element somewhere in the file,"
     write(lerr,"(a)")       "FLUC>       or too many references to the same element name."
     write(lerr,"(2(a,i0))") "FLUC>       Found ",(nZFZ-1)," elements out of ",fluc_nZFZ
-    call prror(-1)
+    call prror
   end if
 
   write(lout,"(a,i0,a)") "FLUC> Read ",fluc_nZFZ," values from fort.30"
@@ -567,7 +567,7 @@ subroutine fluc_readFort30
 
 30 continue
   write(lerr,"(a,i0,a)") "FLUC> ERROR fort.30:",lineNo," '"//trim(inLine)//"'"
-  call prror(-1)
+  call prror
 
 end subroutine fluc_readFort30
 

--- a/source/mod_fluka.f90
+++ b/source/mod_fluka.f90
@@ -236,7 +236,7 @@ contains
       write(lout,*)
       write(lout,*) 'FLUKA> Could not read the host name from network.nfo'
       write(lout,*)
-      call prror(-1)
+      call prror
     end if
 
     read(unit=net_nfo_unit, fmt=*, iostat=ios) port
@@ -245,7 +245,7 @@ contains
       write(lout,*) 'FLUKA> Could not read the port number from network.nfo'
       write(lout,*) 'FLUKA> Is the FLUKA server running and has it had time to write the port number?'
       write(lout,*)
-      call prror(-1)
+      call prror
     end if
 
     call f_close(net_nfo_unit)

--- a/source/mod_particles.f90
+++ b/source/mod_particles.f90
@@ -180,8 +180,6 @@ end subroutine part_updatePartEnergy
 ! ================================================================================================ !
 subroutine part_writeState(theState)
 
-  use, intrinsic :: iso_fortran_env, only : int16, int32, real64
-
   use mod_units
   use parpro
   use mod_hions

--- a/source/mod_pythia.f90
+++ b/source/mod_pythia.f90
@@ -351,20 +351,20 @@ subroutine pythia_postInput
   pythStat = pythia_defaults()
   if(pythStat .eqv. .false.) then
     write(lerr,"(a)") "PYTHIA> ERROR Failed to set default values in libpythia8"
-    call prror(-1)
+    call prror
   end if
 
   if(.not. pythia_useElastic .and. pythia_useCoulomb) then
     write(lerr,"(a)") "PYTHIA> ERROR Coulumb corrections to elastic scattering requires elastic scattering to be enabled."
-    call prror(-1)
+    call prror
   end if
   if(.not. pythia_allowLosses .and. pythia_useDDiffractive) then
     write(lerr,"(a)") "PYTHIA> ERROR Double diffractive scattering requires allowing losses to be enabled."
-    call prror(-1)
+    call prror
   end if
   if(.not. pythia_allowLosses .and. pythia_useNDiffractive) then
     write(lerr,"(a)") "PYTHIA> ERROR Non-diffractive scattering requires allowing losses to be enabled."
-    call prror(-1)
+    call prror
   end if
 
   if(pythia_useSettingsFile) then
@@ -379,7 +379,7 @@ subroutine pythia_postInput
   pythStat = pythia_init()
   if(pythStat .eqv. .false.) then
     write(lerr,"(a)") "PYTHIA> ERROR Failed to initialise libpythia8"
-    call prror(-1)
+    call prror
   end if
 
   call pythia_getCrossSection(sigmaTot, sigmaEl)

--- a/source/plato_seq.f90
+++ b/source/plato_seq.f90
@@ -106,7 +106,7 @@ module platoFMA
 !C.............................................................
       IF (MAXN.GT.MAXITER) THEN
          WRITE(lout,'(a)') '***ERROR(TUNENEWT1): TOO MANY ITERATIONS'
-         call prror(-1)
+         call prror
       ENDIF
 !C.............................................................
 !C    ESTIMATION OF TUNE WITH FFT
@@ -172,7 +172,7 @@ module platoFMA
 !C............................................................
       IF (MAX.LE.0) THEN
          WRITE(lout,'(a)') '***ERROR(TUNEFIT): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................................
       DUEPI=eight*ATAN_MB(one)
@@ -231,7 +231,7 @@ module platoFMA
 !C............................................................
       IF (N.LE.0) THEN
         WRITE(lout,'(a)') '***ERROR(TUNEAPA): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C.............................................................
       X2M=zero
@@ -579,7 +579,7 @@ module platoFMA
 !C.............................................................
       IF (MAXN.GT.MAXITER) THEN
         WRITE(lout,'(a)') '***ERROR(TUNENEWT): TOO MANY ITERATIONS'
-        call prror(-1)
+        call prror
       ENDIF
 !C.............................................................
 !C    ESTIMATION OF TUNE WITH FFT
@@ -757,7 +757,7 @@ module platoFMA
 !C............................................................
       IF (N.LE.0) THEN
         WRITE(lout,'(a)') '***ERROR(TUNEAPA): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................................
       ADV=ZERO
@@ -828,12 +828,12 @@ module platoFMA
 !C..................................................CHECK OF N
       IF(N.GT.MAXITER) THEN
         write(lerr,'(a)') '***ERROR(TUNEFFT): TOO MANY ITERATES'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................................
       IF (N.LE.0) THEN
         write(lerr,'(a)') '***ERROR(TUNEFFT): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................COMPUTATION OF M
       DO M=1,50
@@ -904,12 +904,12 @@ module platoFMA
 !C..................................................CHECK OF N
       IF(N.GT.MAXITER) THEN
         write(lerr,'(a)') '***ERROR(TUNEFFTI): TOO MANY ITERATES'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................................
       IF (N.LE.0) THEN
         write(lerr,'(a)') '***ERROR(TUNEFFTI): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................COMPUTATION OF M
       DO M=1,50
@@ -1011,12 +1011,12 @@ module platoFMA
 !C...............................CHECK OF THE ITERATION NUMBER
       IF(MAX.GT.MAXITER) THEN
         write(lerr,'(a)') '***ERROR(TUNELASK): TOO MANY ITERATIONS'
-        call prror(-1)
+        call prror
       ENDIF
 !C............................................................
       IF (MAX.LE.0) THEN
         write(lerr,'(a)') '***ERROR(TUNELASK): THIRD PARAMETER OUT OF BOUNDS'
-        call prror(-1)
+        call prror
       ENDIF
 !C.................................ESTIMATION OF TUNE WITH FFT
       SUM=ZERO

--- a/source/postprocessing.f90
+++ b/source/postprocessing.f90
@@ -950,7 +950,7 @@ subroutine postpr(arg1,arg2)
         endif
 #else
         write(lout,*) "ERROR in postpr: program=MAD not valid for STF."
-        call prror(-1)
+        call prror
 #endif
       endif ! END if(program.eq.'MAD')
 
@@ -1110,7 +1110,7 @@ subroutine postpr(arg1,arg2)
         endif
 #else
         write(lout,*) "ERROR in postpr: program=MAD not valid for STF."
-        call prror(-1)
+        call prror
 #endif
       endif
 
@@ -1431,7 +1431,7 @@ subroutine postpr(arg1,arg2)
         endif
 #else
         write(lout,*) "ERROR in postpr: program=MAD not valid for STF."
-        call prror(-1)
+        call prror
 #endif
       endif
 !--LYAPUNOV
@@ -1779,7 +1779,7 @@ subroutine postpr(arg1,arg2)
            p=p*c1e3
 #else
            write(lout,*) "ERROR in postpr: program=MAD not valid for STF."
-           call prror(-1)
+           call prror
 #endif
         endif !END if(program.eq.'MAD')
 
@@ -2401,7 +2401,7 @@ subroutine postpr(arg1,arg2)
               end if
 #else
         write(lout,*) "ERROR in postpr: program=MAD not valid for STF."
-        call prror(-1)
+        call prror
 #endif
 
             end if

--- a/source/ranecu.f90
+++ b/source/ranecu.f90
@@ -97,7 +97,7 @@ subroutine recuinit(is1,is2)
 
   if(is1 < 1 .or. is1 > 2147483562) then
     write(lerr,"(a,i0)") "RANECU> ERROR Seed 1 must be an integer in the range 1 to 2147483562, got ", is1
-    call prror(-1)
+    call prror
   else
     iseed1 = is1
   end if
@@ -105,7 +105,7 @@ subroutine recuinit(is1,is2)
   if(present(is2)) then
     if(is2 < 1 .or. is2 > 2147483398) then
       write(lerr,"(a,i0)") "RANECU> ERROR Seed 2 must be an integer in the range 1 to 2147483398, got ", is2
-      call prror(-1)
+      call prror
     else
       iseed2 = is2
     end if

--- a/source/read_write.f90
+++ b/source/read_write.f90
@@ -85,7 +85,7 @@ subroutine readFort13
   call f_open(unit=13,file="fort.13",formatted=.true.,mode="r",err=fErr)
   if(fErr) then
     write(lerr,"(a)") "FORT13> ERROR Could not open fort.13."
-    call prror(-1)
+    call prror
   end if
 
   do j=1,napx,2
@@ -160,11 +160,11 @@ subroutine readFort13
     ! Report Errors
     if(rErr) then
       write(lerr,"(a,i0,a)") "FORT13> ERROR While reading particle pair ",nPair," from file."
-      call prror(-1)
+      call prror
     end if
     if(cErr) then
       write(lerr,"(a,i0,a)") "FORT13> ERROR While converting particle pair ",nPair," to float."
-      call prror(-1)
+      call prror
     end if
 
     mtc(j)        = one
@@ -204,13 +204,13 @@ subroutine readFort33
   read(33,"(a)",iostat=ioStat) inLine
   if(ioStat /= 0) then
     write(lerr,"(a,i0)") "READ33> ERROR Failed to read line from 'fort.33'. iostat = ",ioStat
-    call prror(-1)
+    call prror
   end if
 
   call chr_split(inLine, lnSplit, nSplit, spErr)
   if(spErr) then
     write(lerr,"(a)") "READ33> ERROR Failed to parse line from 'fort.33'"
-    call prror(-1)
+    call prror
   end if
 
   if(nSplit > 0) call chr_cast(lnSplit(1),clo6(1), spErr)

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -332,7 +332,7 @@ subroutine umlauda
     if(ix.gt.nblo) goto 50
     if(ix <= 0) then
       write(lerr,"(a)") "UMLAUDA> ERROR Inverted linear blocks not allowed."
-      call prror(-1)
+      call prror
     endif
 #include "include/dalin1.f90"
           ipch=0
@@ -434,7 +434,7 @@ subroutine umlauda
     if(abs(dare(x(1))) > aint(aper(1)) .or. abs(dare(x(2))) > aint(aper(2))) then
       write(lout,10120)j,i,dare(x(1)),aper(1),dare(x(2)),aper(2),ix,kz(ix),bez(ix)
       write(lerr,"(a)") "UMLAUDA> ERROR Unstable closed orbit in DA calculation."
-      call prror(-1)
+      call prror
     end if
     kpz=abs(kp(ix))
     if(kpz.ge.0 .and. kpz.lt.6) goto 80
@@ -470,7 +470,7 @@ subroutine umlauda
       wire_num_aux = wire_num_aux+1
       if(wire_num_aux.gt.wire_max) then
         write(lerr,"(2(a,i0))") "UMLAUDA> ERROR Maximum number of wires exceeded. Max is ",wire_max,", got ",wire_num_aux
-        call prror(-1)
+        call prror
       endif
       wire_num(i) = wire_num_aux
 !FOX  YP(1)=Y(1)*(ONE+DPDA)/MTCDA ;
@@ -532,7 +532,7 @@ subroutine umlauda
         ibb=ibb+1
         if(ibb > nbb) then
           write(lerr,"(a,i0)") "UMLAUDA> ERROR Maximum element number for beam-beam with coupling exceeded: nbb = ",nbb
-          call prror(-1)
+          call prror
         end if
         imbb(i)=ibb
 !FOX  YP(1)=Y(1)*(ONE+DPDA)/MTCDA ;
@@ -643,7 +643,7 @@ subroutine umlauda
           endif
         else
            write(lerr,"(a,i0,a)") "UMLAUDA> ERROR beam_expflag was ",beam_expflag,", expected 0 or 1. This is a BUG!"
-           call prror(-1)
+           call prror
         end if
 
         if (.not.beam_expfile_open) then
@@ -698,7 +698,7 @@ subroutine umlauda
           sfac3=sqrt(sfac2**2+(four*bbcu(ibb,3))*bbcu(ibb,3))          !hr03
           if(sfac3 > sfac1) then
             write(lerr,"(a)") "UMLAUDA> ERROR 6D beam-beam with tilt not possible."
-            call prror(-1)
+            call prror
           end if
           sfac4=(sfac2s*sfac2)/sfac3                                   !hr03
           sfac5=(((-one*sfac2s)*two)*bbcu(ibb,3))/sfac3                !hr03
@@ -1517,7 +1517,7 @@ subroutine umlauda
     det1=coefh1*coefv2-coefv1*coefh2
     if(abs(det1) <= pieni) then
       write(lerr,"(a)") "UMLAUDA> ERROR Quadrupoles are not suited to adjust the tunes."
-      call prror(-1)
+      call prror
     end if
     corr(2,1)=coefv2/det1
     corr(2,2)=(-one*coefh2)/det1                                     !hr05
@@ -1541,7 +1541,7 @@ subroutine umlauda
     det1=coefh1*coefv2-coefv1*coefh2
     if(abs(det1) <= pieni) then
       write(lerr,"(a)") "UMLAUDA> ERROR Sextupoles are not suited to adjust the chromaticity."
-      call prror(-1)
+      call prror
     end if
     corr(2,1)=coefv2/det1
     corr(2,2)=(-one*coefh2)/det1                                     !hr05
@@ -1568,7 +1568,7 @@ subroutine umlauda
 
 9088 continue
   write(lerr,"(a)") "UMLAUDA> ERROR Either normalized emittances or the resulting sigma values equal to zero for beam-beam/"
-  call prror(-1)
+  call prror
   return
 !-----------------------------------------------------------------------
 10000 format(/t5 ,'---- ENTRY ',i1,'D LINOPT ----')
@@ -2358,7 +2358,7 @@ call comt_daStart
   &'ERROR: in wirekick -  wire_flagco defined in WIRE block must ',  &
   &'be either 1 or -1!','bez(',ix,') = ',bez(ix),                    &
   &'wire_flagco(',ix,') = ',wire_flagco(ix)
-    call prror(-1)
+    call prror
   endif
 
 !FOX  YY(1)=YY(1)*C1M3;
@@ -2799,7 +2799,7 @@ subroutine invert_tas(fma_tas_inv,fma_tas)
   if (ierro.ne.0) then
       write(lout,*) "Error in INVERT_TAS - Matrix inversion failed!"
       write(lout,*) "Subroutine DINV returned ierro=",ierro
-      call prror(-1)
+      call prror
   endif
 
 !     - transpose fma_tas_inv

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -34,7 +34,7 @@ subroutine daliesix
   if(nvarf/2.lt.ndim) ndim=nvarf/2
   if(ndim == 0) then
     write(lerr,"(a)") "DALIESIX> ERROR Number of normal form variables have to be: 2, 4, 5, 6 + parameters."
-    call prror(-1)
+    call prror
   end if
   nv=nvarf
   nd2=2*ndim
@@ -182,7 +182,7 @@ subroutine mydaini(ncase,nnord,nnvar,nndim,nnvar2,nnord1)
 
   if(nndim < 2 .or. nndim > 3) then
     write(lerr,"(a)") "DAINI> ERROR DA corrections implemented for 4D and 6D only."
-    call prror(-1)
+    call prror
   end if
 
   nordo=nord
@@ -734,7 +734,7 @@ subroutine runda
       endif
       if(ix <= 0) then
         write(lerr,"(a)") "RUNDA> ERROR Inverted linear blocks not allowed."
-        call prror(-1)
+        call prror
       endif
 #include "include/dalin1.f90"
 #include "include/dalin2.f90"
@@ -1682,7 +1682,7 @@ call comt_daEnd
 
 9088 continue
   write(lerr,"(a)") "RUNDA> ERROR Either normalized emittances or the resulting sigma values equal to zero for beam-beam/"
-  call prror(-1)
+  call prror
   return
 
 10000 format(/t10,'TRACKING ENDED ABNORMALLY'/t10, 'PARTICLE NO. ',     &

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -882,17 +882,17 @@ subroutine daten
     if (ipos == 1) then
       if (do_coll) then
         write(lerr,'(a)') "ENDE> ERROR COLLimation block and POSTprocessing block are not compatible."
-        call prror(-1)
+        call prror
       endif
 
       if (scatter_active) then
         write(lerr,'(a)') "ENDE> ERROR SCATTER block and POSTprocessing block are not compatible."
-        call prror(-1)
+        call prror
       endif
 #ifdef FLUKA
       if (fluka_enable) then
         write(lerr,'(a)') "ENDE> ERROR FLUKA block and POSTprocessing block are not compatible."
-        call prror(-1)
+        call prror
       endif
 #endif
     endif
@@ -924,7 +924,7 @@ subroutine daten
         write(lerr,"(3(a,i5))") "ENDE> ERROR Requested ",int(parbe(j,2))," slices for 6D beam-beam element"//&
           " #",j," named '"//trim(bez(j))//"', maximum is mbea = ",mbea
         parbe(j,2) = real(mbea,fPrec)
-        call prror(-1) ! Treat this warning as an error
+        call prror ! Treat this warning as an error
       end if
     end do
   end if
@@ -2947,7 +2947,7 @@ subroutine chroma
             isl=is(l)
             if(kz(isl).ne.3) then
               write(lerr,"(a)") "CHROMA> ERROR Element specified for chromaticity correction is not a sextupole."
-              call prror(-1)
+              call prror
             end if
             ed(isl)=ed(isl)+dsm(l,ii)
             if(kp(isl).eq.5) call combel(isl)
@@ -2957,12 +2957,12 @@ subroutine chroma
             call clorb(dpp)
             if(ierro.gt.0) then
               write(lerr,"(a)") "CHROMA> ERROR Unstable closed orbit during chromaticity correction."
-              call prror(-1)
+              call prror
             end if
             call phasad(dpp,qwc)
             if(ierro.gt.0) then
               write(lerr,"(a)") "CHROMA> ERROR No optical solution during chromaticity correction."
-              call prror(-1)
+              call prror
             end if
             ox=qwc(1)
             oz=qwc(2)
@@ -3269,7 +3269,7 @@ subroutine clorb2(dpp)
       ierro=ierr
       if(ierro /= 0) then
         write(lerr,"(a)") "CLORB> ERROR No convergence in rmod."
-        call prror(-1)
+        call prror
       end if
 
       do 40 ii=1,itco
@@ -3291,7 +3291,7 @@ subroutine clorb2(dpp)
 
         if(ierro /= 0) then
           write(lerr,"(a)") "CLORB> ERROR No convergence in rmod."
-          call prror(-1)
+          call prror
         end if
 
         do 30 l=1,2
@@ -3336,7 +3336,7 @@ subroutine combel(iql)
           if(ico.eq.0) goto 10
           if(kz(ico0).ne.kz(ico)) then
             write(lerr,"(a)") "COMBEL> ERROR Elements of different types are combined in data block combination of elements."
-            call prror(-1)
+            call prror
           end if
           if(abs(el(ico0)).gt.pieni) then
             if(abs(el(ico)).gt.pieni) then
@@ -3964,7 +3964,7 @@ subroutine linopt(dpp)
 
       if(ierro /= 0) then
         write(lerr,"(a)") "LINOPT> ERROR No optical solution."
-        call prror(-1)
+        call prror
       end if
       if(ncorru.eq.0) write(lout,10040) dpp,qwc(1),qwc(2)
 
@@ -4044,7 +4044,7 @@ subroutine linopt(dpp)
 
             write(lerr,"(a)") "LINOPT> ERROR In block '"//trim(bezb(ix))//"': found a thick non-drift element '"//&
               trim(bez(jk))//"' while ithick=1. This should not be possible!"
-            call prror(-1)
+            call prror
             cycle STRUCTLOOP
           endif
 
@@ -5169,7 +5169,7 @@ subroutine corrorb
       if(ierro.gt.0) then
         write(lerr,"(a)") "CLORB> ERROR Unstable closed orbit during initial dispersion calculation."
         write(lerr,"(a)") "CLORB>       Instability occurred for small relative energy deviation."
-        call prror(-1)
+        call prror
       end if
 
       do l=1,2
@@ -5180,7 +5180,7 @@ subroutine corrorb
       call clorb(zero)
       if(ierro.gt.0) then
         write(lerr,"(a)") "CLORB> ERROR Unstable closed orbit for zero energy deviation."
-        call prror(-1)
+        call prror
       end if
 
       do l=1,2
@@ -5205,7 +5205,7 @@ subroutine corrorb
 
       if(ncorru == 0) then
         write(lerr,"(a)") "CLORB> ERROR Number of orbit correctors is zero."
-        call prror(-1)
+        call prror
       else
         if(ncorrep.le.0) then
           write(lout,10010) ncorru,sigma0(1),sigma0(2)
@@ -6052,7 +6052,7 @@ subroutine ord
         if(kzz.eq.11.and.abs(ek(ix)).gt.pieni) izu=izu+2*mmul
         if(izu > nran) then
           write(lerr,"(a,i0,a)") "ORD> ERROR The random number: ",nran," for the initial structure is too small."
-          call prror(-1)
+          call prror
         end if
         if(izu > nzfz) then
           call fluc_moreRandomness
@@ -6065,7 +6065,7 @@ subroutine ord
             jra(i,1)=j
             if(kz(j) == 0 .or. kz(j) == 20 .or. kz(j) == 22) then
               write(lerr,"(a)") "ORD> ERROR Elements that need random numbers have a kz not equal to 0, 20 or 22."
-              call prror(-1)
+              call prror
             end if
             jra(i,2)=kz(j)
           endif
@@ -6073,7 +6073,7 @@ subroutine ord
             jra(i,3)=j
             if(kz(j) == 0 .or. kz(j) == 20 .or. kz(j) == 22) then
               write(lerr,"(a)") "ORD> ERROR Elements that need random numbers have a kz not equal to 0, 20 or 22."
-              call prror(-1)
+              call prror
             end if
             jra(i,4)=kz(j)
           endif
@@ -6091,7 +6091,7 @@ subroutine ord
         if(kzz1 == 11 .and. (kzz2 /= 11 .and. kzz2 /= 0)) then
           write(lerr,"(a)") "ORD> ERROR To use the same random numbers for 2 elements, the inserted element "//&
             "must not need more of such numbers than the reference element."
-          call prror(-1)
+          call prror
         end if
       end do
       do i=1,iu
@@ -6116,7 +6116,7 @@ subroutine ord
           inz(j)=inz(j)+1
           if(inz(j) > mran) then
             write(lerr,"(a,i0,a)") "ORD> ERROR Not more than ",mran," of each type of inserted elements can be used."
-            call prror(-1)
+            call prror
           end if
           ! map position of errors for present element in lattice structure
           mzu(i)=jra(j,5)
@@ -6132,7 +6132,7 @@ subroutine ord
         if(kzz.eq.11.and.abs(ek(ix)).gt.pieni) izu=izu+2*mmul
         if(izu > nran) then
           write(lerr,"(a,i0,a)") "ORD> ERROR The random number: ",nran," for the initial structure is too small."
-          call prror(-1)
+          call prror
         end if
       end do
     endif
@@ -6151,7 +6151,7 @@ subroutine ord
       ! why just checking? shouldn't we map on mzu(i)?
       if(izu > nran) then
         write(lerr,"(a,i0,a)") "ORD> ERROR The random number: ",nran," for the initial structure is too small."
-        call prror(-1)
+        call prror
       end if
       if(izu > nzfz) then
         call fluc_moreRandomness
@@ -6272,7 +6272,7 @@ subroutine phasad(dpp,qwc)
       call betalf(dpp,qw)
       if(ierro /= 0) then
         write(lerr,"(a)") "PHASAD> ERROR No optical solution."
-        call prror(-1)
+        call prror
       end if
       call envar(dpp)
 
@@ -6750,7 +6750,7 @@ subroutine qmod0
       iq2=iq(2)
       if(kz(iq1).ne.2.or.kz(iq2).ne.2) then
         write(lerr,"(a)") "QMOD> ERROR Element is not a quadrupole."
-        call prror(-1)
+        call prror
       end if
 
       if (abs(el(iq1)).le.pieni.or.abs(el(iq2)).le.pieni) then
@@ -6770,7 +6770,7 @@ subroutine qmod0
         iq3=iq(3)
         if(kz(iq3).ne.2) then
           write(lerr,"(a)") "QMOD> ERROR Element is not a quadrupole."
-          call prror(-1)
+          call prror
         end if
         if (abs(el(iq3)).le.pieni) then
           sm0(3)=ed(iq3)
@@ -6786,7 +6786,7 @@ subroutine qmod0
       call clorb(dpp)
       if(ierro.gt.0) then
         write(lerr,"(a)") "QMOD> ERROR Unstable closed orbit during tune variation."
-        call prror(-1)
+        call prror
       end if
       call phasad(dpp,qwc)
       sens(1,5)=qwc(1)
@@ -6812,7 +6812,7 @@ subroutine qmod0
           call clorb(dpp)
           if(ierro.gt.0) then
             write(lerr,"(a)") "QMOD> ERROR Unstable closed orbit during tune variation."
-            call prror(-1)
+            call prror
           end if
           call phasad(dpp,qwc)
           sens(1,n+1)=qwc(1)
@@ -6866,7 +6866,7 @@ subroutine qmod0
         endif
         if(ierr == 1) then
           write(lerr,"(a)") "QMOD> ERROR Problems during matrix-inversion."
-          call prror(-1)
+          call prror
         end if
         do 50 l=1,nite
           iql=iq(l)
@@ -6880,7 +6880,7 @@ subroutine qmod0
         call clorb(dpp)
         if(ierro.gt.0) then
           write(lerr,"(a)") "QMOD> ERROR Unstable closed orbit during tune variation."
-          call prror(-1)
+          call prror
         end if
         call phasad(dpp,qwc)
         sens(1,5)=qwc(1)
@@ -7259,7 +7259,7 @@ subroutine umlauf(dpp,ium,ierr)
     if(abs(x(1,1)).lt.aper(1).and.abs(x(1,2)).lt.aper(2)) goto 70
     ierr=1
     write(lout,"(a)") "UMLAUF> Error amplitudes exceed the maximum values."
-    call prror(-1)
+    call prror
     return
 
 70  continue
@@ -7707,7 +7707,7 @@ subroutine resex(dpp)
 
       if(ierro /= 0) then
         write(lerr,"(a)") "RESEX> ERROR No optical solution."
-        call prror(-1)
+        call prror
       end if
       call envar(dpp)
 
@@ -8561,7 +8561,7 @@ subroutine rmod(dppr)
         call loesd(aa,bb,j2,10,ierr)
         if(ierr == 1) then
           write(lerr,"(a)") "RMOD> ERROR Problems during matrix-inversion."
-          call prror(-1)
+          call prror
         end if
         do 170 i=1,j2
           if(i.eq.jj1.or.i.eq.jj2) then
@@ -8947,7 +8947,7 @@ subroutine subre(dpp)
         call phasad(dpp,qwc)
         if(ierro /= 0) then
           write(lerr,"(a)") "SUBRE> ERROR No optical solution."
-          call prror(-1)
+          call prror
         end if
         write(lout,10070) dpp,qwc(1),qwc(2)
         call envar(dpp)
@@ -9920,7 +9920,7 @@ subroutine subsea(dpp)
       call betalf(dpp,qw)
       if(ierro /= 0) then
         write(lerr,"(a)") "SUBSEA> ERROR No optical solution."
-        call prror(-1)
+        call prror
       end if
       call envar(dpp)
 
@@ -10675,7 +10675,7 @@ subroutine decoup
         endif
         if(ierr == 1) then
           write(lerr,"(a)") "DECOUP> ERROR Problems during matrix-inversion."
-          call prror(-1)
+          call prror
         end if
         do 50 i=1,6
           if(iskew.eq.2.and.i.gt.4) goto 50

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -611,7 +611,7 @@ subroutine mydaini(ncase,nnord,nnvar,nndim,nnvar2,nnord1)
 !-----------------------------------------------------------------------
   if(nndim < 2 .or. nndim > 3) then
     write(lerr,"(a)") "DAINI> ERROR DA corrections implemented for 4D and 6D only."
-    call prror(-1)
+    call prror
   end if
 !--------------------
   nordo=nord

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -452,7 +452,7 @@ subroutine trauthck(nthinerr)
 
       if(abs(phas).ge.pieni) then
         write(lerr,"(a)") "TRACKING> ERROR thck6dua no longer supported. Please use DYNK instead."
-        call prror(-1)
+        call prror
       else
         write(lout,"(a)") ""
         write(lout,"(a)") "TRACKING> Calling thck6d subroutine"
@@ -611,7 +611,7 @@ subroutine thck4d(nthinerr)
         if(ldumpfront) then
           write(lout,"(a)") "TRACKING> DUMP/FRONT not yet supported on thick elements "//&
             "due to lack of test cases. Please contact developers!"
-          call prror(-1)
+          call prror
         end if
 
       end if
@@ -666,7 +666,7 @@ subroutine thck4d(nthinerr)
             if (bdex_enable) then
                !TODO - if you have a test case, please contact developers!
                write(lout,"(a)") "BDEX> BDEX only available for thin6d"
-               call prror(-1)
+               call prror
             endif
 
 !----------count=43

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -1249,7 +1249,7 @@ subroutine thin6d(nthinerr)
       ix=ic(i)-nblo
 
       ! Fringe Fields
-      if(ffield_enabled) then
+      if(ffield_enabled .and. ix > 0) then
         doFField = FFindex(ix) > 0
       else
         doFField = .false.

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -453,7 +453,7 @@ subroutine trauthin(nthinerr)
     end do
     if(abs(phas).ge.pieni) then
       write(lerr,"(a)") "TRACKING> ERROR thin6dua no longer supported. Please use DYNK instead."
-      call prror(-1)
+      call prror
     else
       write(lout,"(a)") ""
       write(lout,"(a)") "TRACKING> Calling thin6d subroutine"

--- a/source/utils.f90
+++ b/source/utils.f90
@@ -35,11 +35,11 @@ contains
     ! Sanity checks
     if(datalen <= 0) then
       write(lerr,"(a)") "UTILS> ERROR lininterp: datalen was 0!"
-      call prror(-1)
+      call prror
     end if
     if(x < xvals(1) .or. x > xvals(datalen)) then
       write(lerr,"(3(a,e16.9))") "UTILS> ERROR lininterp: x = ",x," outside range",xvals(1)," - ",xvals(datalen)
-      call prror(-1)
+      call prror
     end if
 
     ! Find the right indexes i1 and i2
@@ -52,7 +52,7 @@ contains
     do ii=1, datalen-1
       if(xvals(ii) >= xvals(ii+1)) then
         write(lerr,"(a)") "UTILS> ERROR lininterp: xvals should be in increasing order"
-        call prror(-1)
+        call prror
       end if
 
       if(x <= xvals(ii+1)) then
@@ -66,7 +66,7 @@ contains
 
     ! We didn't return yet: Something wrong
     write(lerr,"(a)") "UTILS> ERROR lininterp: Reached the end of the function. This should not happen, please contact developers"
-    call prror(-1)
+    call prror
 
   end function lininterp
 

--- a/source/zipf.f90
+++ b/source/zipf.f90
@@ -72,7 +72,7 @@ subroutine zipf_parseInputDone
 
   if(.not.(zipf_numFiles > 0)) then
     write(lerr,"(a)") "ZIPF> ERROR Block was empty; no files specified!"
-    call prror(-1)
+    call prror
   endif
 
 end subroutine zipf_parseInputDone


### PR DESCRIPTION
This PR addresses three issues spotted in nightly builds (two of them caught now that the fringe field test actually runs):

* Floating point exception in fringe field module where `abs(log10(x))` would error when `x` was negative. Changed to `abs(log10(abs(x)))`. This check is actually there to prevent floating point exceptions, so this is not without irony. :)
* The indexing of single elements for fringe fields did not check for negative indices, i.e. block elements. Caught by debug build bounds check.
* Although this has been working for a while, having the error code as an optional argument in the subroutine `prror` actually requires an explicit interface as the routine is not in a module. The compilers have been able to handle it anyway, put `ifort` face-planted into this during yesterday's nightly builds. Since all calls still using an error value used `-1` anyway, I just did a global replace of `call prror(-1)` with `call prror` and removed the optional argument.

In addition, I added backtrace and bounds check flags to the ifort debug build type. Nagfor also complained about unused stuff in the recently changed modules, which I cleaned up too. There is still a lot of that left in the older parts of the code.