### PR TITLE
More thickarray cleanup

### DIFF
--- a/source/checkpoint_restart.f90
+++ b/source/checkpoint_restart.f90
@@ -67,7 +67,6 @@ module checkpoint_restart
   real(kind=fPrec), allocatable, private, save :: crejfv(:)     ! (npart)
   real(kind=fPrec), allocatable, private, save :: crdpd(:)      ! (npart)
   real(kind=fPrec), allocatable, private, save :: crdpsq(:)     ! (npart)
-  real(kind=fPrec), allocatable, private, save :: crfokqv(:)    ! (npart)
   real(kind=fPrec), allocatable, private, save :: craperv(:,:)  ! (npart,2)
 
   integer,          allocatable, public,  save :: binrecs(:)    ! ((npart+1)/2)
@@ -178,7 +177,6 @@ subroutine cr_expand_arrays(npart_new)
   call alloc(crejfv,     npart_new,    zero,    "crejfv")
   call alloc(crdpd,      npart_new,    zero,    "crdpd")
   call alloc(crdpsq,     npart_new,    zero,    "crdpsq")
-  call alloc(crfokqv,    npart_new,    zero,    "crfokqv")
   call alloc(craperv,    npart_new, 2, zero,    "craperv")
   call alloc(binrecs,    npair_new,    0,       "binrecs")
   call alloc(crbinrecs,  npair_new,    0,       "crbinrecs")
@@ -393,7 +391,6 @@ subroutine crcheck
       (crejfv(j),    j=1,crnapxo),       &
       (crdpd(j),     j=1,crnapxo),       &
       (crdpsq(j),    j=1,crnapxo),       &
-      (crfokqv(j),   j=1,crnapxo),       &
       (craperv(j,1), j=1,crnapxo),       &
       (craperv(j,2), j=1,crnapxo),       &
       (crllostp(j),  j=1,crnapxo)
@@ -650,7 +647,6 @@ subroutine crpoint
       (ejfv(j),    j=1,napxo),       &
       (dpd(j),     j=1,napxo),       &
       (dpsq(j),    j=1,napxo),       &
-      (fokqv(j),   j=1,napxo),       &
       (aperv(j,1), j=1,napxo),       &
       (aperv(j,2), j=1,napxo),       &
       (llostp(j),  j=1,napxo)
@@ -808,7 +804,6 @@ subroutine crstart
 
   dpd(1:napxo)       = crdpd(1:napxo)
   dpsq(1:napxo)      = crdpsq(1:napxo)
-  fokqv(1:napxo)     = crfokqv(1:napxo)
 
   numxv(1:napxo)     = crnumxv(1:napxo)
   nnumxv(1:napxo)    = crnnumxv(1:napxo)

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -837,7 +837,6 @@ module mod_common_main
   real(kind=fPrec), allocatable, save :: zsiv(:)      ! (nblz)
   real(kind=fPrec), allocatable, save :: xsiv(:)      ! (nblz)
 
-  real(kind=fPrec), allocatable, save :: fokqv(:)     ! (npart)
   real(kind=fPrec), allocatable, save :: xsv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: zsv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: xv1(:)       ! (npart)
@@ -932,7 +931,6 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
   end if
 
   if(npart_new /= npart_prev) then
-    call alloc(fokqv,            npart_new,      zero,    "fokqv")
     call alloc(xsv,              npart_new,      zero,    "xsv")
     call alloc(zsv,              npart_new,      zero,    "zsv")
     call alloc(xv1,              npart_new,      zero,    "xv1")

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -833,7 +833,6 @@ module mod_common_main
   implicit none
 
   ! Main 1
-  real(kind=fPrec), allocatable, save :: ekv(:,:)     ! (npart,nele)
   real(kind=fPrec), allocatable, save :: smiv(:)      ! (nblz)
   real(kind=fPrec), allocatable, save :: zsiv(:)      ! (nblz)
   real(kind=fPrec), allocatable, save :: xsiv(:)      ! (nblz)
@@ -983,7 +982,6 @@ subroutine mod_commonmn_expand_thickarrays(nele_new, npart_new, nblo_new)
 
   integer,intent(in) :: nele_new, npart_new, nblo_new
 
-  call alloc(ekv,     npart_new,nele_new,zero,"ekv")
   call alloc(bl1v,6,2,npart_new,nblo_new,zero,"bl1v")
 
 end subroutine mod_commonmn_expand_thickarrays

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -851,10 +851,6 @@ program maincr
     oidpsv(ib1)  = one/(one+dp1)
     moidpsv(ib1) = mtc(ib1)/(one+dp1)
     nms(ib1)     = 1
-
-    if(ithick == 1) then
-      ekv(ib1,1:nele) = ek(1:nele)
-    end if
   end do
 
 ! ================================================================================================ !

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -438,17 +438,17 @@ subroutine envarsv
     case(7,8)
 
       if(kz1.eq.7) then
-        fokq = one
+        fokq = ek(l)
         ih1  = 1
         ih2  = 2
       else
-        fokq = -one
+        fokq = -ek(l)
         ih1  = 2
         ih2  = 1
       end if
       do j=1,napx
         wf   = ed(l)/dpsq(j)
-        fok  = (fokq*ek(l))/dpd(j)-wf**2
+        fok  = fokq/dpd(j)-wf**2
         afok = abs(fok)
         hi   = sqrt(afok)
         fi   = hi*el(l)

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -207,7 +207,7 @@ subroutine envarsv
   use mod_commons
   use mod_common_track
   use mod_common_da
-  use mod_common_main, only : dpsv,oidpsv,rvv,ekv,dpd,dpsq,fokqv
+  use mod_common_main, only : dpsv,oidpsv,rvv,dpd,dpsq,fokqv
 
   use mod_alloc
 
@@ -363,7 +363,7 @@ subroutine envarsv
     case(3)
 
       do j=1,napx
-        fok = ekv(j,l)*oidpsv(j)
+        fok = ek(l)*oidpsv(j)
         aek = abs(fok)
         hi  = sqrt(aek)
         fi  = el(l)*hi
@@ -438,14 +438,14 @@ subroutine envarsv
 
       if(kz1.eq.7) then
         do j=1,napx
-          fokqv(j) = ekv(j,l)
+          fokqv(j) = ek(l)
         end do
         ih1 = 1
         ih2 = 2
       else
 !  COMBINED FUNCTION MAGNET VERTICAL
         do j=1,napx
-          fokqv(j) = -ekv(j,l)
+          fokqv(j) = -ek(l)
         end do
         ih1 = 2
         ih2 = 1
@@ -491,7 +491,7 @@ subroutine envarsv
           as(5,ih1,j,l) = (((-one*rvv(j))*sm12)*afok)/c4e3
           as(6,ih1,j,l) = ((-one*rvv(j))*(el(l)+al(1,ih1,j,l)*al(2,ih1,j,l)))/c4e3
 
-          aek = abs(ekv(j,l)/dpd(j))
+          aek = abs(ek(l)/dpd(j))
           hi  = sqrt(aek)
           fi  = hi*el(l)
           hp  = exp_mb(fi)
@@ -532,7 +532,7 @@ subroutine envarsv
           as(5,ih1,j,l) = ((rvv(j)*sm12)*afok)/c4e3
           as(6,ih1,j,l) = ((-one*rvv(j))*(el(l)+al(1,ih1,j,l)*al(2,ih1,j,l)))/c4e3
 
-          aek = abs(ekv(j,l)/dpd(j))
+          aek = abs(ek(l)/dpd(j))
           hi  = sqrt(aek)
           fi  = hi*el(l)
           si  = sin_mb(fi)

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -207,7 +207,7 @@ subroutine envarsv
   use mod_commons
   use mod_common_track
   use mod_common_da
-  use mod_common_main, only : dpsv,oidpsv,rvv,dpd,dpsq,fokqv
+  use mod_common_main, only : dpsv,oidpsv,rvv,dpd,dpsq
 
   use mod_alloc
 
@@ -216,7 +216,7 @@ subroutine envarsv
   integer ih1,ih2,j,kz1,l,l1,l2
 
   real(kind=fPrec) aek,afok,as3,as4,as6,co,fi,fok,fok1,g,gl,hc,hi,hi1,hm,hp,hs,rho,rhoc,rhoi,&
-    si,siq,sm1,sm12,sm2,sm23,sm3,wf,wfa,wfhi,fokm
+    si,siq,sm1,sm12,sm2,sm23,sm3,wf,wfa,wfhi,fokm,fokq
 
   ! The dpd and dpsq arrays used to be local and zeroed here.
   ! Currently using the global ones instead.
@@ -431,28 +431,24 @@ subroutine envarsv
       end do
       cycle
 !-----------------------------------------------------------------------
-!  COMBINED FUNCTION MAGNET HORIZONTAL
+!  COMBINED FUNCTION MAGNET HORIZONTAL (7)
+!  COMBINED FUNCTION MAGNET VERTICAL   (8)
 !  FOCUSING
 !-----------------------------------------------------------------------
     case(7,8)
 
       if(kz1.eq.7) then
-        do j=1,napx
-          fokqv(j) = ek(l)
-        end do
-        ih1 = 1
-        ih2 = 2
+        fokq = one
+        ih1  = 1
+        ih2  = 2
       else
-!  COMBINED FUNCTION MAGNET VERTICAL
-        do j=1,napx
-          fokqv(j) = -ek(l)
-        end do
-        ih1 = 2
-        ih2 = 1
+        fokq = -one
+        ih1  = 2
+        ih2  = 1
       end if
       do j=1,napx
         wf   = ed(l)/dpsq(j)
-        fok  = fokqv(j)/dpd(j)-wf**2
+        fok  = (fokq*ek(l))/dpd(j)-wf**2
         afok = abs(fok)
         hi   = sqrt(afok)
         fi   = hi*el(l)

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -1976,7 +1976,7 @@ subroutine synuthck
 !  FOCUSSING
 !-----------------------------------------------------------------------
 80   do j=1,napx
-        fok = ekv(j,l)*oidpsv(j)
+        fok = ek(l)*oidpsv(j)
         aek = abs(fok)
         hi  = sqrt(aek)
         fi  = el(l)*hi
@@ -2050,14 +2050,14 @@ subroutine synuthck
 !-----------------------------------------------------------------------
 100   if(kz1 == 7) then
         do j=1,napx
-          fokqv(j) = ekv(j,l)
+          fokqv(j) = ek(l)
         end do
         ih1 = 1
         ih2 = 2
       else
 !  COMBINED FUNCTION MAGNET VERTICAL
         do j=1,napx
-          fokqv(j) = -ekv(j,l)
+          fokqv(j) = -ek(l)
         end do
         ih1 = 2
         ih2 = 1
@@ -2095,7 +2095,7 @@ subroutine synuthck
           as(5,ih1,j,l) = (((-one*rvv(j))*sm12)*afok)/c4e3
           as(6,ih1,j,l) = ((-one*rvv(j))*(el(l)+al(1,ih1,j,l)*al(2,ih1,j,l)))/c4e3
 
-          aek = abs(ekv(j,l)/dpd(j))
+          aek = abs(ek(l)/dpd(j))
           hi  = sqrt(aek)
           fi  = hi*el(l)
           hp  = exp_mb(fi)
@@ -2136,7 +2136,7 @@ subroutine synuthck
           as(5,ih1,j,l) = ((rvv(j)*sm12)*afok)/c4e3
           as(6,ih1,j,l) = ((-one*rvv(j))*(el(l)+al(1,ih1,j,l)*al(2,ih1,j,l)))/c4e3
 
-          aek = abs(ekv(j,l)/dpd(j))
+          aek = abs(ek(l)/dpd(j))
           hi  = sqrt(aek)
           fi  = hi*el(l)
           si  = sin_mb(fi)

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -1861,7 +1861,7 @@ subroutine synuthck
   implicit none
   integer ih1,ih2,j,kz1,l
   real(kind=fPrec) fokm,fok,fok1,rho,si,co,sm1,sm2,sm3,sm12,sm23,as3,as4,as6,g,gl,rhoc,siq,aek,hi,  &
-    fi,hi1,hp,hm,hc,hs,wf,afok,wfa,wfhi,rhoi
+    fi,hi1,hp,hm,hc,hs,wf,afok,wfa,wfhi,rhoi,fokq
 
   save
 
@@ -2049,22 +2049,18 @@ subroutine synuthck
 !  FOCUSSING
 !-----------------------------------------------------------------------
 100   if(kz1 == 7) then
-        do j=1,napx
-          fokqv(j) = ek(l)
-        end do
-        ih1 = 1
-        ih2 = 2
+        fokq = one
+        ih1  = 1
+        ih2  = 2
       else
 !  COMBINED FUNCTION MAGNET VERTICAL
-        do j=1,napx
-          fokqv(j) = -ek(l)
-        end do
-        ih1 = 2
-        ih2 = 1
+        fokq = -one
+        ih1  = 2
+        ih2  = 1
       end if
       do j=1,napx
         wf   = ed(l)/dpsq(j)
-        fok  = fokqv(j)/dpd(j)-wf**2
+        fok  = (fokq*ek(l))/dpd(j)-wf**2
         afok = abs(fok)
         hi   = sqrt(afok)
         fi   = hi*el(l)

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -2049,18 +2049,18 @@ subroutine synuthck
 !  FOCUSSING
 !-----------------------------------------------------------------------
 100   if(kz1 == 7) then
-        fokq = one
+        fokq = ek(l)
         ih1  = 1
         ih2  = 2
       else
 !  COMBINED FUNCTION MAGNET VERTICAL
-        fokq = -one
+        fokq = -ek(l)
         ih1  = 2
         ih2  = 1
       end if
       do j=1,napx
         wf   = ed(l)/dpsq(j)
-        fok  = (fokq*ek(l))/dpd(j)-wf**2
+        fok  = fokq/dpd(j)-wf**2
         afok = abs(fok)
         hi   = sqrt(afok)
         fi   = hi*el(l)


### PR DESCRIPTION
Spotted more arrays that do not need to be arrays any more.

* For `ekv(j,l)` all `j` were set to `ek(l)` where `j` is particle id and `l` is single element id. `ekv(j,l)` replaced by `ek(l)`.
* `fokqv(j)` only contained `ekv(j,l)` times a sign that depended on horisontal or vertical magnet. Since `ekv` was repalced with `ek`, there is no longer a particle ID dependency, so it's a single variable with a sign per element.
* There is no need to checkpoint the arrays `dpd`, `dpsq`, `as`, and `al`. These are computed by the subroutine `synuthck`, and can just be recomputed from energy/momentum arrays after restart.
