### PR TITLE
Cleanup in mod_common_main

### DIFF
--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -834,26 +834,26 @@ module mod_common_main
 
   implicit none
 
-  ! Main 1
-  real(kind=fPrec), allocatable, save :: smiv(:)      ! (nblz)
-  real(kind=fPrec), allocatable, save :: zsiv(:)      ! (nblz)
-  real(kind=fPrec), allocatable, save :: xsiv(:)      ! (nblz)
+  ! Number of Structure Elements (nblz)
+  real(kind=fPrec), allocatable, save :: zsiv(:)      ! Displacement of elements, including error
+  real(kind=fPrec), allocatable, save :: xsiv(:)      ! Displacement of elements, including error
+  real(kind=fPrec), allocatable, save :: smiv(:)      ! Magnetic kick, including error
 
-  real(kind=fPrec), allocatable, save :: xsv(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: zsv(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: xv1(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: yv1(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: xv2(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: yv2(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: dam(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: ekkv(:)      ! (npart)
-  real(kind=fPrec), allocatable, save :: sigmv(:)     ! (npart)
-  real(kind=fPrec), allocatable, save :: dpsv(:)      ! (npart)
+  ! Number of Particles (npart)
+  real(kind=fPrec), allocatable, save :: xv1(:)       ! Transverse coordinates: Horisontal position
+  real(kind=fPrec), allocatable, save :: yv1(:)       ! Transverse coordinates: Horisontal angle
+  real(kind=fPrec), allocatable, save :: xv2(:)       ! Transverse coordinates: Vertical position
+  real(kind=fPrec), allocatable, save :: yv2(:)       ! Transverse coordinates: Vertical angle
+  real(kind=fPrec), allocatable, save :: sigmv(:)     ! Longitudinal coordinate: Position offset
+  real(kind=fPrec), allocatable, save :: dpsv(:)      ! Longitudinal coordinate: Momentum offset from reference momentum e0f
+  real(kind=fPrec), allocatable, save :: ejfv(:)      ! Particle momentum
+  real(kind=fPrec), allocatable, save :: ejv(:)       ! Particle energy
+
+  real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
+
   real(kind=fPrec), allocatable, save :: dp0v(:)      ! (npart)
   real(kind=fPrec), allocatable, save :: sigmv6(:)    ! (npart)
   real(kind=fPrec), allocatable, save :: dpsv6(:)     ! (npart)
-  real(kind=fPrec), allocatable, save :: ejv(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: ejfv(:)      ! (npart)
   real(kind=fPrec), allocatable, save :: xlv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: zlv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: rvv(:)       ! (npart)
@@ -929,21 +929,19 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
   end if
 
   if(npart_new /= npart_prev) then
-    call alloc(xsv,              npart_new,      zero,    "xsv")
-    call alloc(zsv,              npart_new,      zero,    "zsv")
     call alloc(xv1,              npart_new,      zero,    "xv1")
     call alloc(yv1,              npart_new,      zero,    "yv1")
     call alloc(xv2,              npart_new,      zero,    "xv2")
     call alloc(yv2,              npart_new,      zero,    "yv2")
-    call alloc(dam,              npart_new,      zero,    "dam")
-    call alloc(ekkv,             npart_new,      zero,    "ekkv")
     call alloc(sigmv,            npart_new,      zero,    "sigmv")
     call alloc(dpsv,             npart_new,      zero,    "dpsv")
-    call alloc(dp0v,             npart_new,      zero,    "dp0v")
-    call alloc(sigmv6,           npart_new,      zero,    "sigmv6")
-    call alloc(dpsv6,            npart_new,      zero,    "dpsv6")
     call alloc(ejv,              npart_new,      zero,    "ejv")
     call alloc(ejfv,             npart_new,      zero,    "ejfv")
+    call alloc(dam,              npart_new,      zero,    "dam")
+    call alloc(dp0v,             npart_new,      zero,    "dp0v")
+
+    call alloc(sigmv6,           npart_new,      zero,    "sigmv6")
+    call alloc(dpsv6,            npart_new,      zero,    "dpsv6")
     call alloc(xlv,              npart_new,      zero,    "xlv")
     call alloc(zlv,              npart_new,      zero,    "zlv")
     call alloc(rvv,              npart_new,      one,     "rvv")

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -856,7 +856,6 @@ module mod_common_main
   integer,          allocatable, save :: nnumxv(:)    ! Turn in which a particle was lost
   integer,          allocatable, save :: numxv(:)     ! Turn in which a particle was lost
 
-  integer,          allocatable, save :: nms(:)       ! (npart)
   integer,          allocatable, save :: partID(:)    ! (npart)
   integer,          allocatable, save :: parentID(:)  ! (npart)
 
@@ -939,7 +938,7 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
     call alloc(ejf0v,            npart_new,      zero,    "ejf0v")
     call alloc(numxv,            npart_new,      0,       "numxv")
     call alloc(nnumxv,           npart_new,      0,       "nnumxv")
-    call alloc(nms,              npart_new,      0,       "nms")
+
     call alloc(partID,           npart_new,      0,       "partID")
     call alloc(parentID,         npart_new,      0,       "parentID")
     call alloc(pstop,            npart_new,      .false., "pstop")

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -882,8 +882,8 @@ module mod_common_main
   real(kind=fPrec), allocatable, save :: rvv(:)        ! Beta_0 / Beta(j)
   real(kind=fPrec), allocatable, save :: ejf0v(:)      ! Temporary array for momentum updates
   real(kind=fPrec), allocatable, save :: dam(:)        ! Distance in phase space3
-  real(kind=fPrec), allocatable, save :: dpd(:)        ! Tick tracking only: 1+dpsv
-  real(kind=fPrec), allocatable, save :: dpsq(:)       ! Tick tracking only: sqrt(1+dpsv)
+  real(kind=fPrec), allocatable, save :: dpd(:)        ! Thick tracking only: 1+dpsv
+  real(kind=fPrec), allocatable, save :: dpsq(:)       ! Thick tracking only: sqrt(1+dpsv)
   real(kind=fPrec), allocatable, save :: ampv(:)       ! Amplitude variations
 
   integer,          allocatable, save :: nnumxv(:)     ! Turn in which a particle was lost
@@ -896,7 +896,7 @@ module mod_common_main
   real(kind=fPrec), allocatable, save :: aperv(:,:)    ! Aperture at loss
   integer,          allocatable, save :: iv(:)         ! Entry in the seque3nce where loss occured
 
-  real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! Tick tracking only: Transfer matrix for linear tracking (6,2,npart,nblo)
+  real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! Thick tracking only: Transfer matrix for linear tracking (6,2,npart,nblo)
 
 contains
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -851,8 +851,6 @@ module mod_common_main
 
   real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
 
-  real(kind=fPrec), allocatable, save :: sigmv6(:)    ! (npart)
-  real(kind=fPrec), allocatable, save :: dpsv6(:)     ! (npart)
   real(kind=fPrec), allocatable, save :: xlv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: zlv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: rvv(:)       ! (npart)
@@ -939,8 +937,6 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
 
     call alloc(dam,              npart_new,      zero,    "dam")
 
-    call alloc(sigmv6,           npart_new,      zero,    "sigmv6")
-    call alloc(dpsv6,            npart_new,      zero,    "dpsv6")
     call alloc(xlv,              npart_new,      zero,    "xlv")
     call alloc(zlv,              npart_new,      zero,    "zlv")
     call alloc(rvv,              npart_new,      one,     "rvv")

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -849,10 +849,11 @@ module mod_common_main
   real(kind=fPrec), allocatable, save :: ejfv(:)      ! Particle momentum
   real(kind=fPrec), allocatable, save :: ejv(:)       ! Particle energy
 
+  real(kind=fPrec), allocatable, save :: rvv(:)       ! Beta_0 / Beta(j)
+  real(kind=fPrec), allocatable, save :: ejf0v(:)     ! Temporary array for momentum updates
+
   real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
 
-  real(kind=fPrec), allocatable, save :: rvv(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: ejf0v(:)     ! (npart)
 
   integer,          allocatable, save :: numxv(:)     ! (npart)
   integer,          allocatable, save :: nnumxv(:)    ! (npart)

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -881,7 +881,7 @@ module mod_common_main
   real(kind=fPrec), allocatable, save :: oidpsv(:)     ! 1/(1+dpsv)
   real(kind=fPrec), allocatable, save :: rvv(:)        ! Beta_0 / Beta(j)
   real(kind=fPrec), allocatable, save :: ejf0v(:)      ! Temporary array for momentum updates
-  real(kind=fPrec), allocatable, save :: dam(:)        ! Distance in phase space3
+  real(kind=fPrec), allocatable, save :: dam(:)        ! Distance in phase space
   real(kind=fPrec), allocatable, save :: dpd(:)        ! Thick tracking only: 1+dpsv
   real(kind=fPrec), allocatable, save :: dpsq(:)       ! Thick tracking only: sqrt(1+dpsv)
   real(kind=fPrec), allocatable, save :: ampv(:)       ! Amplitude variations
@@ -894,7 +894,7 @@ module mod_common_main
   logical,          allocatable, save :: pstop(:)      ! Particle lost flag
   logical,          allocatable, save :: llostp(:)     ! Particle lost flag
   real(kind=fPrec), allocatable, save :: aperv(:,:)    ! Aperture at loss
-  integer,          allocatable, save :: iv(:)         ! Entry in the seque3nce where loss occured
+  integer,          allocatable, save :: iv(:)         ! Entry in the sequence where loss occured
 
   real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! Thick tracking only: Transfer matrix for linear tracking (6,2,npart,nblo)
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -851,12 +851,11 @@ module mod_common_main
 
   real(kind=fPrec), allocatable, save :: rvv(:)       ! Beta_0 / Beta(j)
   real(kind=fPrec), allocatable, save :: ejf0v(:)     ! Temporary array for momentum updates
-
   real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
 
+  integer,          allocatable, save :: nnumxv(:)    ! Turn in which a particle was lost
+  integer,          allocatable, save :: numxv(:)     ! Turn in which a particle was lost
 
-  integer,          allocatable, save :: numxv(:)     ! (npart)
-  integer,          allocatable, save :: nnumxv(:)    ! (npart)
   integer,          allocatable, save :: nms(:)       ! (npart)
   integer,          allocatable, save :: partID(:)    ! (npart)
   integer,          allocatable, save :: parentID(:)  ! (npart)

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -161,6 +161,7 @@ module mod_common
   real(kind=fPrec), save :: amp0       = zero ! End amplitude
   integer,          save :: numl       = 1    ! Number of turns in the forward direction
   integer,          save :: numlr      = 0    ! Number of turns in the backward direction
+  integer,          save :: numx       = 0    ! Checkpoint turn (turn-1)
   integer,          save :: napx       = 0    ! Number of amplitude variations
   integer,          save :: ird        = 0    ! Ignored
   integer,          save :: niu(2)     = 0    ! Start and stop structure element for optics calculation
@@ -343,7 +344,8 @@ module mod_common
   integer,          save :: nordm      = 0
 
   ! Reference Particle
-  real(kind=fPrec), save :: e0         = zero ! Reference energy
+  real(kind=fPrec), save :: e0         = zero ! Reference energy [MeV]
+  real(kind=fPrec), save :: e0f        = zero ! Reference momentum [MeV/c]
 
   ! Tracking Particles
   real(kind=fPrec), save :: ej(mpa)    = zero ! Particle energy
@@ -903,10 +905,6 @@ module mod_common_main
   real(kind=fPrec),              save :: fake(2,20)
   real(kind=fPrec),              save :: xau(2,6)
   real(kind=fPrec),              save :: cloau(6)
-
-  ! Main 4
-  real(kind=fPrec), save :: e0f
-  integer,          save :: numx     = 0       ! Checkpoint turn (turn-1)
 
 contains
 

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -823,8 +823,8 @@ end subroutine comt_daEnd
 end module mod_common_track
 
 ! ================================================================================================ !
-!  MAIN COMMON VARIABLES
-!  Last modified: 2018-06-13
+!  Main Variables Used for Particle Tracking
+!  Last modified: 2019-05-09
 ! ================================================================================================ !
 module mod_common_main
 
@@ -834,71 +834,69 @@ module mod_common_main
 
   implicit none
 
+  real(kind=fPrec), save :: qw(2)      = zero
+  real(kind=fPrec), save :: qwc(3)     = zero
+  real(kind=fPrec), save :: clo0(2)    = zero
+  real(kind=fPrec), save :: clop0(2)   = zero
+  real(kind=fPrec), save :: ekk(2)     = zero
+  real(kind=fPrec), save :: cr(mmul)   = zero
+  real(kind=fPrec), save :: ci(mmul)   = zero
+  real(kind=fPrec), save :: temptr(6)  = zero
+  real(kind=fPrec), save :: clo6v(3)   = zero
+  real(kind=fPrec), save :: clop6v(3)  = zero
+  real(kind=fPrec), save :: tas(6,6)   = zero
+  real(kind=fPrec), save :: tasau(6,6) = zero
+  real(kind=fPrec), save :: qwcs(3)    = zero
+  real(kind=fPrec), save :: di0xs      = zero
+  real(kind=fPrec), save :: di0zs      = zero
+  real(kind=fPrec), save :: dip0xs     = zero
+  real(kind=fPrec), save :: dip0zs     = zero
+  real(kind=fPrec), save :: di0au(4)
+  real(kind=fPrec), save :: tau(6,6)
+  real(kind=fPrec), save :: wx(3)
+  real(kind=fPrec), save :: x1(6)
+  real(kind=fPrec), save :: x2(6)
+  real(kind=fPrec), save :: fake(2,20)
+  real(kind=fPrec), save :: xau(2,6)
+  real(kind=fPrec), save :: cloau(6)
+
+  !  Arrays
+  ! ========
+
   ! Number of Structure Elements (nblz)
-  real(kind=fPrec), allocatable, save :: zsiv(:)      ! Displacement of elements, including error
-  real(kind=fPrec), allocatable, save :: xsiv(:)      ! Displacement of elements, including error
-  real(kind=fPrec), allocatable, save :: smiv(:)      ! Magnetic kick, including error
+  real(kind=fPrec), allocatable, save :: zsiv(:)       ! Displacement of elements, including error
+  real(kind=fPrec), allocatable, save :: xsiv(:)       ! Displacement of elements, including error
+  real(kind=fPrec), allocatable, save :: smiv(:)       ! Magnetic kick, including error
 
   ! Number of Particles (npart)
-  real(kind=fPrec), allocatable, save :: xv1(:)       ! Transverse coordinates: Horisontal position
-  real(kind=fPrec), allocatable, save :: yv1(:)       ! Transverse coordinates: Horisontal angle
-  real(kind=fPrec), allocatable, save :: xv2(:)       ! Transverse coordinates: Vertical position
-  real(kind=fPrec), allocatable, save :: yv2(:)       ! Transverse coordinates: Vertical angle
-  real(kind=fPrec), allocatable, save :: sigmv(:)     ! Longitudinal coordinate: Position offset
-  real(kind=fPrec), allocatable, save :: dpsv(:)      ! Longitudinal coordinate: Momentum offset from reference momentum e0f
-  real(kind=fPrec), allocatable, save :: ejfv(:)      ! Particle momentum
-  real(kind=fPrec), allocatable, save :: ejv(:)       ! Particle energy
+  real(kind=fPrec), allocatable, save :: xv1(:)        ! Transverse coordinates: Horisontal position
+  real(kind=fPrec), allocatable, save :: yv1(:)        ! Transverse coordinates: Horisontal angle
+  real(kind=fPrec), allocatable, save :: xv2(:)        ! Transverse coordinates: Vertical position
+  real(kind=fPrec), allocatable, save :: yv2(:)        ! Transverse coordinates: Vertical angle
+  real(kind=fPrec), allocatable, save :: sigmv(:)      ! Longitudinal coordinate: Position offset
+  real(kind=fPrec), allocatable, save :: dpsv(:)       ! Longitudinal coordinate: Momentum offset from reference momentum e0f
+  real(kind=fPrec), allocatable, save :: ejfv(:)       ! Particle momentum
+  real(kind=fPrec), allocatable, save :: ejv(:)        ! Particle energy
 
-  real(kind=fPrec), allocatable, save :: rvv(:)       ! Beta_0 / Beta(j)
-  real(kind=fPrec), allocatable, save :: ejf0v(:)     ! Temporary array for momentum updates
-  real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
+  real(kind=fPrec), allocatable, save :: oidpsv(:)     ! 1/(1+dpsv)
+  real(kind=fPrec), allocatable, save :: rvv(:)        ! Beta_0 / Beta(j)
+  real(kind=fPrec), allocatable, save :: ejf0v(:)      ! Temporary array for momentum updates
+  real(kind=fPrec), allocatable, save :: dam(:)        ! Distance in phase space3
+  real(kind=fPrec), allocatable, save :: dpd(:)        ! Tick tracking only: 1+dpsv
+  real(kind=fPrec), allocatable, save :: dpsq(:)       ! Tick tracking only: sqrt(1+dpsv)
+  real(kind=fPrec), allocatable, save :: ampv(:)       ! Amplitude variations
 
-  integer,          allocatable, save :: nnumxv(:)    ! Turn in which a particle was lost
-  integer,          allocatable, save :: numxv(:)     ! Turn in which a particle was lost
+  integer,          allocatable, save :: nnumxv(:)     ! Turn in which a particle was lost
+  integer,          allocatable, save :: numxv(:)      ! Turn in which a particle was lost
 
-  integer,          allocatable, save :: partID(:)    ! (npart)
-  integer,          allocatable, save :: parentID(:)  ! (npart)
+  integer,          allocatable, save :: partID(:)     ! Particle ID
+  integer,          allocatable, save :: parentID(:)   ! Particle parent ID in case of secondary particles
+  logical,          allocatable, save :: pstop(:)      ! Particle lost flag
+  logical,          allocatable, save :: llostp(:)     ! Particle lost flag
+  real(kind=fPrec), allocatable, save :: aperv(:,:)    ! Aperture at loss
+  integer,          allocatable, save :: iv(:)         ! Entry in the seque3nce where loss occured
 
-  logical,          allocatable, save :: pstop(:)     ! (npart)
-  logical,          allocatable, save :: llostp(:)    ! (npart)
-
-  real(kind=fPrec),              save :: qw(2)     = zero
-  real(kind=fPrec),              save :: qwc(3)    = zero
-  real(kind=fPrec),              save :: clo0(2)   = zero
-  real(kind=fPrec),              save :: clop0(2)  = zero
-  real(kind=fPrec),              save :: ekk(2)    = zero
-  real(kind=fPrec),              save :: cr(mmul)  = zero
-  real(kind=fPrec),              save :: ci(mmul)  = zero
-  real(kind=fPrec),              save :: temptr(6) = zero
-  real(kind=fPrec),              save :: clo6v(3)  = zero
-  real(kind=fPrec),              save :: clop6v(3) = zero
-  real(kind=fPrec),              save :: tas(6,6)  = zero
-
-  ! Main 2
-  real(kind=fPrec), allocatable, save :: dpd(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: dpsq(:)      ! (npart)
-  real(kind=fPrec), allocatable, save :: oidpsv(:)    ! (npart)
-  real(kind=fPrec), allocatable, save :: ampv(:)      ! (npart)
-  real(kind=fPrec), allocatable, save :: aperv(:,:)   ! (npart,2)
-
-  integer,          allocatable, save :: iv(:)        ! (npart)
-
-  ! Main 3
-  real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! (6,2,npart,nblo)
-  real(kind=fPrec),              save :: tasau(6,6) = zero
-  real(kind=fPrec),              save :: qwcs(3)    = zero
-  real(kind=fPrec),              save :: di0xs      = zero
-  real(kind=fPrec),              save :: di0zs      = zero
-  real(kind=fPrec),              save :: dip0xs     = zero
-  real(kind=fPrec),              save :: dip0zs     = zero
-  real(kind=fPrec),              save :: di0au(4)
-  real(kind=fPrec),              save :: tau(6,6)
-  real(kind=fPrec),              save :: wx(3)
-  real(kind=fPrec),              save :: x1(6)
-  real(kind=fPrec),              save :: x2(6)
-  real(kind=fPrec),              save :: fake(2,20)
-  real(kind=fPrec),              save :: xau(2,6)
-  real(kind=fPrec),              save :: cloau(6)
+  real(kind=fPrec), allocatable, save :: bl1v(:,:,:,:) ! Tick tracking only: Transfer matrix for linear tracking (6,2,npart,nblo)
 
 contains
 
@@ -915,41 +913,36 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
   integer :: nblz_prev  = -2
   integer :: npart_prev = -2
 
-
   if(nblz_new /= nblz_prev) then
-    call alloc(smiv,             nblz_new,       zero,    "smiv")
-    call alloc(zsiv,             nblz_new,       zero,    "zsiv")
-    call alloc(xsiv,             nblz_new,       zero,    "xsiv")
+    call alloc(smiv,     nblz_new,     zero,    "smiv")
+    call alloc(zsiv,     nblz_new,     zero,    "zsiv")
+    call alloc(xsiv,     nblz_new,     zero,    "xsiv")
   end if
 
   if(npart_new /= npart_prev) then
-    call alloc(xv1,              npart_new,      zero,    "xv1")
-    call alloc(yv1,              npart_new,      zero,    "yv1")
-    call alloc(xv2,              npart_new,      zero,    "xv2")
-    call alloc(yv2,              npart_new,      zero,    "yv2")
-    call alloc(sigmv,            npart_new,      zero,    "sigmv")
-    call alloc(dpsv,             npart_new,      zero,    "dpsv")
-    call alloc(ejv,              npart_new,      zero,    "ejv")
-    call alloc(ejfv,             npart_new,      zero,    "ejfv")
-
-    call alloc(dam,              npart_new,      zero,    "dam")
-
-    call alloc(rvv,              npart_new,      one,     "rvv")
-    call alloc(ejf0v,            npart_new,      zero,    "ejf0v")
-    call alloc(numxv,            npart_new,      0,       "numxv")
-    call alloc(nnumxv,           npart_new,      0,       "nnumxv")
-
-    call alloc(partID,           npart_new,      0,       "partID")
-    call alloc(parentID,         npart_new,      0,       "parentID")
-    call alloc(pstop,            npart_new,      .false., "pstop")
-    call alloc(llostp,           npart_new,      .false., "llostp")
-
-    call alloc(dpd,              npart_new,      zero,    "dpd")
-    call alloc(dpsq,             npart_new,      zero,    "dpsq")
-    call alloc(oidpsv,           npart_new,      one,     "oidpsv")
-    call alloc(ampv,             npart_new,      zero,    "ampv")
-    call alloc(aperv,            npart_new, 2,   zero,    "aperv")
-    call alloc(iv,               npart_new,      0,       "iv")
+    call alloc(xv1,      npart_new,    zero,    "xv1")
+    call alloc(yv1,      npart_new,    zero,    "yv1")
+    call alloc(xv2,      npart_new,    zero,    "xv2")
+    call alloc(yv2,      npart_new,    zero,    "yv2")
+    call alloc(sigmv,    npart_new,    zero,    "sigmv")
+    call alloc(dpsv,     npart_new,    zero,    "dpsv")
+    call alloc(ejv,      npart_new,    zero,    "ejv")
+    call alloc(ejfv,     npart_new,    zero,    "ejfv")
+    call alloc(dam,      npart_new,    zero,    "dam")
+    call alloc(rvv,      npart_new,    one,     "rvv")
+    call alloc(ejf0v,    npart_new,    zero,    "ejf0v")
+    call alloc(numxv,    npart_new,    0,       "numxv")
+    call alloc(nnumxv,   npart_new,    0,       "nnumxv")
+    call alloc(partID,   npart_new,    0,       "partID")
+    call alloc(parentID, npart_new,    0,       "parentID")
+    call alloc(pstop,    npart_new,    .false., "pstop")
+    call alloc(llostp,   npart_new,    .false., "llostp")
+    call alloc(dpd,      npart_new,    zero,    "dpd")
+    call alloc(dpsq,     npart_new,    zero,    "dpsq")
+    call alloc(oidpsv,   npart_new,    one,     "oidpsv")
+    call alloc(ampv,     npart_new,    zero,    "ampv")
+    call alloc(aperv,    npart_new, 2, zero,    "aperv")
+    call alloc(iv,       npart_new,    0,       "iv")
   end if
 
   nblz_prev  = nblz_new

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -851,7 +851,6 @@ module mod_common_main
 
   real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
 
-  real(kind=fPrec), allocatable, save :: dp0v(:)      ! (npart)
   real(kind=fPrec), allocatable, save :: sigmv6(:)    ! (npart)
   real(kind=fPrec), allocatable, save :: dpsv6(:)     ! (npart)
   real(kind=fPrec), allocatable, save :: xlv(:)       ! (npart)
@@ -937,8 +936,8 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
     call alloc(dpsv,             npart_new,      zero,    "dpsv")
     call alloc(ejv,              npart_new,      zero,    "ejv")
     call alloc(ejfv,             npart_new,      zero,    "ejfv")
+
     call alloc(dam,              npart_new,      zero,    "dam")
-    call alloc(dp0v,             npart_new,      zero,    "dp0v")
 
     call alloc(sigmv6,           npart_new,      zero,    "sigmv6")
     call alloc(dpsv6,            npart_new,      zero,    "dpsv6")

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -851,8 +851,6 @@ module mod_common_main
 
   real(kind=fPrec), allocatable, save :: dam(:)       ! Distance in phase space3
 
-  real(kind=fPrec), allocatable, save :: xlv(:)       ! (npart)
-  real(kind=fPrec), allocatable, save :: zlv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: rvv(:)       ! (npart)
   real(kind=fPrec), allocatable, save :: ejf0v(:)     ! (npart)
 
@@ -937,8 +935,6 @@ subroutine mod_commonmn_expand_arrays(nblz_new,npart_new)
 
     call alloc(dam,              npart_new,      zero,    "dam")
 
-    call alloc(xlv,              npart_new,      zero,    "xlv")
-    call alloc(zlv,              npart_new,      zero,    "zlv")
     call alloc(rvv,              npart_new,      one,     "rvv")
     call alloc(ejf0v,            npart_new,      zero,    "ejf0v")
     call alloc(numxv,            npart_new,      0,       "numxv")

--- a/source/include/alignva.f90
+++ b/source/include/alignva.f90
@@ -1,13 +1,13 @@
 ! start include/alignva.f90
 #ifndef TILT
-  xlv(j)=xv1(j)-xsiv(i)
-  zlv(j)=xv2(j)-zsiv(i)
-  crkve=xlv(j)
-  cikve=zlv(j)
+  xlv   = xv1(j)-xsiv(i)
+  zlv   = xv2(j)-zsiv(i)
+  crkve = xlv
+  cikve = zlv
 #else
-  xlv(j)=(xv1(j)-xsiv(i))*tiltc(i)+(xv2(j)-zsiv(i))*tilts(i)
-  zlv(j)=(xv2(j)-zsiv(i))*tiltc(i)-(xv1(j)-xsiv(i))*tilts(i)
-  crkve=xlv(j)
-  cikve=zlv(j)
+  xlv   = (xv1(j)-xsiv(i))*tiltc(i)+(xv2(j)-zsiv(i))*tilts(i)
+  zlv   = (xv2(j)-zsiv(i))*tiltc(i)-(xv1(j)-xsiv(i))*tilts(i)
+  crkve = xlv
+  cikve = zlv
 #endif
 ! end include/alignva.f90

--- a/source/include/kickvho.f90
+++ b/source/include/kickvho.f90
@@ -1,5 +1,6 @@
 ! start include/kickvho.f90
-crkveuk=crkve*xlv(j)-cikve*zlv(j)
-cikve=crkve*zlv(j)+cikve*xlv(j)
-crkve=crkveuk
+! xlv and zlv is set in include/alignva.f90
+crkveuk = crkve*xlv - cikve*zlv
+cikve   = crkve*zlv + cikve*xlv
+crkve   = crkveuk
 ! end include/kickvho.f90

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -849,7 +849,6 @@ program maincr
     dpsv(ib1)    = dp10
     oidpsv(ib1)  = one/(one+dp1)
     moidpsv(ib1) = mtc(ib1)/(one+dp1)
-    nms(ib1)     = 1
   end do
 
 ! ================================================================================================ !
@@ -1010,7 +1009,7 @@ program maincr
       nucm(ia+1) = nucm0
 
       if(st_quiet == 0) then
-        write(lout,10260) ia,nms(ia)*izu0,dpsv(ia)
+        write(lout,10260) ia,izu0,dpsv(ia)
         write(lout,10060) xv1(ia),yv1(ia),xv2(ia),yv2(ia),sigmv(ia),dpsv(ia), &
           xv1(ia+1),yv1(ia+1),xv2(ia+1),yv2(ia+1),sigmv(ia+1),dpsv(ia+1)
         write(lout,10020) ampv(ia),amp(2),epsa
@@ -1320,33 +1319,33 @@ program maincr
     napxto = napxto+numxv(ia)+numxv(ie)
 
     if(pstop(ia).and.pstop(ie)) then !-- BOTH PARTICLES LOST
-      write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
-      write(lout,10000) ie,nms(ia)*izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
+      write(lout,10000) ia,izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
+      write(lout,10000) ie,izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
     end if
 
     if(.not.pstop(ia).and.pstop(ie)) then !-- SECOND PARTICLE LOST
       if(st_quiet == 0) then
-        write(lout,10240) ia,nms(ia)*izu0,dpsv(ia),numxv(ia)
+        write(lout,10240) ia,izu0,dpsv(ia),numxv(ia)
       else if(st_quiet == 1) then
-        write(lout,10241) ia,nms(ia)*izu0,dpsv(ia),numxv(ia)
+        write(lout,10241) ia,izu0,dpsv(ia),numxv(ia)
       end if
-      write(lout,10000) ie,nms(ia)*izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
+      write(lout,10000) ie,izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
     end if
 
     if(pstop(ia).and..not.pstop(ie)) then !-- FIRST PARTICLE LOST
-      write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
+      write(lout,10000) ia,izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
       if(st_quiet == 0) then
-        write(lout,10240) ie,nms(ia)*izu0,dpsv(ia),numxv(ie)
+        write(lout,10240) ie,izu0,dpsv(ia),numxv(ie)
       else if(st_quiet == 1) then
-        write(lout,10241) ie,nms(ia)*izu0,dpsv(ia),numxv(ie)
+        write(lout,10241) ie,izu0,dpsv(ia),numxv(ie)
       end if
     end if
 
     if(.not.pstop(ia).and..not.pstop(ie)) then !-- BOTH PARTICLES STABLE
       if(st_quiet == 0) then
-        write(lout,10270) ia,ie,nms(ia)*izu0,dpsv(ia),numxv(ia)
+        write(lout,10270) ia,ie,izu0,dpsv(ia),numxv(ia)
       else if(st_quiet == 1) then
-        write(lout,10271) ia,ie,nms(ia)*izu0,dpsv(ia),numxv(ia)
+        write(lout,10271) ia,ie,izu0,dpsv(ia),numxv(ia)
       end if
     end if
 

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -846,7 +846,6 @@ program maincr
       ampv(ib1) = amp0
     end if
 
-    dp0v(ib1)    = dp10
     dpsv(ib1)    = dp10
     oidpsv(ib1)  = one/(one+dp1)
     moidpsv(ib1) = mtc(ib1)/(one+dp1)
@@ -1321,33 +1320,33 @@ program maincr
     napxto = napxto+numxv(ia)+numxv(ie)
 
     if(pstop(ia).and.pstop(ie)) then !-- BOTH PARTICLES LOST
-      write(lout,10000) ia,nms(ia)*izu0,dp0v(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
-      write(lout,10000) ie,nms(ia)*izu0,dp0v(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
+      write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
+      write(lout,10000) ie,nms(ia)*izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
     end if
 
     if(.not.pstop(ia).and.pstop(ie)) then !-- SECOND PARTICLE LOST
       if(st_quiet == 0) then
-        write(lout,10240) ia,nms(ia)*izu0,dp0v(ia),numxv(ia)
+        write(lout,10240) ia,nms(ia)*izu0,dpsv(ia),numxv(ia)
       else if(st_quiet == 1) then
-        write(lout,10241) ia,nms(ia)*izu0,dp0v(ia),numxv(ia)
+        write(lout,10241) ia,nms(ia)*izu0,dpsv(ia),numxv(ia)
       end if
-      write(lout,10000) ie,nms(ia)*izu0,dp0v(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
+      write(lout,10000) ie,nms(ia)*izu0,dpsv(ia),numxv(ie),abs(xv1(ie)),aperv(ie,1),abs(xv2(ie)),aperv(ie,2)
     end if
 
     if(pstop(ia).and..not.pstop(ie)) then !-- FIRST PARTICLE LOST
-      write(lout,10000) ia,nms(ia)*izu0,dp0v(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
+      write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),numxv(ia),abs(xv1(ia)),aperv(ia,1),abs(xv2(ia)),aperv(ia,2)
       if(st_quiet == 0) then
-        write(lout,10240) ie,nms(ia)*izu0,dp0v(ia),numxv(ie)
+        write(lout,10240) ie,nms(ia)*izu0,dpsv(ia),numxv(ie)
       else if(st_quiet == 1) then
-        write(lout,10241) ie,nms(ia)*izu0,dp0v(ia),numxv(ie)
+        write(lout,10241) ie,nms(ia)*izu0,dpsv(ia),numxv(ie)
       end if
     end if
 
     if(.not.pstop(ia).and..not.pstop(ie)) then !-- BOTH PARTICLES STABLE
       if(st_quiet == 0) then
-        write(lout,10270) ia,ie,nms(ia)*izu0,dp0v(ia),numxv(ia)
+        write(lout,10270) ia,ie,nms(ia)*izu0,dpsv(ia),numxv(ia)
       else if(st_quiet == 1) then
-        write(lout,10271) ia,ie,nms(ia)*izu0,dp0v(ia),numxv(ia)
+        write(lout,10271) ia,ie,nms(ia)*izu0,dpsv(ia),numxv(ia)
       end if
     end if
 

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -37,9 +37,9 @@ program mainda
 
   integer i,iation,itiono,idate,im,itime,ix,izu,j,k,kpz,kzz,l,ll,ncorruo,ndim,nlino,nlinoo,nmz
   real(kind=fPrec) alf0s1,alf0s2,alf0s3,alf0x2,alf0x3,alf0z2,alf0z3,amp00,bet0s1,bet0s2,bet0s3,     &
-    bet0x2,bet0x3,bet0z2,bet0z3,clo0,clop0,dp0,dp10,e0f,eps,epsa,gam0s1,gam0s2,gam0s3,gam0x1,gam0x2,&
-    gam0x3,gam0z1,gam0z2,gam0z3,phag,qw,qwc,r0,r0a,rv,&
-    tas,tas16,tas26,tas36,tas46,tas56,tas61,tas62,tas63,tas64,tas65
+    bet0x2,bet0x3,bet0z2,bet0z3,clo0,clop0,dp0,dp10,eps,epsa,gam0s1,gam0s2,gam0s3,gam0x1,gam0x2,    &
+    gam0x3,gam0z1,gam0z2,gam0z3,phag,qw,qwc,r0,r0a,rv,tas,tas16,tas26,tas36,tas46,tas56,tas61,tas62,&
+    tas63,tas64,tas65
 
   character(len=8)  cdate,ctime ! Note: Keep in sync with maincr. If the len changes, CRCHECK will break.
   dimension qw(2),qwc(3),clo0(2),clop0(2)

--- a/source/postprocessing.f90
+++ b/source/postprocessing.f90
@@ -3361,7 +3361,7 @@ end subroutine join
       enddo
 
       mmac_tmp   = 1.0_real64
-      nms_tmp    = real(nms(ia_p1), real64)
+      nms_tmp    = 1.0_real64
       izu0_tmp   = real(izu0,       real64)
       numlr_tmp  = real(numlr,      real64)
       sigcor_tmp = real(sigcor,     real64)

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -14,7 +14,6 @@ subroutine umlauda
   use parpro
   use parbeam, only : beam_expflag,beam_expfile_open
   use mod_common
-  use mod_common_main, only : e0f
   use mod_commons
   use mod_common_track, only : xxtr,yytr,issss,tasm,comt_daStart,comt_daEnd
   use mod_common_da
@@ -2105,7 +2104,6 @@ subroutine synoda
   use numerical_constants
   use parpro
   use mod_common
-  use mod_common_main, only : e0f
   use mod_commons
   use mod_common_track
   use mod_common_da

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -248,7 +248,6 @@ subroutine runcav
   use parpro
   use mod_time
   use mod_common
-  use mod_common_main, only : e0f
   use mod_commons
   use mod_common_track, only : comt_daStart,comt_daEnd
   use mod_common_da

--- a/source/sixda.f90
+++ b/source/sixda.f90
@@ -436,7 +436,6 @@ subroutine runda
   use crcoall
   use parpro
   use mod_common
-  use mod_common_main, only : e0f,numx
   use mod_commons
   use mod_common_track, only : xxtr,yytr,comt_daStart,comt_daEnd
   use mod_common_da

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -2564,7 +2564,7 @@ subroutine distance(x,clo,di0,t,dam)
           phi(i)=zero
         endif
    80 continue
-      dam=sqrt((phi(1)**2+phi(2)**2+phi(3)**2)/real(idam,fPrec))/pi            !hr06
+      dam=sqrt((phi(1)**2+phi(2)**2+phi(3)**2)/real(idam,fPrec))/pi
 !-----------------------------------------------------------------------
       return
 end subroutine distance

--- a/source/sixve.f90
+++ b/source/sixve.f90
@@ -93,6 +93,7 @@ subroutine sumpos
     ! and we always print the maximum DMMAC as NMAC
     ! or zero which should really be OK I think.
     ! N.B. If particle is lost nms is 0, so we set mmac to zero too
+    ! (nms is always 1)
     d(60) = one ! was real(nmac)
     if(nint(d(59)) == 0) d(60) = zero
     write(lout,10030) i,nint(d(59)),nint(d(60)),nint(d(59))*nint(d(24))

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -517,7 +517,7 @@ subroutine thck4d(nthinerr)
   real(kind=fPrec) cccc,cikve,crkve,crkveuk,puxve,puxve1,puxve2,puzve1,puzve2,puzve,r0,xlvj,yv1j,   &
     yv2j,zlvj,acdipamp,qd,acphase, acdipamp2,acdipamp1,crabamp,crabfreq,kcrab,RTWO,NNORM,l,cur,dx,  &
     dy,tx,ty,embl,chi,xi,yi,dxi,dyi,rrelens,frrelens,xelens,yelens,onedp,fppsig,costh_temp,         &
-    sinth_temp,pxf,pyf,r_temp,z_temp,sigf,q_temp
+    sinth_temp,pxf,pyf,r_temp,z_temp,sigf,q_temp,xlv,zlv
 
   logical llost
   real(kind=fPrec) crkveb(npart),cikveb(npart),rho2b(npart),tkb(npart),r2b(npart),rb(npart),        &
@@ -1175,7 +1175,7 @@ subroutine thck6d(nthinerr)
   real(kind=fPrec) cccc,cikve,crkve,crkveuk,puxve1,puxve2,puzve1,puzve2,r0,xlvj,yv1j,yv2j,zlvj,     &
     acdipamp,qd,acphase,acdipamp2,acdipamp1,crabamp,crabfreq,kcrab,RTWO,NNORM,l,cur,dx,dy,tx,ty,    &
     embl,chi,xi,yi,dxi,dyi,rrelens,frrelens,xelens,yelens,onedp,fppsig,costh_temp,sinth_temp,pxf,   &
-    pyf,r_temp,z_temp,sigf,q_temp,pttemp
+    pyf,r_temp,z_temp,sigf,q_temp,pttemp,xlv,zlv
   logical llost
   real(kind=fPrec) crkveb(npart),cikveb(npart),rho2b(npart),tkb(npart),r2b(npart),rb(npart),        &
     rkb(npart),xrb(npart),zrb(npart),xbb(npart),zbb(npart),crxb(npart),crzb(npart),cbxb(npart),     &

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -2252,7 +2252,7 @@ subroutine write6(n)
 #endif
     !-- PARTICLES STABLE (Only if QUIET < 2)
     if(.not.pstop(ia).and..not.pstop(ig)) then
-      if(st_quiet < 2) write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),n
+      if(st_quiet < 2) write(lout,10000) ia,izu0,dpsv(ia),n
       if(st_quiet < 1) write(lout,10010)                    &
         xv1(ia),yv1(ia),xv2(ia),yv2(ia),sigmv(ia),dpsv(ia), &
         xv1(ig),yv1(ig),xv2(ig),yv2(ig),sigmv(ig),dpsv(ig), &

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -2252,7 +2252,7 @@ subroutine write6(n)
 #endif
     !-- PARTICLES STABLE (Only if QUIET < 2)
     if(.not.pstop(ia).and..not.pstop(ig)) then
-      if(st_quiet < 2) write(lout,10000) ia,nms(ia)*izu0,dp0v(ia),n
+      if(st_quiet < 2) write(lout,10000) ia,nms(ia)*izu0,dpsv(ia),n
       if(st_quiet < 1) write(lout,10010)                    &
         xv1(ia),yv1(ia),xv2(ia),yv2(ia),sigmv(ia),dpsv(ia), &
         xv1(ig),yv1(ig),xv2(ig),yv2(ig),sigmv(ig),dpsv(ig), &

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -539,7 +539,7 @@ subroutine thin4d(nthinerr)
   real(kind=fPrec) pz,cccc,cikve,crkve,crkveuk,r0,stracki,xlvj,yv1j,yv2j,zlvj,acdipamp,qd,acphase,  &
     acdipamp2,acdipamp1,crabamp,crabfreq,kcrab,RTWO,NNORM,l,cur,dx,dy,tx,ty,embl,chi,xi,yi,dxi,dyi, &
     rrelens,frrelens,xelens,yelens,onedp,fppsig,costh_temp,sinth_temp,pxf,pyf,r_temp,z_temp,sigf,   &
-    q_temp,pttemp
+    q_temp,pttemp,xlv,zlv
   logical llost
   real(kind=fPrec) crkveb(npart),cikveb(npart),rho2b(npart),tkb(npart),r2b(npart),rb(npart),        &
     rkb(npart),xrb(npart),zrb(npart),xbb(npart),zbb(npart),crxb(npart),crzb(npart),cbxb(npart),     &
@@ -1153,7 +1153,7 @@ subroutine thin6d(nthinerr)
   real(kind=fPrec) pz,cccc,cikve,crkve,crkveuk,r0,stracki,xlvj,yv1j,yv2j,zlvj,acdipamp,qd,          &
     acphase,acdipamp2,acdipamp1,crabamp,crabfreq,crabamp2,crabamp3,crabamp4,kcrab,RTWO,NNORM,l,cur, &
     dx,dy,tx,ty,embl,chi,xi,yi,dxi,dyi,rrelens,frrelens,xelens,yelens, onedp,fppsig,costh_temp,     &
-    sinth_temp,pxf,pyf,r_temp,z_temp,sigf,q_temp,pttemp
+    sinth_temp,pxf,pyf,r_temp,z_temp,sigf,q_temp,pttemp,xlv,zlv
   logical llost, doFField
   real(kind=fPrec) crkveb(npart),cikveb(npart),rho2b(npart),tkb(npart),r2b(npart),rb(npart),        &
     rkb(npart),xrb(npart),zrb(npart),xbb(npart),zbb(npart),crxb(npart),crzb(npart),cbxb(npart),     &


### PR DESCRIPTION
There were a number of redundant arrays in the main particle array module, so I cleaned up a bit. Also added comments about what all the arrays are.

A bit difficult to see from the diff, but the deleted arrays are: `xsv`, `zsv`, `dp0v`, `sigmv6`, `dpsv6`, `xlv`, `zlv`, `nms`, and `ekkv`.

`dp0v` was always the same as `dpsv`, `nms` was always `one`, and `xlv` and `zlv` could be replaced by scalars. The rest weren't used at all.

In addition, `dpd`, `dpsq` and `ampv` can probably also be removed with a bit of tweaking of the code. They are all used as local temp arrays. So is `ejf0v`, but this one is used between particle loops.