### PR TITLE
Boinc API, bugfix and progress

### DIFF
--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -118,7 +118,6 @@ module mod_common
 
   use parpro
   use floatPrecision
-  use physical_constants
   use numerical_constants
   use physical_constants, only : pmap
   use, intrinsic :: iso_fortran_env, only : int16

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1444,6 +1444,9 @@ program maincr
       call postpr(ia2)
 #endif
 #endif
+#ifdef BOINC
+      call boinc_postpr(ia)
+#endif
     end do
     if(iposc >= 1) call sumpos
     call f_close(unit10)
@@ -1476,6 +1479,9 @@ program maincr
 #else
       call postpr(91-ia)
 #endif
+#endif
+#ifdef BOINC
+      call boinc_postpr(ia)
 #endif
     end do
     if(ndafi >= 1) call sumpos

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1444,9 +1444,6 @@ program maincr
       call postpr(ia2)
 #endif
 #endif
-#ifdef BOINC
-      call boinc_postpr(ia)
-#endif
     end do
     if(iposc >= 1) call sumpos
     call f_close(unit10)
@@ -1480,9 +1477,6 @@ program maincr
       call postpr(91-ia)
 #endif
 #endif
-#ifdef BOINC
-      call boinc_postpr(ia)
-#endif
     end do
     if(ndafi >= 1) call sumpos
     call f_close(unit10)
@@ -1507,7 +1501,7 @@ program maincr
   endif
 #endif
 
-call ffield_mod_end()
+  call ffield_mod_end()
 
   time3=0.
   call time_timerCheck(time3)
@@ -1521,6 +1515,11 @@ call ffield_mod_end()
   ! HASH library. Must be before ZIPF
   call hash_fileSums
   call time_timeStamp(time_afterHASH)
+#endif
+
+#ifdef BOINC
+  ! Do the final things in BOINC before ZIPF, but after HASH
+  call boinc_done
 #endif
 
   if(zipf_numfiles > 0) then

--- a/source/mod_boinc.f90
+++ b/source/mod_boinc.f90
@@ -174,7 +174,7 @@ subroutine boinc_finalise(exitCode)
   if(exitCode == 0) then
     stop
   else
-    stop exitCode
+    stop 1
   end if
 #endif
 

--- a/source/mod_boinc.f90
+++ b/source/mod_boinc.f90
@@ -147,7 +147,6 @@ subroutine boinc_post
   use checkpoint_restart
 
   write(boinc_logBuffer,"(a)") "Tracking completed. Final checkpoint."
-  write(boinc_logBuffer,"(a,f8.3,a)") "Progress: ",99.0," %"
   call boinc_writeLog
 
 #ifdef API

--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -539,6 +539,7 @@ subroutine sixin_parseInputLineSIMU(inLine, iLine, iErr)
   use mod_common
   use mod_commons
   use mod_common_track
+  use physical_constants
 
   character(len=*), intent(in)    :: inLine
   integer,          intent(in)    :: iLine
@@ -908,6 +909,7 @@ subroutine sixin_parseInputDoneSIMU(iErr)
   use crcoall
   use mod_common
   use mod_settings
+  use physical_constants
 
   logical, intent(inout) :: iErr
 
@@ -1905,6 +1907,7 @@ subroutine sixin_parseInputLineSYNC(inLine, iLine, iErr)
   use mod_common
   use mod_common_da,   only : nvar
   use mathlib_bouncer, only : cos_mb
+  use physical_constants
 
   character(len=*), intent(in)    :: inLine
   integer,          intent(in)    :: iLine


### PR DESCRIPTION
This PR:

* Repositions the BOINC submodule to latest master where my fortran_api changes were merged.
* Fixes building for ifort/nagfor (didn't like `stop exitCode` so changed to `stop 1`).
* If postprocessing is on, tracking progress stops at 99%, and jumps to 100% after.
* Reshuffles a little bit how BOINC is finished due to the log file needing to be closed before ZIPF.

**Additional**

Do we really need two flags for BOINC and API? @kyrsjo asked the same question. This is why we need dummy routines, like `boincrf`, and it complicates the service module. I can't see any reason why we shouldn't just link BOINC with the API always. I suppose there was a reason for the test suite before perhaps, but the tests pass fine now.