### PR TITLE
SixTestWrapper Fixes

### DIFF
--- a/test/beam-HO_6D-simple-newstyle-coupling/extra_checks.txt
+++ b/test/beam-HO_6D-simple-newstyle-coupling/extra_checks.txt
@@ -1,0 +1,1 @@
+final_state.dat

--- a/test/beam-HO_6D-simple-newstyle-coupling/final_state.dat.canonical
+++ b/test/beam-HO_6D-simple-newstyle-coupling/final_state.dat.canonical
@@ -1,4 +1,3 @@
-# imc   = 1
 # napx  = 4096
 # napxo = 4096
 # npart = 4096

--- a/test/tools/SixTestWrapper.cpp
+++ b/test/tools/SixTestWrapper.cpp
@@ -703,7 +703,9 @@ int main(int argc, char* argv[])
         CheckPrint("CR Number of Restarts",!crRestartFail);
         if(!crRestartFail) passCount++;
     }
-    CheckPrint("Checks Passed > 0", passCount > 0);
+    std::stringstream numPassed;
+    numPassed << "Checks Passed: " << passCount << " > 0";
+    CheckPrint(numPassed.str(), passCount > 0);
     std::cout << std::endl;
 
     PrettyDivider("EXIT");

--- a/test/tools/SixTestWrapper.cpp
+++ b/test/tools/SixTestWrapper.cpp
@@ -687,23 +687,23 @@ int main(int argc, char* argv[])
     }
 #endif
     PrettyDivider("CHECKS SUMMARY");
-    if(fort10)           CheckPrint("fort.10",!fort10fail);
-    if(fort90)           CheckPrint("fort.90",!fort90fail);
-    if(STF)              CheckPrint("singletrackfile.dat",!STFfail);
-    if(extrachecks)      CheckPrint("Extra Checks",!ExtraChecksfail);
-    if(!fort10fail)      passCount++;
-    if(!fort90fail)      passCount++;
-    if(!STFfail)         passCount++;
-    if(!ExtraChecksfail) passCount++;
+    if(fort10)      CheckPrint("fort.10",!fort10fail);
+    if(fort90)      CheckPrint("fort.90",!fort90fail);
+    if(STF)         CheckPrint("singletrackfile.dat",!STFfail);
+    if(extrachecks) CheckPrint("Extra Checks",!ExtraChecksfail);
+    if(fort10      && !fort10fail)      passCount++;
+    if(fort90      && !fort90fail)      passCount++;
+    if(STF         && !STFfail)         passCount++;
+    if(extrachecks && !ExtraChecksfail) passCount++;
 #ifdef LIBARCHIVE
-    if(sixoutzip)        CheckPrint(sixoutzip_fname,!sixoutzipfail);
-    if(!sixoutzipfail)   passCount++;
+    if(sixoutzip)   CheckPrint(sixoutzip_fname,!sixoutzipfail);
+    if(sixoutzip && !sixoutzipfail)     passCount++;
 #endif
     if(CRon && atoi(argv[12]) > 0) {
         CheckPrint("CR Number of Restarts",!crRestartFail);
+        if(!crRestartFail) passCount++;
     }
-    if(!crRestartFail)   passCount++;
-    CheckPrint("Checks Passed > 0",passCount > 0);
+    CheckPrint("Checks Passed > 0", passCount > 0);
     std::cout << std::endl;
 
     PrettyDivider("EXIT");
@@ -712,7 +712,7 @@ int main(int argc, char* argv[])
     //or together any fail bits.
     //If all tests pass this will return 0 (good)
     //if not we get something else out (bad)
-    return (fort10fail || fort90fail || STFfail || ExtraChecksfail || sixoutzipfail || crRestartFail || passCount == 0);
+    return (fort10fail || fort90fail || STFfail || ExtraChecksfail || sixoutzipfail || crRestartFail || (passCount == 0));
 }
 
 /**
@@ -1454,6 +1454,7 @@ void UnlinkCRFiles() {
     unlinkFiles.push_back("fort.6");
     unlinkFiles.push_back("fort.10");
     unlinkFiles.push_back("fort.90");
+    unlinkFiles.push_back("cr_boinc.log");
     unlinkFiles.push_back("cr_status.log");
     unlinkFiles.push_back("crpoint_pri.bin");
     unlinkFiles.push_back("crpoint_sec.bin");


### PR DESCRIPTION
The SixTestWrapper could still pass tests that actually didn't check anything at all, as it turns out it did for the test beam-HO_6D-simple-newstyle-coupling. This has now been fixed, and so has the test.