### PR TITLE
Chromaticity block updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ list(APPEND FORT90_LIB
   ranecu wire elens mod_dist scatter dump dynk
   aperture mod_fluc beam6d_fox six_fox postprocessing
   read_write ranlux collimation coll_db mod_particles cheby utils
-  mod_ffield mod_ffield_aux
+  mod_ffield mod_ffield_aux mod_find
 )
 
 # Files unique to DA or CR version

--- a/doc/user_manual/chProcessing.tex
+++ b/doc/user_manual/chProcessing.tex
@@ -92,7 +92,7 @@ The chromaticity can be adjusted to desired values with two sextupole family usi
 \begin{longtabu}{@{}llp{0.65\linewidth}}
     \texttt{name1, name2} & char    & Names (in the single element list (\ref{NonEle}) of the two sextupole\index{sextupole} families. \\
     \texttt{$Q^\prime$}   & float   & Desired values of the chromaticity\index{chromaticity}: $Q^\prime=\frac{\delta Q}{\delta( \frac{\Delta p}{p_o})}$. \\
-    \texttt{ichrom}       & integer & Logical switch to calculate the traditional chromaticity calculation (\texttt{1 = ichrom}) and with the DA approach including the beam-beam kick (\texttt{2 = ichrom}). \\
+    \texttt{ichrom}       & integer & Logical switch to calculate the traditional chromaticity calculation (\texttt{1}) and with the DA approach including the beam-beam kick (\texttt{2}). Setting this flag to \texttt{3} switches on both. \\
 \end{longtabu}
 
 \paragraph{Remarks}~\\

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -771,7 +771,7 @@ module mod_common_track
 
   ! Chromaticity
   real(kind=fPrec), save :: cro(2)   = zero
-  integer,          save :: is(2)    = 0
+  integer,          save :: crois(2) = 0
   integer,          save :: ichrom   = 0
 
   ! tas
@@ -789,7 +789,6 @@ module mod_common_track
   ! Substitute variables for x,y and is for DA version
   real(kind=fPrec), save :: xxtr(mpa,2)
   real(kind=fPrec), save :: yytr(mpa,2)
-  integer,          save :: issss(2)
 
 contains
 
@@ -818,14 +817,12 @@ end subroutine mod_commont_expand_arrays
 subroutine comt_daStart
   xxtr(1:mpa,1:2) = x(1:mpa,1:2)
   yytr(1:mpa,1:2) = y(1:mpa,1:2)
-  issss(1:2)      = is(1:2)
 end subroutine comt_daStart
 
 ! Copy from temp DA variables to actual variables
 subroutine comt_daEnd
   x(1:mpa,1:2) = xxtr(1:mpa,1:2)
   y(1:mpa,1:2) = yytr(1:mpa,1:2)
-  is(1:2)      = issss(1:2)
 end subroutine comt_daEnd
 
 end module mod_common_track

--- a/source/common_modules.f90
+++ b/source/common_modules.f90
@@ -770,9 +770,9 @@ module mod_common_track
   integer,          save :: nwri     = 0     ! Flag for frequency of calls to writebin. Set by nwr(3) in TRAC
 
   ! Chromaticity
-  real(kind=fPrec), save :: cro(2)   = zero
-  integer,          save :: crois(2) = 0
-  integer,          save :: ichrom   = 0
+  real(kind=fPrec), save :: cro(2)   = zero  ! Desired values of the chromaticity
+  integer,          save :: crois(2) = 0     ! Index of the elements in the single elements list
+  integer,          save :: ichrom   = 0     ! Flag for calculation, 1: "traditional", 2: including beam-beam, 3: both
 
   ! tas
   real(kind=fPrec), save :: tasm(6,6)

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -562,9 +562,9 @@ program maincr
     do ncrr=1,iu
       ix = ic(ncrr)
       if(ix > nblo) ix = ix-nblo
-      if(ix == is(1) .or. iratioe(ix) == is(1)) then
+      if(ix == crois(1) .or. iratioe(ix) == crois(1)) then
         smiv(ncrr) = smi(ncrr)
-      else if(ix == is(2) .or. iratioe(ix) == is(2)) then
+      else if(ix == crois(2) .or. iratioe(ix) == crois(2)) then
         smiv(ncrr) = smi(ncrr)
       end if
     end do

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -465,7 +465,7 @@ program maincr
 
   if(irmod2.eq.1) call rmod(dp1)
   if(iqmod.ne.0) call qmod0
-  if(ichrom.eq.1.or.ichrom.eq.3) call chroma
+  if(ichrom == 1 .or. ichrom == 3) call chroma
   if(iskew.ne.0) call decoup
   if(ilin.eq.1.or.ilin.eq.3) then
     call linopt(dp1)

--- a/source/main_da.f90
+++ b/source/main_da.f90
@@ -168,7 +168,7 @@ program mainda
   call corrorb
   if(irmod2.eq.1) call rmod(dp1)
   if(iqmod.ne.0) call qmod0
-  if(ichrom.eq.1.or.ichrom.eq.3) call chroma
+  if(ichrom == 1 .or. ichrom == 3) call chroma
   if(iskew.ne.0) call decoup
   dp0=dp1
 

--- a/source/mod_find.f90
+++ b/source/mod_find.f90
@@ -1,0 +1,125 @@
+! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  A collection of common search routines for SixTrack
+!  Created: 2019-06-05
+!  Updated: 2019-06-07
+! ================================================================================================ !
+module mod_find
+
+  use floatPrecision
+
+  implicit none
+
+  private
+
+  public :: find_singElemFromName
+  public :: find_struElemFromName
+  public :: find_struElemFromPos
+
+contains
+
+! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Returns the single element index of a given element name. Is -1 if not found.
+!  Created: 2019-06-05
+!  Updated: 2019-06-05
+! ================================================================================================ !
+integer function find_singElemFromName(elemName)
+
+  use mod_common
+
+  character(len=*), intent(in) :: elemName
+  integer i
+
+  find_singElemFromName = -1
+  do i=1,il
+    if(bez(i) == elemName) then
+      find_singElemFromName = i
+      exit
+    end if
+  end do
+
+end function find_singElemFromName
+
+! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Returns the structure element index of a given element name. Is -1 if not found.
+!  Requires a start and end index as these are not necessarily the same during parsing as after
+!  reshuffling of the lattice.
+!  Created: 2019-06-05
+!  Updated: 2019-06-05
+! ================================================================================================ !
+integer function find_struElemFromName(elemName, iStart, iEnd)
+
+  use mod_common
+
+  character(len=*), intent(in) :: elemName
+  integer,          intent(in) :: iStart
+  integer,          intent(in) :: iEnd
+
+  integer i
+
+  find_struElemFromName = -1
+
+  ! If we don't have a multicolumn struct block, the name is not unique
+  if(strumcol .eqv. .false.) return
+
+  do i=iStart,iEnd
+    if(bezs(i) == elemName) then
+      find_struElemFromName = i
+      exit
+    end if
+  end do
+
+end function find_struElemFromName
+
+! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Returns the structure element index of a given element position. Is -1 if not found.
+!  Created: 2019-06-05
+!  Updated: 2019-06-05
+! ================================================================================================ !
+integer function find_struElemFromPos(sPos, selectMethod)
+
+  use mod_common, only : dcum, iu
+
+  real(kind=fPrec), intent(in) :: sPos
+  integer,          intent(in) :: selectMethod
+
+  integer i, iA, iB, iC, iD, iN
+
+  find_struElemFromPos = -1
+
+  iA = 0
+  iB = iu+1
+  iC = 0
+  iD = 0
+  iN = 2*nint(log(real(iu))) + 5 ! Give some extra room, but 2*log(n) should be enough
+
+  ! Binary search
+  do i=1,iN
+    iD = iB - iA
+    if(iD == 1) exit
+    iC = iA + iD/2
+    if(sPos > dcum(iC)) then
+      iA = iC
+    else
+      iB = iC
+    end if
+  end do
+
+  if(selectMethod == -1) then    ! Return lowest index
+    find_struElemFromPos = iA
+  elseif(selectMethod == 1) then ! Return highest index
+    find_struElemFromPos = iB
+  elseif(selectMethod == 0) then ! Return nearest index
+    if(sPos - dcum(iA) < dcum(iB) - sPos) then
+      find_struElemFromPos = iA
+    else
+      find_struElemFromPos = iB ! If they are equal, we get the last element
+    end if
+  end if
+
+end function find_struElemFromPos
+
+end module mod_find

--- a/source/mod_geometry.f90
+++ b/source/mod_geometry.f90
@@ -481,6 +481,61 @@ subroutine geom_parseInputLineSTRU_MULT(inLine, iLine, iErr)
 end subroutine geom_parseInputLineSTRU_MULT
 
 ! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Returns the single element index of a given element name. Is -1 if not found.
+!  Created: 2019-06-05
+!  Updated: 2019-06-05
+! ================================================================================================ !
+integer function geom_getSingElemID(elemName)
+
+  use mod_common
+
+  character(len=*), intent(in) :: elemName
+  integer i
+
+  geom_getSingElemID = -1
+  do i=1,il
+    if(bez(i) == elemName) then
+      geom_getSingElemID = i
+      exit
+    end if
+  end do
+
+end function geom_getSingElemID
+
+! ================================================================================================ !
+!  V.K. Berglyd Olsen, BE-ABP-HSS
+!  Returns the structure element index of a given element name. Is -1 if not found.
+!  Requires a start and end index as these are not necessarily the same during parsing as after
+!  reshuffling of the lattice.
+!  Created: 2019-06-05
+!  Updated: 2019-06-05
+! ================================================================================================ !
+integer function geom_getStruElemID(elemName, iStart, iEnd)
+
+  use mod_common
+
+  character(len=*), intent(in) :: elemName
+  integer,          intent(in) :: iStart
+  integer,          intent(in) :: iEnd
+
+  integer i
+
+  geom_getStruElemID = -1
+
+  ! If we don't have a multicolumn struct block, the name is not unique
+  if(strumcol .eqv. .false.) return
+
+  do i=iStart,iEnd
+    if(bezs(i) == elemName) then
+      geom_getStruElemID = i
+      exit
+    end if
+  end do
+
+end function geom_getStruElemID
+
+! ================================================================================================ !
 !  A.Mereghetti, V.K. Berglyd Olsen, BE-ABP-HSS
 !  Insert a New Empty Element (empty) in SINGLE ELEMENTS
 !  Updated: 2019-03-28

--- a/source/mod_geometry.f90
+++ b/source/mod_geometry.f90
@@ -481,61 +481,6 @@ subroutine geom_parseInputLineSTRU_MULT(inLine, iLine, iErr)
 end subroutine geom_parseInputLineSTRU_MULT
 
 ! ================================================================================================ !
-!  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Returns the single element index of a given element name. Is -1 if not found.
-!  Created: 2019-06-05
-!  Updated: 2019-06-05
-! ================================================================================================ !
-integer function geom_getSingElemID(elemName)
-
-  use mod_common
-
-  character(len=*), intent(in) :: elemName
-  integer i
-
-  geom_getSingElemID = -1
-  do i=1,il
-    if(bez(i) == elemName) then
-      geom_getSingElemID = i
-      exit
-    end if
-  end do
-
-end function geom_getSingElemID
-
-! ================================================================================================ !
-!  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Returns the structure element index of a given element name. Is -1 if not found.
-!  Requires a start and end index as these are not necessarily the same during parsing as after
-!  reshuffling of the lattice.
-!  Created: 2019-06-05
-!  Updated: 2019-06-05
-! ================================================================================================ !
-integer function geom_getStruElemID(elemName, iStart, iEnd)
-
-  use mod_common
-
-  character(len=*), intent(in) :: elemName
-  integer,          intent(in) :: iStart
-  integer,          intent(in) :: iEnd
-
-  integer i
-
-  geom_getStruElemID = -1
-
-  ! If we don't have a multicolumn struct block, the name is not unique
-  if(strumcol .eqv. .false.) return
-
-  do i=iStart,iEnd
-    if(bezs(i) == elemName) then
-      geom_getStruElemID = i
-      exit
-    end if
-  end do
-
-end function geom_getStruElemID
-
-! ================================================================================================ !
 !  A.Mereghetti, V.K. Berglyd Olsen, BE-ABP-HSS
 !  Insert a New Empty Element (empty) in SINGLE ELEMENTS
 !  Updated: 2019-03-28

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -15,7 +15,7 @@ subroutine umlauda
   use parbeam, only : beam_expflag,beam_expfile_open
   use mod_common
   use mod_commons
-  use mod_common_track, only : xxtr,yytr,issss,tasm,comt_daStart,comt_daEnd
+  use mod_common_track, only : xxtr,yytr,crois,tasm,comt_daStart,comt_daEnd
   use mod_common_da
   use mod_commond2
   use wire
@@ -122,8 +122,8 @@ subroutine umlauda
     endif
   endif
   if(ichromc.eq.1) then
-    ed1=ed(issss(1))
-    ed2=ed(issss(2))
+    ed1=ed(crois(1))
+    ed2=ed(crois(2))
   endif
   call davar(x(1),ox,1)
   oxp1=oxp*(one+dps1)
@@ -1218,9 +1218,9 @@ subroutine umlauda
       endif
     endif
     if(ichromc.eq.1) then
-      if(ix.eq.issss(1).or.iratioe(ix).eq.issss(1)) then
+      if(ix.eq.crois(1).or.iratioe(ix).eq.crois(1)) then
         ipch=1
-      else if(ix.eq.issss(2).or.iratioe(ix).eq.issss(2)) then
+      else if(ix.eq.crois(2).or.iratioe(ix).eq.crois(2)) then
         ipch=2
       endif
     endif
@@ -2170,7 +2170,7 @@ subroutine errff(xx,yy,wx,wy)
   use parpro
   use mod_common
   use mod_commons
-  use mod_common_track, only : xxtr,yytr,issss,comt_daStart,comt_daEnd
+  use mod_common_track, only : xxtr,yytr,crois,comt_daStart,comt_daEnd
   use mod_common_da
   use mod_lie_dab, only : idao,iscrri,rscrri,iscrda
   implicit none
@@ -2312,7 +2312,7 @@ subroutine wireda(ix,i)
   use parpro
   use mod_common
   use mod_commons
-  use mod_common_track, only : xxtr,yytr,issss,comt_daStart,comt_daEnd
+  use mod_common_track, only : xxtr,yytr,crois,comt_daStart,comt_daEnd
   use mod_common_da
   use wire
   use mod_lie_dab, only : idao,rscrri,iscrda

--- a/source/sixtrack.f90
+++ b/source/sixtrack.f90
@@ -3002,7 +3002,7 @@ subroutine chroma
           suxy=zero
           suzy=zero
           do 30 l=1,2
-            isl=is(l)
+            isl=crois(l)
             if(kz(isl).ne.3) then
               write(lerr,"(a)") "CHROMA> ERROR Element specified for chromaticity correction is not a sextupole."
               call prror
@@ -3029,7 +3029,7 @@ subroutine chroma
             suzy=suzy+oz*dpp
    40     continue
           do 50 l=1,2
-            isl=is(l)
+            isl=crois(l)
             ed(isl)=ed(isl)-dsm(l,ii)
             if(kp(isl).eq.5) call combel(isl)
    50     continue
@@ -3052,8 +3052,8 @@ subroutine chroma
             dm(2)=(cro0(1)*zi(1)-cro0(2)*xi(1))/det                      !hr06
 
             do l=1,2
-              sm0(l)=ed(is(l))
-              isl=is(l)
+              sm0(l)=ed(crois(l))
+              isl=crois(l)
               ed(isl)=ed(isl)+dm(l)
               if(kp(isl).eq.5) call combel(isl)
             end do
@@ -3065,8 +3065,7 @@ subroutine chroma
         write(lout,10020) sens(1,1),sens(1,4),sens(2,1),sens(2,4)
         chromc(1)=sens(1,4)*c1m3
         chromc(2)=sens(2,4)*c1m3
-        write(lout,10030) sm0(1),ed(is(1)),bez(is(1)), sm0(2),ed(is(2)),&
-     &bez(is(2))
+        write(lout,10030) sm0(1),ed(crois(1)),bez(crois(1)),sm0(2),ed(crois(2)),bez(crois(2))
         write(lout,10040) xi,zi
         write(lout,10010)
         if(abs(sens(1,4)-cro(1)).lt.dech.and.abs(sens(2,4)-cro(2))      &
@@ -3122,8 +3121,8 @@ subroutine chromda
 #include "include/beamcou.f90"
       endif
       ncorru=ncorruo
-      iq1=is(1)
-      iq2=is(2)
+      iq1=crois(1)
+      iq2=crois(2)
       edcor(1)=ed(iq1)
       edcor(2)=ed(iq2)
       edcor1=edcor(1)

--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -1595,17 +1595,15 @@ subroutine sixin_parseInputLineCHRO(inLine, iLine, iErr)
   use mod_settings
   use mod_common
   use mod_common_track
+  use mod_find
 
   character(len=*), intent(in)    :: inLine
   integer,          intent(inout) :: iLine
   logical,          intent(inout) :: iErr
 
   character(len=:), allocatable   :: lnSplit(:)
-  character(len=mNameLen)         :: tmp_is(2)
-  integer nSplit,i,ichrom0
+  integer nSplit,i
   logical spErr
-
-  save :: tmp_is,ichrom0
 
   call chr_split(inLine, lnSplit, nSplit, spErr)
   if(spErr) then
@@ -1613,47 +1611,53 @@ subroutine sixin_parseInputLineCHRO(inLine, iLine, iErr)
     iErr = .true.
     return
   end if
+  if(nSplit == 0) return
 
   select case(iLine)
 
   case(1)
 
-    ichrom0   = 0
-    tmp_is(:) = " "
+    if(nSplit > 1) call chr_cast(lnSplit(2),cro(1), iErr)
+    if(nSplit > 2) call chr_cast(lnSplit(3),ichrom, iErr)
 
-    if(nSplit > 0) tmp_is(1) = lnSplit(1)
-    if(nSplit > 1) call chr_cast(lnSplit(2),cro(1),   iErr)
-    if(nSplit > 2) call chr_cast(lnSplit(3),ichrom0,  iErr)
+    crois(1) = find_singElemFromName(lnSplit(1))
+    if(crois(1) <= 0) then
+      write(lerr,"(a)") "CHRO> ERROR Element '"//trim(lnSplit(1))//"' not in single elements list"
+      iErr = .true.
+      return
+    end if
+
+    if(ichrom < 1 .or. ichrom > 3) then
+      write(lerr,"(a,i0)") "CHRO> ERROR Chromaticity calculation flag ichrom must be 1, 2 or 3, got ",ichrom
+      iErr = .true.
+      return
+    end if
 
     if(st_debug) then
-      call sixin_echoVal("bez_is(1)",tmp_is(1),"CHRO",iLine)
-      call sixin_echoVal("cro(1)",   cro(1),   "CHRO",iLine)
-      call sixin_echoVal("ichrom0",  ichrom0,  "CHRO",iLine)
+      call sixin_echoVal("bez_is(1)",lnSplit(1),"CHRO",iLine)
+      call sixin_echoVal("crois(1)", crois(1),  "CHRO",iLine)
+      call sixin_echoVal("cro(1)",   cro(1),    "CHRO",iLine)
+      call sixin_echoVal("ichrom",   ichrom,    "CHRO",iLine)
     end if
     if(iErr) return
 
   case(2)
 
-    if(nSplit > 0) tmp_is(2) = lnSplit(1)
-    if(nSplit > 1) call chr_cast(lnSplit(2),cro(2),   iErr)
+    if(nSplit > 1) call chr_cast(lnSplit(2),cro(2), iErr)
+
+    crois(2) = find_singElemFromName(lnSplit(1))
+    if(crois(2) <= 0) then
+      write(lerr,"(a)") "CHRO> ERROR Element '"//trim(lnSplit(1))//"' not in single elements list"
+      iErr = .true.
+      return
+    end if
 
     if(st_debug) then
-      call sixin_echoVal("bez_is(2)",tmp_is(2),"CHRO",iLine)
-      call sixin_echoVal("cro(1)",   cro(2),   "CHRO",iLine)
+      call sixin_echoVal("bez_is(2)",lnSplit(1),"CHRO",iLine)
+      call sixin_echoVal("crois(2)", crois(2),  "CHRO",iLine)
+      call sixin_echoVal("cro(2)",   cro(2),    "CHRO",iLine)
     end if
     if(iErr) return
-
-    do i=1,il
-      if(tmp_is(1) == bez(i)) crois(1) = i
-      if(tmp_is(2) == bez(i)) crois(2) = i
-    end do
-    if(ichrom0 >= 1 .and. ichrom0 <= 3) ichrom = ichrom0
-
-    if(st_debug) then
-      call sixin_echoVal("crois(1)", crois(1), "CHRO",iLine)
-      call sixin_echoVal("crois(2)", crois(2), "CHRO",iLine)
-      call sixin_echoVal("ichrom",ichrom,"CHRO",iLine)
-    end if
 
   case default
     write(lerr,"(a,i0)") "CHRO> ERROR Unexpected line number ",iLine

--- a/source/sixtrack_input.f90
+++ b/source/sixtrack_input.f90
@@ -1585,7 +1585,8 @@ end subroutine sixin_parseInputLineDIFF
 ! ================================================================================================ !
 !  Parse Chromaticity Adjustment Line
 !  Rewritten from code from DATEN by VKBO
-!  Last modified: 2018-06-xx
+!  Rewritten: 2018-06
+!  Updated:   2019-06-07
 ! ================================================================================================ !
 subroutine sixin_parseInputLineCHRO(inLine, iLine, iErr)
 
@@ -1600,7 +1601,7 @@ subroutine sixin_parseInputLineCHRO(inLine, iLine, iErr)
   logical,          intent(inout) :: iErr
 
   character(len=:), allocatable   :: lnSplit(:)
-  character(len=mNameLen)      :: tmp_is(2)
+  character(len=mNameLen)         :: tmp_is(2)
   integer nSplit,i,ichrom0
   logical spErr
 
@@ -1643,14 +1644,14 @@ subroutine sixin_parseInputLineCHRO(inLine, iLine, iErr)
     if(iErr) return
 
     do i=1,il
-      if(tmp_is(1) == bez(i)) is(1) = i
-      if(tmp_is(2) == bez(i)) is(2) = i
+      if(tmp_is(1) == bez(i)) crois(1) = i
+      if(tmp_is(2) == bez(i)) crois(2) = i
     end do
     if(ichrom0 >= 1 .and. ichrom0 <= 3) ichrom = ichrom0
 
     if(st_debug) then
-      call sixin_echoVal("is(1)", is(1), "CHRO",iLine)
-      call sixin_echoVal("is(2)", is(2), "CHRO",iLine)
+      call sixin_echoVal("crois(1)", crois(1), "CHRO",iLine)
+      call sixin_echoVal("crois(2)", crois(2), "CHRO",iLine)
       call sixin_echoVal("ichrom",ichrom,"CHRO",iLine)
     end if
 


### PR DESCRIPTION
The input parsing was pretty dodgy here. No checks that the elements exist (although this is done later in the code) and no check that the main block flag `ichrom` was set to a valid value.

Flag `ichrom = 3` was not documented in the manual. It has been added.

Also added a few lattice search routines from a different PR, but due to circular dependencies added them to a new module `mod_find`. I am planning to add more here in the future.

In addition, I renamed the global variable `is` to `crois` as it already has name conflicts with some da variables. There was already a da-version of it called `issss`. The variables hold the indices of the single elements selected in the `CHRO` block.