### PR TITLE
Test suite fixes with new DIST block tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,6 +546,9 @@ if(32BITM)
   if(CRLIBM)
     message(FATAL_ERROR "Cannot use CRLIBM with single precision math.")
   endif(CRLIBM)
+  if(DISTLIB)
+    message(FATAL_ERROR "Cannot use DISTLIB with single precision math.")
+  endif(DISTLIB)
 endif(32BITM)
 
 if(64BITM)
@@ -570,13 +573,16 @@ if(128BITM)
   if(CRLIBM)
     message(FATAL_ERROR "Cannot use CRLIBM with quad precision math.")
   endif(CRLIBM)
+  if(DISTLIB)
+    message(FATAL_ERROR "Cannot use DISTLIB with quad precision math.")
+  endif(DISTLIB)
 endif(128BITM)
 
 if(NOT SIXDA)
   message(STATUS "Not building SixDA version.")
 endif(NOT SIXDA)
 
-# Since each AVX option includes the others, just turn the lower ones off
+# Since each AVX option includes the lower obes, just turn the lower flags off to avoid duplication
 if(AVX512_SKYLAKE)
   set(AVX OFF)
   set(AVX2 OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -582,7 +582,7 @@ if(NOT SIXDA)
   message(STATUS "Not building SixDA version.")
 endif(NOT SIXDA)
 
-# Since each AVX option includes the lower obes, just turn the lower flags off to avoid duplication
+# Since each AVX option includes the lower ones, just turn the lower flags off to avoid duplication
 if(AVX512_SKYLAKE)
   set(AVX OFF)
   set(AVX2 OFF)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -221,7 +221,7 @@ if(PYTHIA)
   )
 endif()
 
-if(DISTLIB)
+if(DISTLIB AND STF)
   list(APPEND SIXTRACK_TESTS
     distlib_normalised
     distlib_tmatrix

--- a/test/dist_file_6d/extra_inputs.txt
+++ b/test/dist_file_6d/extra_inputs.txt
@@ -1,0 +1,1 @@
+partDist.dat


### PR DESCRIPTION
Some build options and tests failed on the nightly.

* DISTlib does not work with single or quad math. Since we're using intent(inout) in the interface, it's not as trivial as casting the values to double on the way in. Therefore DISTlib must be disabled when running single or quad.
* The tests for DISTlib cannot be run when STF flag is off as they have more than 64 particles.
* One test was missing extra_inputs.txt for BOINC.