### PR TITLE
Compact DUMP TAS

### DIFF
--- a/source/dump.f90
+++ b/source/dump.f90
@@ -107,9 +107,9 @@ subroutine dump_setTasMatrix(elemID, tasData, cloData)
   use mod_common, only : bez
   use mod_settings
 
-  integer,          intent(in) :: elemID
-  real(kind=fPrec), intent(in) :: tasData(6,6)
-  real(kind=fPrec), intent(in) :: cloData(6)
+  integer,          intent(in) :: elemID       ! Single element index
+  real(kind=fPrec), intent(in) :: tasData(6,6) ! Tas matrix with consistent units (no mm scaling)
+  real(kind=fPrec), intent(in) :: cloData(6)   ! Closed orbit
 
   type(dump_normType), allocatable :: tmpNorm(:)
   real(kind=fPrec) invData(6,6)
@@ -131,7 +131,7 @@ subroutine dump_setTasMatrix(elemID, tasData, cloData)
       if(elemID > 0) then
         write(lout,"(a,i0,a)") "DUMP> Saving normalisation matrix for element ",elemID," '"//trim(bez(elemID))//"'"
       else if(elemID == -1) then
-        write(lout,"(a)") "DUMP> Saving normalisation matrix for element 'StartDUMP'"
+        write(lout,"(a)") "DUMP> Saving normalisation matrix for element -1 'StartDUMP'"
       end if
     end if
   else
@@ -140,7 +140,7 @@ subroutine dump_setTasMatrix(elemID, tasData, cloData)
       if(elemID > 0) then
         write(lout,"(a,i0,a)") "DUMP> Updating normalisation matrix for element ",elemID," '"//trim(bez(elemID))//"'"
       else if(elemID == -1) then
-        write(lout,"(a)") "DUMP> Updating normalisation matrix for element 'StartDUMP'"
+        write(lout,"(a)") "DUMP> Updating normalisation matrix for element -1 'StartDUMP'"
       end if
     end if
   end if

--- a/source/fma.f90
+++ b/source/fma.f90
@@ -155,21 +155,16 @@ subroutine fma_postpr
   logical spErr, fErr, cErr, isOpen, fExist
   integer i,j,k,l,m,n
 
-  ! Current turn no (particle, rel. turn no)
-  integer, allocatable :: turn(:,:)
-  ! Number of turns to analyze for this particle
-  integer, allocatable :: nturns(:)
-  ! Have we written a normDump file for this element before?
-  logical, allocatable :: hasNormDumped(:)
-  ! Number of turns used for fft for this FMA
-  integer, allocatable :: fma_nturn(:)
-  ! Phase space variables (x,x',y,y',z,dE/E) [mm,mrad,mm,mrad,mm,1.e-3]
-  real(kind=fPrec), allocatable :: xyzv(:,:,:)
-  ! Normalised phase space variables [sqrt(m) 1.e-3]
-  real(kind=fPrec), allocatable :: nxyzv(:,:,:)
-  ! Normalised emittances
-  real(kind=fPrec), allocatable :: epsnxyzv(:,:,:)
-  real(kind=fPrec) dumptas(6,6), dumpclo(6), dumptasinv(6,6)
+  integer,          allocatable :: turn(:,:)        ! Current turn no (particle, rel. turn no)
+  integer,          allocatable :: nturns(:)        ! Number of turns to analyze for this particle
+  logical,          allocatable :: hasNormDumped(:) ! Have we written a normDump file for this element before?
+  integer,          allocatable :: fma_nturn(:)     ! Number of turns used for fft for this FMA
+  real(kind=fPrec), allocatable :: xyzv(:,:,:)      ! Phase space variables (x,x',y,y',z,dE/E) [mm,mrad,mm,mrad,mm,1.e-3]
+  real(kind=fPrec), allocatable :: nxyzv(:,:,:)     ! Normalised phase space variables [sqrt(m) 1.e-3]
+  real(kind=fPrec), allocatable :: epsnxyzv(:,:,:)  ! Normalised emittances
+  real(kind=fPrec) dumptas(6,6)    ! Local copy of tas matrix from DUMP
+  real(kind=fPrec) dumptasinv(6,6) ! Local copy of inverse tas matrix from DUMP
+  real(kind=fPrec) dumpclo(6)      ! Local copy of closed orbit from DUMP
 
 #ifdef NAFF
   interface

--- a/source/fma.f90
+++ b/source/fma.f90
@@ -136,7 +136,7 @@ subroutine fma_postpr
   use string_tools
   use mathlib_bouncer
   use platofma
-  use dump, only : dump_fname, dumpfmt, dumpunit, dumpfirst, dumplast, dumptas, dumpclo, dumptasinv
+  use dump, only : dump_fname, dumpfmt, dumpunit, dumpfirst, dumplast, dump_getTasMatrix
   use numerical_constants, only : zero, one, c1e3
 
   use crcoall
@@ -169,10 +169,11 @@ subroutine fma_postpr
   real(kind=fPrec), allocatable :: nxyzv(:,:,:)
   ! Normalised emittances
   real(kind=fPrec), allocatable :: epsnxyzv(:,:,:)
+  real(kind=fPrec) dumptas(6,6), dumpclo(6), dumptasinv(6,6)
 
 #ifdef NAFF
   interface
-    real(c_double) function tunenaff(x,xp,maxn,plane_idx,norm_flag, fft_naff) bind(c)
+    real(c_double) function tunenaff(x,xp,maxn,plane_idx,norm_flag,fft_naff) bind(c)
       use, intrinsic :: iso_c_binding
       implicit none
       real(c_double), intent(in), dimension(1) :: x,xp
@@ -231,13 +232,13 @@ subroutine fma_postpr
     fExist = .false.
     do j=-1,nele ! START: loop over dump files = loop over single elements
       if(fma_fname(i) == dump_fname(j)) then
+        call dump_getTasMatrix(j,dumptasinv,dumptas, dumpclo)
         fExist = .true.
         write(lout,"(3(a,i0))") "FMA> Start FMA analysis using file '"//trim(fma_fname(i))//&
           "': Number of particles = ",napx,", first turn = ",fma_first(i),", last turn = ",fma_last(i)
 
         ! Check the format, if dumpfmt != 2,3 (physical) or 7,8 (normalised) then abort
-        if(.not.(dumpfmt(j) == 2 .or. dumpfmt(j) == 3 .or. &
-                 dumpfmt(j) == 7 .or. dumpfmt(j) == 8)) then
+        if(.not.(dumpfmt(j) == 2 .or. dumpfmt(j) == 3 .or. dumpfmt(j) == 7 .or. dumpfmt(j) == 8)) then
           write(lerr,"(a)") "FMA> ERROR Input file has wrong format. Choose format 2, 3, 7 or 8 in DUMP block."
           call prror
         end if
@@ -356,8 +357,8 @@ subroutine fma_postpr
         else ! Reading physical coordinates
           if(fma_norm_flag(i) == 1 ) then
             ! Have a matrix that's not zero (i.e. did we put a 6d LINE block?)
-            if(dumptas(j,1,1) == zero .and. dumptas(j,1,2) == zero .and. &
-                dumptas(j,1,3) == zero .and. dumptas(j,1,4) == zero) then
+            if(dumptas(1,1) == zero .and. dumptas(1,2) == zero .and. &
+               dumptas(1,3) == zero .and. dumptas(1,4) == zero) then
               write(lerr,"(a)") "FMA> ERROR The normalisation matrix appears to not be set? Did you forget to put a 6D LINE block?"
               call prror
             end if
@@ -391,35 +392,35 @@ subroutine fma_postpr
           ! - write closed orbit in header of file with normalised phase space coordinates (tmpUnit)
           !   units: x,xp,y,yp,sig,dp/p = [mm,mrad,mm,mrad,1] (note: units are already changed in linopt part)
           write(tmpUnit,"(a,1x,6(1x,1pe16.9))") "# closorb", &
-            dumpclo(j,1),dumpclo(j,2),dumpclo(j,3), &
-            dumpclo(j,4),dumpclo(j,5),dumpclo(j,6)
+            dumpclo(1),dumpclo(2),dumpclo(3), &
+            dumpclo(4),dumpclo(5),dumpclo(6)
 
           ! - write tas-matrix and its inverse in header of file with normalised phase space coordinates (tmpUnit)
           !   units: x,px,y,py,sig,dp/p [mm,mrad,mm,mrad,1]
           write(tmpUnit,"(a,1x,36(1x,1pe16.9))") "# tamatrix [mm,mrad,mm,mrad,1]", &
-            dumptas(j,1,1),dumptas(j,1,2),dumptas(j,1,3),dumptas(j,1,4), &
-            dumptas(j,1,5),dumptas(j,1,6),dumptas(j,2,1),dumptas(j,2,2), &
-            dumptas(j,2,3),dumptas(j,2,4),dumptas(j,2,5),dumptas(j,2,6), &
-            dumptas(j,3,1),dumptas(j,3,2),dumptas(j,3,3),dumptas(j,3,4), &
-            dumptas(j,3,5),dumptas(j,3,6),dumptas(j,4,1),dumptas(j,4,2), &
-            dumptas(j,4,3),dumptas(j,4,4),dumptas(j,4,5),dumptas(j,4,6), &
-            dumptas(j,5,1),dumptas(j,5,2),dumptas(j,5,3),dumptas(j,5,4), &
-            dumptas(j,5,5),dumptas(j,5,6),dumptas(j,6,1),dumptas(j,6,2), &
-            dumptas(j,6,3),dumptas(j,6,4),dumptas(j,6,5),dumptas(j,6,6)
+            dumptas(1,1),dumptas(1,2),dumptas(1,3),dumptas(1,4), &
+            dumptas(1,5),dumptas(1,6),dumptas(2,1),dumptas(2,2), &
+            dumptas(2,3),dumptas(2,4),dumptas(2,5),dumptas(2,6), &
+            dumptas(3,1),dumptas(3,2),dumptas(3,3),dumptas(3,4), &
+            dumptas(3,5),dumptas(3,6),dumptas(4,1),dumptas(4,2), &
+            dumptas(4,3),dumptas(4,4),dumptas(4,5),dumptas(4,6), &
+            dumptas(5,1),dumptas(5,2),dumptas(5,3),dumptas(5,4), &
+            dumptas(5,5),dumptas(5,6),dumptas(6,1),dumptas(6,2), &
+            dumptas(6,3),dumptas(6,4),dumptas(6,5),dumptas(6,6)
 
           write(tmpUnit,"(a,1x,36(1x,1pe16.9))") "# inv(tamatrix)", &
-            dumptasinv(j,1,1),dumptasinv(j,1,2),dumptasinv(j,1,3), &
-            dumptasinv(j,1,4),dumptasinv(j,1,5),dumptasinv(j,1,6), &
-            dumptasinv(j,2,1),dumptasinv(j,2,2),dumptasinv(j,2,3), &
-            dumptasinv(j,2,4),dumptasinv(j,2,5),dumptasinv(j,2,6), &
-            dumptasinv(j,3,1),dumptasinv(j,3,2),dumptasinv(j,3,3), &
-            dumptasinv(j,3,4),dumptasinv(j,3,5),dumptasinv(j,3,6), &
-            dumptasinv(j,4,1),dumptasinv(j,4,2),dumptasinv(j,4,3), &
-            dumptasinv(j,4,4),dumptasinv(j,4,5),dumptasinv(j,4,6), &
-            dumptasinv(j,5,1),dumptasinv(j,5,2),dumptasinv(j,5,3), &
-            dumptasinv(j,5,4),dumptasinv(j,5,5),dumptasinv(j,5,6), &
-            dumptasinv(j,6,1),dumptasinv(j,6,2),dumptasinv(j,6,3), &
-            dumptasinv(j,6,4),dumptasinv(j,6,5),dumptasinv(j,6,6)
+            dumptasinv(1,1),dumptasinv(1,2),dumptasinv(1,3), &
+            dumptasinv(1,4),dumptasinv(1,5),dumptasinv(1,6), &
+            dumptasinv(2,1),dumptasinv(2,2),dumptasinv(2,3), &
+            dumptasinv(2,4),dumptasinv(2,5),dumptasinv(2,6), &
+            dumptasinv(3,1),dumptasinv(3,2),dumptasinv(3,3), &
+            dumptasinv(3,4),dumptasinv(3,5),dumptasinv(3,6), &
+            dumptasinv(4,1),dumptasinv(4,2),dumptasinv(4,3), &
+            dumptasinv(4,4),dumptasinv(4,5),dumptasinv(4,6), &
+            dumptasinv(5,1),dumptasinv(5,2),dumptasinv(5,3), &
+            dumptasinv(5,4),dumptasinv(5,5),dumptasinv(5,6), &
+            dumptasinv(6,1),dumptasinv(6,2),dumptasinv(6,3), &
+            dumptasinv(6,4),dumptasinv(6,5),dumptasinv(6,6)
 
           write(tmpUnit,"(a)") "# id turn pos[m] nx[1.e-3 sqrt(m)] npx[1.e-3 sqrt(m)] ny[1.e-3 sqrt(m)] "//&
             "npy[1.e-3 sqrt(m)] nsig[1.e-3 sqrt(m)] ndp/p[1.e-3 sqrt(m)] kt"
@@ -497,18 +498,18 @@ subroutine fma_postpr
 
               ! remove closed orbit -> check units used in dumpclo (is x' or px used?)
               do m=1,6
-                xyzvdummy2(m)=xyzvdummy(m)-dumpclo(j,m)
+                xyzvdummy2(m)=xyzvdummy(m)-dumpclo(m)
               end do
 
               ! For use in with normalised coordinates: convert to canonical variables
-              xyzvdummy2(2)=xyzvdummy2(2) * ((one+xyzvdummy2(6))+dumpclo(j,6))
-              xyzvdummy2(4)=xyzvdummy2(4) * ((one+xyzvdummy2(6))+dumpclo(j,6))
+              xyzvdummy2(2)=xyzvdummy2(2) * ((one+xyzvdummy2(6))+dumpclo(6))
+              xyzvdummy2(4)=xyzvdummy2(4) * ((one+xyzvdummy2(6))+dumpclo(6))
 
               ! Normalise nxyz=dumptasinv*xyz2
               do m=1,6
                 nxyzvdummy(m)=zero
                 do n=1,6
-                  nxyzvdummy(m)=nxyzvdummy(m) + dumptasinv(j,m,n)*xyzvdummy2(n)
+                  nxyzvdummy(m)=nxyzvdummy(m) + dumptasinv(m,n)*xyzvdummy2(n)
                 end do
                 ! convert nxyzvdummy(6) to 1.e-3 sqrt(m)
                 ! unit: nx,npx,ny,npy,nsig,ndelta all in [1.e-3 sqrt(m)]

--- a/source/include/umlalid.f90
+++ b/source/include/umlalid.f90
@@ -94,10 +94,10 @@ do j=1,ndimf
   call dapek(damap(ii),jj,au(i3,i3))
   jj(i3)=0
 
-!     Store tas matrix (normalisation of phase space) and closed orbit for FMA and DUMP normalization.
-!     Variable added to DUMP block module variables;
-!     units dumptas: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
-  if(ic(i)-nblo.gt.0) then !check if structure element is a block
+  ! Store tas matrix (normalisation of phase space) and closed orbit for FMA and DUMP normalization.
+  ! Variable added to DUMP block module variables;
+  ! units tasData: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
+  if(ic(i)-nblo > 0) then !check if structure element is a block
     if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
       tasData(ii-1,ii-1) = angp(1,ii-1)
       tasData(ii-1,ii  ) = angp(1,ii)
@@ -111,36 +111,17 @@ do j=1,ndimf
       tasData(ii  ,i3-1) = au(i3  ,i3-1)
       tasData(ii-1,i3  ) = au(i3-1,i3  )
       tasData(ii  ,i3  ) = au(i3  ,i3  )
+      ! closed orbit in canonical variables x,px,y,py,sig,delta [mm,mrad,mm,mrad,mm,1.e-3]
+      ! convert to x,xp,y,yp,sig,delta [mm,mrad,mm,mrad,mm,1]
+      !  -> check units used in dumpclo (is x' or px used?)
       cloData(2*j-1) = c(j)
       if(j == 3) then ! dp/p
         cloData(2*j) = cp(j)*c1m3
       else ! xp,yp
         cloData(2*j) = cp(j)/(one+cp(3)*c1m3)
       end if
-
-      dumptas(ic(i)-nblo,ii-1,ii-1)=angp(1,ii-1)
-      dumptas(ic(i)-nblo,ii-1,ii  )=angp(1,ii)
-      dumptas(ic(i)-nblo,ii  ,ii-1)=au(ii,ii-1)
-      dumptas(ic(i)-nblo,ii  ,ii  )=au(ii,ii  )
-      dumptas(ic(i)-nblo,ii-1,i2-1)=au(i2-1,i2-1)
-      dumptas(ic(i)-nblo,ii  ,i2-1)=au(i2  ,i2-1)
-      dumptas(ic(i)-nblo,ii-1,i2  )=au(i2-1,i2  )
-      dumptas(ic(i)-nblo,ii  ,i2  )=au(i2  ,i2  )
-      dumptas(ic(i)-nblo,ii-1,i3-1)=au(i3-1,i3-1)
-      dumptas(ic(i)-nblo,ii  ,i3-1)=au(i3  ,i3-1)
-      dumptas(ic(i)-nblo,ii-1,i3  )=au(i3-1,i3  )
-      dumptas(ic(i)-nblo,ii  ,i3  )=au(i3  ,i3  )
-!    closed orbit in canonical variables x,px,y,py,sig,delta [mm,mrad,mm,mrad,mm,1.e-3]
-!    convert to x,xp,y,yp,sig,delta [mm,mrad,mm,mrad,mm,1]
-!     -> check units used in dumpclo (is x' or px used?)
-      dumpclo(ic(i)-nblo,2*j-1)=c(j)
-      if (j.eq.3) then !dp/p
-        dumpclo(ic(i)-nblo,2*j)  =cp(j)*c1m3
-      else ! xp,yp
-        dumpclo(ic(i)-nblo,2*j)  =cp(j)/(one+cp(3)*c1m3)
-      endif
-    endif
-  endif
+    end if
+  end if
 
   b1(j)=angp(1,ii-1)**2+angp(1,ii)**2                          !hr08
   b2(j)=au(i2-1,i2-1)**2+au(i2-1,i2)**2                        !hr08
@@ -177,21 +158,12 @@ enddo ! end include/of optics calculation
 
 if(ic(i)-nblo > 0) then !check if structure element is a block
   if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
-
-!     do the unit conversion + inversion of dumptas
-!     convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
-
-    dumptas(ic(i)-nblo,1:5,6)=dumptas(ic(i)-nblo,1:5,6)*c1e3
-    dumptas(ic(i)-nblo,6,1:5)=dumptas(ic(i)-nblo,6,1:5)*c1m3
-
-!     invert the tas matrix
-    call invert_tas(dumptasinv(ic(i)-nblo,:,:),dumptas(ic(i)-nblo,:,:))
-!     dumptas and dumptasinv are now in units [mm,mrad,mm,mrad,1]
-
+    ! do the unit conversion + inversion of tasData
+    ! convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
+    ! tasData is now in units [mm,mrad,mm,mrad,1]
     tasData(1:5,6) = tasData(1:5,6)*c1e3
     tasData(6,1:5) = tasData(6,1:5)*c1m3
     call dump_setTasMatrix(ic(i)-nblo, tasData, cloData)
-
   end if
 end if
 

--- a/source/include/umlalid.f90
+++ b/source/include/umlalid.f90
@@ -94,9 +94,7 @@ do j=1,ndimf
   call dapek(damap(ii),jj,au(i3,i3))
   jj(i3)=0
 
-  ! Store tas matrix (normalisation of phase space) and closed orbit for FMA and DUMP normalization.
-  ! Variable added to DUMP block module variables;
-  ! Units tasData: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
+  ! Store tas matrix (normalisation of phase space) and closed orbit for FMA and DUMP normalisation.
   if(ic(i)-nblo > 0) then ! Check if structure element is a block
     if(ldump(ic(i)-nblo)) then ! Check if particles are dumped at this element
       tasData(ii-1,ii-1) = angp(1,ii-1)
@@ -111,9 +109,10 @@ do j=1,ndimf
       tasData(ii  ,i3-1) = au(i3  ,i3-1)
       tasData(ii-1,i3  ) = au(i3-1,i3  )
       tasData(ii  ,i3  ) = au(i3  ,i3  )
-      ! closed orbit in canonical variables x,px,y,py,sig,delta [mm,mrad,mm,mrad,mm,1.e-3]
+      ! Closed orbit in canonical variables x,px,y,py,sig,delta [mm,mrad,mm,mrad,mm,1.e-3]
       ! convert to x,xp,y,yp,sig,delta [mm,mrad,mm,mrad,mm,1]
       !  -> check units used in dumpclo (is x' or px used?)
+      ! Note: this needs to be checked again. sigm is not canonical
       cloData(2*j-1) = c(j)
       if(j == 3) then ! dp/p
         cloData(2*j) = cp(j)*c1m3
@@ -123,43 +122,42 @@ do j=1,ndimf
     end if
   end if
 
-  b1(j)=angp(1,ii-1)**2+angp(1,ii)**2                          !hr08
-  b2(j)=au(i2-1,i2-1)**2+au(i2-1,i2)**2                        !hr08
-  b3(j)=au(i3-1,i3-1)**2+au(i3-1,i3)**2                        !hr08
-  al1(j)=-one*(angp(1,ii-1)*au(ii,ii-1)+angp(1,ii)*au(ii,ii))  !hr03
-  al2(j)=-one*(au(i2-1,i2-1)*au(i2,i2-1)+au(i2-1,i2)*au(i2,i2)) !hr03
-  al3(j)=-one*(au(i3-1,i3-1)*au(i3,i3-1)+au(i3-1,i3)*au(i3,i3)) !hr03
-  g1(j)=au(ii,ii-1)**2+au(ii,ii)**2                            !hr04
-  g2(j)=au(i2,i2-1)**2+au(i2,i2)**2                            !hr04
-  g3(j)=au(i3,i3-1)**2+au(i3,i3)**2                            !hr04
-  if(ndimf.eq.3) then
+  b1(j)  = angp(1,ii-1)**2+angp(1,ii)**2
+  b2(j)  = au(i2-1,i2-1)**2+au(i2-1,i2)**2
+  b3(j)  = au(i3-1,i3-1)**2+au(i3-1,i3)**2
+  al1(j) = -one*(angp(1,ii-1)*au(ii,ii-1)+angp(1,ii)*au(ii,ii))
+  al2(j) = -one*(au(i2-1,i2-1)*au(i2,i2-1)+au(i2-1,i2)*au(i2,i2))
+  al3(j) = -one*(au(i3-1,i3-1)*au(i3,i3-1)+au(i3-1,i3)*au(i3,i3))
+  g1(j)  = au(ii,ii-1)**2+au(ii,ii)**2
+  g2(j)  = au(i2,i2-1)**2+au(i2,i2)**2
+  g3(j)  = au(i3,i3-1)**2+au(i3,i3)**2
+  if(ndimf == 3) then
     call dainv(damap,nvar,damapi,nvar)
-    jj(6)=1
+    jj(6) = 1
     call dapek(damapi(5),jj,aui(1))
     call dapek(damapi(6),jj,aui(2))
-    jj(6)=0
-    if(j.lt.3) then
-      d(j)=au(i3-1,i3-1)*aui(1)+au(i3-1,i3)*aui(2)
-      dp(j)=au(i3,i3-1)*aui(1)+au(i3,i3)*aui(2)
+    jj(6) = 0
+    if(j < 3) then
+      d(j)  = au(i3-1,i3-1)*aui(1)+au(i3-1,i3)*aui(2)
+      dp(j) = au(i3,i3-1)*aui(1)+au(i3,i3)*aui(2)
     else
-      d(j)=angp(1,ii-1)*aui(1)+angp(1,ii)*aui(2)
-      dp(j)=au(ii,ii-1)*aui(1)+au(ii,ii)*aui(2)
-    endif
-  endif
-  sx=angp(2,ii-1)*angp(1,ii)-angp(1,ii-1)*angp(2,ii)
-  cx=angp(1,ii-1)*angp(2,ii-1)+angp(1,ii)*angp(2,ii)
-  if(abs(sx).gt.c1m15.or.abs(cx).gt.c1m15) then
-    dphi(j)=atan2_mb(sx,cx)/x2pi
+      d(j)  = angp(1,ii-1)*aui(1)+angp(1,ii)*aui(2)
+      dp(j) = au(ii,ii-1)*aui(1)+au(ii,ii)*aui(2)
+    end if
+  end if
+  sx = angp(2,ii-1)*angp(1,ii)-angp(1,ii-1)*angp(2,ii)
+  cx = angp(1,ii-1)*angp(2,ii-1)+angp(1,ii)*angp(2,ii)
+  if(abs(sx) > c1m15 .or. abs(cx) > c1m15) then
+    dphi(j) = atan2_mb(sx,cx)/x2pi
   else
-    dphi(j)=zero
-  endif
-  phi(j)=phi(j)+dphi(j)
-enddo ! end include/of optics calculation
+    dphi(j) = zero
+  end if
+  phi(j) = phi(j)+dphi(j)
+end do ! end include/of optics calculation
 
 if(ic(i)-nblo > 0) then ! Check if structure element is a block
   if(ldump(ic(i)-nblo)) then ! Check if particles are dumped at this element
-    ! Convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
-    ! tasData is now in units [mm,mrad,mm,mrad,1]
+    ! Fix scaling of the 6th column and row due to the use of mm and mrad elsewhere
     tasData(1:5,6) = tasData(1:5,6)*c1e3
     tasData(6,1:5) = tasData(6,1:5)*c1m3
     call dump_setTasMatrix(ic(i)-nblo, tasData, cloData)

--- a/source/include/umlalid.f90
+++ b/source/include/umlalid.f90
@@ -50,8 +50,8 @@ else
   jj(5)=0
   do j1=1,2
     ii=2*j1
-    d(j1)=(((rdd(ii-1,1)*dicu(1)+rdd(ii-1,2)*dicu(2))+rdd(ii-1,3)*dicu(3))+rdd(ii-1,4)*dicu(4))+rdd(ii-1,5)              !hr03
-    dp(j1)=(((rdd(ii,1)*dicu(1)+rdd(ii,2)*dicu(2))+rdd(ii,3)*dicu(3))+rdd(ii,4)*dicu(4))+rdd(ii,5)                    !hr03
+    d(j1)=(((rdd(ii-1,1)*dicu(1)+rdd(ii-1,2)*dicu(2))+rdd(ii-1,3)*dicu(3))+rdd(ii-1,4)*dicu(4))+rdd(ii-1,5)
+    dp(j1)=(((rdd(ii,1)*dicu(1)+rdd(ii,2)*dicu(2))+rdd(ii,3)*dicu(3))+rdd(ii,4)*dicu(4))+rdd(ii,5)
   enddo
 endif
 call dacct(damap,nvar,aa2,nvar,damap,nvar)
@@ -96,9 +96,9 @@ do j=1,ndimf
 
   ! Store tas matrix (normalisation of phase space) and closed orbit for FMA and DUMP normalization.
   ! Variable added to DUMP block module variables;
-  ! units tasData: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
-  if(ic(i)-nblo > 0) then !check if structure element is a block
-    if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
+  ! Units tasData: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
+  if(ic(i)-nblo > 0) then ! Check if structure element is a block
+    if(ldump(ic(i)-nblo)) then ! Check if particles are dumped at this element
       tasData(ii-1,ii-1) = angp(1,ii-1)
       tasData(ii-1,ii  ) = angp(1,ii)
       tasData(ii  ,ii-1) = au(ii,ii-1)
@@ -156,10 +156,9 @@ do j=1,ndimf
   phi(j)=phi(j)+dphi(j)
 enddo ! end include/of optics calculation
 
-if(ic(i)-nblo > 0) then !check if structure element is a block
-  if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
-    ! do the unit conversion + inversion of tasData
-    ! convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
+if(ic(i)-nblo > 0) then ! Check if structure element is a block
+  if(ldump(ic(i)-nblo)) then ! Check if particles are dumped at this element
+    ! Convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
     ! tasData is now in units [mm,mrad,mm,mrad,1]
     tasData(1:5,6) = tasData(1:5,6)*c1e3
     tasData(6,1:5) = tasData(6,1:5)*c1m3

--- a/source/include/umlalid.f90
+++ b/source/include/umlalid.f90
@@ -98,6 +98,29 @@ do j=1,ndimf
 !     units dumptas: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
   if(ic(i)-nblo.gt.0) then !check if structure element is a block
     if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
+      block
+        real(kind=fPrec) tasData(6,6)
+        real(kind=fPrec) cloData(6)
+        tasData(ii-1,ii-1) = angp(1,ii-1)
+        tasData(ii-1,ii  ) = angp(1,ii)
+        tasData(ii  ,ii-1) = au(ii,ii-1)
+        tasData(ii  ,ii  ) = au(ii,ii  )
+        tasData(ii-1,i2-1) = au(i2-1,i2-1)
+        tasData(ii  ,i2-1) = au(i2  ,i2-1)
+        tasData(ii-1,i2  ) = au(i2-1,i2  )
+        tasData(ii  ,i2  ) = au(i2  ,i2  )
+        tasData(ii-1,i3-1) = au(i3-1,i3-1)
+        tasData(ii  ,i3-1) = au(i3  ,i3-1)
+        tasData(ii-1,i3  ) = au(i3-1,i3  )
+        tasData(ii  ,i3  ) = au(i3  ,i3  )
+        cloData(2*j-1) = c(j)
+        if(j == 3) then ! dp/p
+          cloData(2*j) = cp(j)*c1m3
+        else ! xp,yp
+          cloData(2*j) = cp(j)/(one+cp(3)*c1m3)
+        end if
+        call dump_setTasMatrix(ic(i)-nblo, tasData, cloData)
+      end block
       dumptas(ic(i)-nblo,ii-1,ii-1)=angp(1,ii-1)
       dumptas(ic(i)-nblo,ii-1,ii  )=angp(1,ii)
       dumptas(ic(i)-nblo,ii  ,ii-1)=au(ii,ii-1)

--- a/source/include/umlalid.f90
+++ b/source/include/umlalid.f90
@@ -1,3 +1,4 @@
+! start include/umlalid.f90
 iwrite=0
 if(nlin.eq.0) then
   iwrite=1
@@ -98,29 +99,25 @@ do j=1,ndimf
 !     units dumptas: mm,mrad,mm,mrad,mm,1.e-3 -> convert later to 1.e3
   if(ic(i)-nblo.gt.0) then !check if structure element is a block
     if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
-      block
-        real(kind=fPrec) tasData(6,6)
-        real(kind=fPrec) cloData(6)
-        tasData(ii-1,ii-1) = angp(1,ii-1)
-        tasData(ii-1,ii  ) = angp(1,ii)
-        tasData(ii  ,ii-1) = au(ii,ii-1)
-        tasData(ii  ,ii  ) = au(ii,ii  )
-        tasData(ii-1,i2-1) = au(i2-1,i2-1)
-        tasData(ii  ,i2-1) = au(i2  ,i2-1)
-        tasData(ii-1,i2  ) = au(i2-1,i2  )
-        tasData(ii  ,i2  ) = au(i2  ,i2  )
-        tasData(ii-1,i3-1) = au(i3-1,i3-1)
-        tasData(ii  ,i3-1) = au(i3  ,i3-1)
-        tasData(ii-1,i3  ) = au(i3-1,i3  )
-        tasData(ii  ,i3  ) = au(i3  ,i3  )
-        cloData(2*j-1) = c(j)
-        if(j == 3) then ! dp/p
-          cloData(2*j) = cp(j)*c1m3
-        else ! xp,yp
-          cloData(2*j) = cp(j)/(one+cp(3)*c1m3)
-        end if
-        call dump_setTasMatrix(ic(i)-nblo, tasData, cloData)
-      end block
+      tasData(ii-1,ii-1) = angp(1,ii-1)
+      tasData(ii-1,ii  ) = angp(1,ii)
+      tasData(ii  ,ii-1) = au(ii,ii-1)
+      tasData(ii  ,ii  ) = au(ii,ii  )
+      tasData(ii-1,i2-1) = au(i2-1,i2-1)
+      tasData(ii  ,i2-1) = au(i2  ,i2-1)
+      tasData(ii-1,i2  ) = au(i2-1,i2  )
+      tasData(ii  ,i2  ) = au(i2  ,i2  )
+      tasData(ii-1,i3-1) = au(i3-1,i3-1)
+      tasData(ii  ,i3-1) = au(i3  ,i3-1)
+      tasData(ii-1,i3  ) = au(i3-1,i3  )
+      tasData(ii  ,i3  ) = au(i3  ,i3  )
+      cloData(2*j-1) = c(j)
+      if(j == 3) then ! dp/p
+        cloData(2*j) = cp(j)*c1m3
+      else ! xp,yp
+        cloData(2*j) = cp(j)/(one+cp(3)*c1m3)
+      end if
+
       dumptas(ic(i)-nblo,ii-1,ii-1)=angp(1,ii-1)
       dumptas(ic(i)-nblo,ii-1,ii  )=angp(1,ii)
       dumptas(ic(i)-nblo,ii  ,ii-1)=au(ii,ii-1)
@@ -178,21 +175,25 @@ do j=1,ndimf
   phi(j)=phi(j)+dphi(j)
 enddo ! end include/of optics calculation
 
-if(ic(i)-nblo.gt.0) then !check if structure element is a block
-   if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
+if(ic(i)-nblo > 0) then !check if structure element is a block
+  if(ldump(ic(i)-nblo)) then !check if particles are dumped at this element
 
 !     do the unit conversion + inversion of dumptas
 !     convert from units [mm,mrad,mm,mrad,1.e-3] to [mm,mrad,mm,mrad,1] as needed for normalization
 
-     dumptas(ic(i)-nblo,1:5,6)=dumptas(ic(i)-nblo,1:5,6)*c1e3
-     dumptas(ic(i)-nblo,6,1:5)=dumptas(ic(i)-nblo,6,1:5)*c1m3
+    dumptas(ic(i)-nblo,1:5,6)=dumptas(ic(i)-nblo,1:5,6)*c1e3
+    dumptas(ic(i)-nblo,6,1:5)=dumptas(ic(i)-nblo,6,1:5)*c1m3
 
 !     invert the tas matrix
-      call invert_tas(dumptasinv(ic(i)-nblo,:,:),dumptas(ic(i)-nblo,:,:))
+    call invert_tas(dumptasinv(ic(i)-nblo,:,:),dumptas(ic(i)-nblo,:,:))
 !     dumptas and dumptasinv are now in units [mm,mrad,mm,mrad,1]
 
-   endif
-endif
+    tasData(1:5,6) = tasData(1:5,6)*c1e3
+    tasData(6,1:5) = tasData(6,1:5)*c1m3
+    call dump_setTasMatrix(ic(i)-nblo, tasData, cloData)
+
+  end if
+end if
 
 do j=1,ndimf
   ii=2*j
@@ -222,3 +223,4 @@ if(iwrite.eq.1) then
   endif
   write(lout,10010)
 endif
+! end include/umlalid.f90

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -23,7 +23,7 @@ program maincr
 
   use dynk,    only : dynk_izuIndex
   use fma,     only : fma_postpr, fma_flag
-  use dump,    only : dump_initialise, dumpclo,dumptas,dumptasinv,dump_setTasMatrix
+  use dump,    only : dump_initialise, dump_setTasMatrix
   use zipf,    only : zipf_numfiles, zipf_dozip
   use scatter, only : scatter_init
 
@@ -731,21 +731,6 @@ program maincr
 
   ! save tas matrix and closed orbit for later dumping of the beam
   ! distribution at the first element (i=-1)
-  ! dumptas(*,*) [mm,mrad,mm,mrad,1] canonical variables
-  ! tas(iar,*,*) [mm,mrad,mm,mrad,1] canonical variables
-  ! clo6v,clop6v [mm,mrad,mm,mrad,1] canonical variables (x' or px?)
-  ! for the initialization of the particles. Only in 5D thick the ta
-  ! matrix is different for each particle.
-  ! -> implement a check for this!
-  ! In 4d,6d thin+thick and 5d thin we have:
-  !   tas(ia,*,*) = tas(1,*,*) for all particles ia
-  do i3=1,3
-    dumpclo(-1,i3*2-1) = clo6v(i3)
-    dumpclo(-1,i3*2)   = clop6v(i3)
-  end do
-  dumptas(-1,:,:) = tas(:,:)
-  call invert_tas(dumptasinv(-1,:,:),dumptas(-1,:,:))
-
   block
     real(kind=fPrec) tmpClo(6)
     tmpClo(1) = clo6v(1)

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -23,7 +23,7 @@ program maincr
 
   use dynk,    only : dynk_izuIndex
   use fma,     only : fma_postpr, fma_flag
-  use dump,    only : dump_initialise, dumpclo,dumptas,dumptasinv
+  use dump,    only : dump_initialise, dumpclo,dumptas,dumptasinv,dump_setTasMatrix
   use zipf,    only : zipf_numfiles, zipf_dozip
   use scatter, only : scatter_init
 
@@ -745,6 +745,17 @@ program maincr
   end do
   dumptas(-1,:,:) = tas(:,:)
   call invert_tas(dumptasinv(-1,:,:),dumptas(-1,:,:))
+
+  block
+    real(kind=fPrec) tmpClo(6)
+    tmpClo(1) = clo6v(1)
+    tmpClo(2) = clop6v(1)
+    tmpClo(3) = clo6v(2)
+    tmpClo(4) = clop6v(2)
+    tmpClo(5) = clo6v(3)
+    tmpClo(6) = clop6v(3)
+    call dump_setTasMatrix(-1,tas,tmpClo)
+  end block
 
   ! Convert to [mm,mrad,mm,mrad,1.e-3] for optics calculation
   tasiar16 = tas(1,6)*c1m3

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -7,7 +7,7 @@ subroutine umlauda
   use physical_constants
   use numerical_constants
   use mathlib_bouncer
-  use dump, only : dumpclo, dumptas, dumptasinv, ldump, dump_setTasMatrix
+  use dump, only : ldump, dump_setTasMatrix
   use crcoall
   use string_tools
   use mod_units

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -7,7 +7,7 @@ subroutine umlauda
   use physical_constants
   use numerical_constants
   use mathlib_bouncer
-  use dump, only : dumpclo, dumptas, dumptasinv, ldump
+  use dump, only : dumpclo, dumptas, dumptasinv, ldump, dump_setTasMatrix
   use crcoall
   use string_tools
   use mod_units

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -2771,55 +2771,56 @@ end subroutine clorda
 !           note: inversion method copied from subroutine postpr        *
 !-----------------------------------------------------------------------*
 subroutine invert_tas(fma_tas_inv,fma_tas)
+
   use floatPrecision
   use numerical_constants
   use matrix_inv
   use mod_common_track
   use crcoall
+
   implicit none
 
-  integer :: i,j            !iterators
-  real(kind=fPrec), dimension(6,6), intent(inout) :: fma_tas !tas = normalisation matrix
-  real(kind=fPrec), dimension(6,6), intent(out) :: fma_tas_inv !inverse of tas
-  integer ierro                   !error messages
-!     dummy variables
-  real(kind=fPrec), dimension(6,6) :: tdummy !dummy variable for transposing the matrix
-  integer, dimension(6) :: idummy !for matrix inversion
+  real(kind=fPrec), intent(inout) :: fma_tas(6,6) !tas = normalisation matrix
+  real(kind=fPrec), intent(out)   :: fma_tas_inv(6,6) !inverse of tas
+
+  real(kind=fPrec) tdummy(6,6)
+  integer ierro,i,j,idummy(6)
+
 !     units: [mm,mrad,mm,mrad,mm,1]
 !     invert matrix
 !     - set values close to 1 equal to 1
   do i=1,6
-      do j=1,6
-        fma_tas_inv(i,j)=fma_tas(j,i)
-      enddo
-  enddo
+    do j=1,6
+      fma_tas_inv(i,j)=fma_tas(j,i)
+    end do
+  end do
 
-  if(abs(fma_tas_inv(1,1)).le.pieni.and.abs(fma_tas_inv(2,2)).le.pieni) then
+  if(abs(fma_tas_inv(1,1)) <= pieni.and.abs(fma_tas_inv(2,2)) <= pieni) then
     fma_tas_inv(1,1)=one
     fma_tas_inv(2,2)=one
-  endif
-  if(abs(fma_tas_inv(3,3)).le.pieni.and.abs(fma_tas_inv(4,4)).le.pieni) then
+  end if
+  if(abs(fma_tas_inv(3,3)) <= pieni.and.abs(fma_tas_inv(4,4)) <= pieni) then
     fma_tas_inv(3,3)=one
     fma_tas_inv(4,4)=one
-  endif
-  if(abs(fma_tas_inv(5,5)).le.pieni.and.abs(fma_tas_inv(6,6)).le.pieni) then
+  end if
+  if(abs(fma_tas_inv(5,5)) <= pieni.and.abs(fma_tas_inv(6,6)) <= pieni) then
     fma_tas_inv(5,5)=one
     fma_tas_inv(6,6)=one
-  endif
+  end if
 
 !     - invert: dinv returns the transposed matrix
   call dinv(6,fma_tas_inv,6,idummy,ierro)
-  if (ierro.ne.0) then
-      write(lout,*) "Error in INVERT_TAS - Matrix inversion failed!"
-      write(lout,*) "Subroutine DINV returned ierro=",ierro
-      call prror
-  endif
+  if(ierro /= 0) then
+    write(lerr,"(a,i0)") "INVERT_TAS> ERROR Matrix inversion failed. Subroutine DINV returned ierro ",ierro
+    call prror
+  end if
 
 !     - transpose fma_tas_inv
   tdummy=fma_tas_inv
   do i=1,6
     do j=1,6
       fma_tas_inv(i,j)=tdummy(j,i)
-    enddo
-  enddo
+    end do
+  end do
+
 end subroutine invert_tas

--- a/source/six_fox.f90
+++ b/source/six_fox.f90
@@ -33,7 +33,7 @@ subroutine umlauda
   integer damap(6),damapi(6),damap1(6),aa2(6),aa2r(6),a1(6),a1r(6),xy(6),df(6),jj(100),i4(10,2)
   real(kind=fPrec) zfeld1(100),zfeld2(100),dpdav2(6),rrad(3),rdd(6,6),dicu(20),angnoe(3),angp(2,6), &
     phi(3),dphi(3),b1(3),b2(3),b3(3),al1(3),al2(3),al3(3),g1(3),g2(3),g3(3),d(3),dp(3),c(3),cp(3),  &
-    au(6,6),aui(2)
+    au(6,6),aui(2),tasData(6,6),cloData(6)
   common/daele/alda,asda,aldaq,asdaq,smida,xx,yy,dpda,dpda1,sigmda,ej1,ejf1,rv
   character(len=mNameLen) typ
   integer expertUnit


### PR DESCRIPTION
This PR replaces the `dumptas`, `dumptasinv`, and `dumpclo` arrays in `DUMP` with an array of structs that is expanded only when there is an element with a dump assigned to it. An integer map points between the element index and the storage array index.

This saves quite a bit of memory. For n FCC test with 60 particles it saves 33%, and for a HL-LHC test with 2000 particles it save 24%.