### PR TITLE
Bugfixes for Compact TAS PR

### DIFF
--- a/source/dump.f90
+++ b/source/dump.f90
@@ -1894,15 +1894,14 @@ call h5_finaliseWrite(dump_hdf5DataSet(ix))
 
 end subroutine dump_beam_population
 
+#ifdef CR
 ! ================================================================================================================================ !
 !  Begin Checkpoint Restart
 ! ================================================================================================================================ !
-#ifdef CR
-
-! ================================================================================================================================ !
 subroutine dump_crcheck_readdata(fileunit, readerr)
 
-  implicit none
+  use parpro
+  use crcoall
 
   integer, intent(in) :: fileunit
   logical, intent(out) :: readerr
@@ -1926,11 +1925,9 @@ end subroutine dump_crcheck_readdata
 subroutine dump_crcheck_positionFiles
 
   use crcoall
-  use string_tools
-  use mod_common
   use mod_units
-
-  implicit none
+  use mod_common
+  use string_tools
 
   ! For skipping through binary DUMP files (format 3&8)
   integer tmp_ID, tmp_nturn, tmp_ktrack
@@ -2013,6 +2010,7 @@ end subroutine dump_crcheck_positionFiles
 subroutine dump_crpoint(fileunit,lerror)
 
   use parpro
+  use crcoall
 
   integer, intent(in)  :: fileunit
   logical, intent(out) :: lerror
@@ -2034,9 +2032,7 @@ subroutine dump_crpoint(fileunit,lerror)
 
 end subroutine dump_crpoint
 ! ================================================================================================================================ !
-
-#endif
-! ================================================================================================================================ !
 !  End Checkpoint Restart
 ! ================================================================================================================================ !
+#endif
 end module dump

--- a/source/dump.f90
+++ b/source/dump.f90
@@ -186,27 +186,32 @@ subroutine dump_lines(n,i,ix)
 
   use mod_common_track
 
-  implicit none
-
   integer, intent(in) :: n,i,ix
+  real(kind=fPrec) invTas(6,6), cloOrb(6)
 
-  if (ldump(0)) then
+  if(dump_nMatMap(ix) > 0) then
+    invTas = dump_normMat(dump_nMatMap(ix))%invtas
+    cloOrb = dump_normMat(dump_nMatMap(ix))%orbit
+  else
+    invTas = zero
+    cloOrb = zero
+  end if
+
+  if(ldump(0)) then
     ! Dump at all SINGLE ELEMENTs
-    if (ndumpt(0) == 1 .or. mod(n,ndumpt(0)) == 1) then
+    if(ndumpt(0) == 1 .or. mod(n,ndumpt(0)) == 1) then
       if ((n >= dumpfirst(0)) .and. ((n <= dumplast(0)) .or. (dumplast(0) == -1))) then
-        call dump_beam_population(n, i, ix, dumpunit(0), dumpfmt(0), ldumphighprec, &
-          dump_normMat(dump_nMatMap(ix))%orbit, dump_normMat(dump_nMatMap(ix))%invtas)
+        call dump_beam_population(n, i, ix, dumpunit(0), dumpfmt(0), ldumphighprec, cloOrb, invTas)
       end if
     end if
   end if
   if(ktrack(i) /= 1) then
     ! The next "if" is only safe for SINGLE ELEMENTS, not BLOC where ix<0.
-    if (ldump(ix)) then
+    if(ldump(ix)) then
       ! Dump at this precise SINGLE ELEMENT
-      if (ndumpt(ix) == 1 .or. mod(n,ndumpt(ix)) == 1) then
-        if ((n >= dumpfirst(ix)) .and. ((n <= dumplast(ix)) .or. (dumplast(ix) == -1))) then
-          call dump_beam_population(n, i, ix, dumpunit(ix), dumpfmt(ix), ldumphighprec, &
-            dump_normMat(dump_nMatMap(ix))%orbit, dump_normMat(dump_nMatMap(ix))%invtas)
+      if(ndumpt(ix) == 1 .or. mod(n,ndumpt(ix)) == 1) then
+        if((n >= dumpfirst(ix)) .and. ((n <= dumplast(ix)) .or. (dumplast(ix) == -1))) then
+          call dump_beam_population(n, i, ix, dumpunit(ix), dumpfmt(ix), ldumphighprec, cloOrb, invTas)
         end if
       end if
     end if


### PR DESCRIPTION
Forgot to check that the index is non-zero when reading the tas matrix in the actual dump routines. These now use the dum_getTasMatrix call which does the check automatically.

Also, when cleaning up the header, forgot to check that the subroutines had the use statements it needed also under the CR flag.

Additional note: The tas matrix should probably be saved in a global module instead of under DUMP. especially since it is already shared with FMA. Will probably move this when PR #929 is merged, because there all the linopt stuff is moved to a separate file.