### PR TITLE
Bugfixes for Collimation Jaw Fit PRs

### DIFF
--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1698,6 +1698,7 @@ subroutine collimate_openFiles
 
   use mod_units
   use string_tools
+  use mod_common, only : numl
 #ifdef HDF5
   use hdf5_output
   use hdf5_tracks2

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -190,15 +190,20 @@ if(NOT CR)
     collimation_dist_5
     collimation_dist_6
     collimation_dist_radial
+    collimation_new-db_new-block
+    collimation_old-db_new-block
+    collimation_old-db_old-block
+    scatter_collimation
+  )
+endif()
+
+if(NOT CR AND STF)
+  list(APPEND SIXTRACK_TESTS
     collimation_jaw_fit
     collimation_jaw_fit_b4
     collimation_jaw_fit_b4_offsets_tilts
     collimation_jaw_fit_b4_onesided
     collimation_k2
-    collimation_new-db_new-block
-    collimation_old-db_new-block
-    collimation_old-db_old-block
-    scatter_collimation
   )
 endif()
 


### PR DESCRIPTION
Fixes the following:
* Build with HDF5
* Disables the new jaw fit tests when STF is off.
* Also turns off the K2 test with STF off as it uses 20000 particles.