### PR TITLE
Minor Bugfix on Collimation Exit

### DIFF
--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1265,7 +1265,7 @@ program maincr
   time2=0.
   call time_timerCheck(time2)
 
-  if(iclo6 > 0 .and. ithick == 0 .and. do_coll) then
+  if(ithick == 0 .and. do_coll) then
     ! Only if thin 6D and collimation enabled
     call collimate_exit
   endif


### PR DESCRIPTION
The exit routine in collimation is called with a different condition than the init routine, causing the final summary files to not be written when running a thin 4D setup.