### PR TITLE
Add FLUSH statement before stop in splitSingetrack

### DIFF
--- a/source/splitSingletrack/mod_splitSingletrack.f90
+++ b/source/splitSingletrack/mod_splitSingletrack.f90
@@ -47,12 +47,14 @@ contains
     if(itopa <= 0) then
       write(textOutUnit,'(a)')    "ERR in numSTFpairs: Corrupt itopa in first header of file '" // ifname // "'"
       write(textOutUnit,'(a,i0,a)') "itopa = ", itopa, " <= 0"
+      flush(textOutUnit)
       stop 1
     end if
 
     if (modulo(itopa,2) /= 0) then
       write(textOutUnit,'(a)')    "ERR in numSTFpairs: Number of particles not divisible by 2."
       write(textOutUnit,'(a,i6)') "ERR in numSTFpairs: itopa = ", itopa
+      flush(textOutUnit)
       stop 1
     end if
 
@@ -62,12 +64,15 @@ contains
     !Error handling
 510 continue
     write(textOutUnit,'(a,i6)') "ERR while opening file; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 511 continue
     write(textOutUnit,'(a,i6)') "END while reading header; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 520 continue
     write(textOutUnit,'(a,i6)') "ERR while reading header; iostat=",iostat
+    flush(textOutUnit)
     stop 1
   end function numSTFpairs
 
@@ -112,6 +117,7 @@ contains
         ntwin = ilapa-ifipa+1
         if (.not. (ntwin == 1 .or. ntwin == 2)) then
           write(textOutUnit,'(a)' ) "Error when reading header; ifipa=",ifipa, "ilapa=",ilapa,"ntwin=",ntwin
+          flush(textOutUnit)
           stop 1
         end if
 
@@ -148,23 +154,28 @@ contains
 
     !Should never reach this point
     write(textOutUnit,'(a)') "Control reached an unreachable point?!?"
+    flush(textOutUnit)
     stop 1
 
     !Error handling
 410 continue
     write(textOutUnit,'(a,i6)') "ERR while opening input file; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 411 continue
     write(textOutUnit,'(a,i6)') "ERR while opening output file; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 511 continue
     write(textOutUnit,'(a,i6)') "END while reading header; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 520 continue
     write(textOutUnit,'(a,i6)') "ERR while reading header; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 530 continue
@@ -175,14 +186,17 @@ contains
 
 531 continue
     write(textOutUnit,'(a,i6)') "ERR while reading data ; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 620 continue
     write(textOutUnit,'(a,i6)') "ERR while writing header; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
 621 continue
     write(textOutUnit,'(a,i6)') "ERR while writing data; iostat=",iostat
+    flush(textOutUnit)
     stop 1
 
   end subroutine convertSTFpair
@@ -201,6 +215,7 @@ contains
 
     if (oldnames .and. nPairs > 32) then
       write(textOutUnit,'(a,i6,a)') "ERR in convertSTFfile: Oldpairs=true but nPairs = ", npairs, " > 32"
+      flush(textOutUnit)
       stop 1
     end if
 

--- a/source/splitSingletrack/splitSingletrack.f90
+++ b/source/splitSingletrack/splitSingletrack.f90
@@ -5,6 +5,8 @@ program splitSingletrack
   ! K. Sjobak, October 2019
   ! ---------------------------------------------------------------
   use mod_splitSingletrack
+  use iso_fortran_env, only : output_unit
+
   implicit none
 
   logical                     :: hasInputFile
@@ -32,20 +34,22 @@ program splitSingletrack
     elseif (cmdarg_arg .eq. "--getNumPairs") then
       getnumpairs = .true.
     else if (cmdarg_arg .eq. "-h" .or. cmdarg_arg .eq. "--help") then
-      write(*,'(a)') "Usage of 'splitsingletrack'; possible flags"
-      write(*,'(a)') "Note that all flags are mutually exclusive."
-      write(*,'(a)') "The input file should always be named '"//ifname//"'."
-      write(*,'(a)') ""
-      write(*,'(a)') "--oldnames    : Split into files named fort.91-i, where 1<=i<=32 is the pair index."
-      write(*,'(a)') "--getNumPairs : Print the number of pairs and exit."
-      write(*,'(a)') "--h / --help  : Print this help text."
-      write(*,'(a)') ""
-      write(*,'(a)') "By default it will try to split the file into files on the format '"// &
+      write(output_unit,'(a)') "Usage of 'splitsingletrack'; possible flags"
+      write(output_unit,'(a)') "Note that all flags are mutually exclusive."
+      write(output_unit,'(a)') "The input file should always be named '"//ifname//"'."
+      write(output_unit,'(a)') ""
+      write(output_unit,'(a)') "--oldnames    : Split into files named fort.91-i, where 1<=i<=32 is the pair index."
+      write(output_unit,'(a)') "--getNumPairs : Print the number of pairs and exit."
+      write(output_unit,'(a)') "--h / --help  : Print this help text."
+      write(output_unit,'(a)') ""
+      write(output_unit,'(a)') "By default it will try to split the file into files on the format '"// &
            ifname//".i', where i>=1 is the pair index"
+      flush(output_unit)
       stop 0
     else
-      write(*,'(a)') "Unrecognized command line argument '" // &
+      write(output_unit,'(a)') "Unrecognized command line argument '" // &
            trim(cmdarg_arg) // "', try -h"
+      flush(output_unit)
       stop 2
     endif
 
@@ -56,18 +60,19 @@ program splitSingletrack
   !Check that input file is there
   inquire(file=ifname, exist=hasInputFile)
   if (.not. hasInputFile) then
-    write(*, '(a)') "Error in splitSingletrack -- file '"//ifname//"' not found."
+    write(output_unit, '(a)') "Error in splitSingletrack -- file '"//ifname//"' not found."
+    flush(output_unit)
     stop 1
   endif
 
   if (getNumPairs) then
     numPairs = numSTFpairs(ifname)
-    write(*,'(i8)') numPairs
+    write(output_unit,'(i8)') numPairs
     stop !No exit code so that we don't print "STOP 0" etc.
   else
-    write(*,'(a)') "Splitting file '"//ifname//"' (run with '-h' for more options)..."
+    write(output_unit,'(a)') "Splitting file '"//ifname//"' (run with '-h' for more options)..."
     call convertSTFfile(ifname, oldnames)
-    write(*,'(a)') "Done!"
+    write(output_unit,'(a)') "Done!"
   endif
 
 end program splitSingletrack


### PR DESCRIPTION
When compiled with Nagfor, the `STOP: <code>` output arrived before the actual error message, which caused the self test of splitSingletrack to fail.

This fixes it.