### PR TITLE
Add a missing use root_output

### DIFF
--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1959,6 +1959,9 @@ subroutine coll_exitCollimation
   use hdf5_output
   use hdf5_tracks2
 #endif
+#ifdef ROOT
+  use root_output
+#endif
 #ifdef G4COLLIMATION
   use geant4
 #endif


### PR DESCRIPTION
Was missing a single `use root_output` in exit collimator routine. SixTrack part seems to build now.