### PR TITLE
Crystal files

### DIFF
--- a/doc/user_manual/chSpecialElements.tex
+++ b/doc/user_manual/chSpecialElements.tex
@@ -1880,12 +1880,13 @@ All flags default to \texttt{false}.
 
 \bigskip
 \begin{tabular}{@{}llp{0.7\linewidth}}
-    \texttt{WRITE\_DIST}   & Writes the beam distribution to file before and after tracking. \\
-    \texttt{WRITE\_IMPACT} & Writes the impact parameters for each collimator. \\
-    \texttt{WRITE\_SECOND} & Writes a secondary halo file based on normalised amplitude. \\
-    \texttt{WRITE\_AMPL}   & Writes checking files for amplitude, closed orbit. \\
-    \texttt{WRITE\_EFFIC}  & Writes the efficiency files. \\
-    \texttt{WRITE\_TRACKS} & Writes secondary/tertiary halo files.
+    \texttt{WRITE\_DIST}     & Writes the beam distribution to file before and after tracking. \\
+    \texttt{WRITE\_IMPACT}   & Writes the impact parameters for each collimator. \\
+    \texttt{WRITE\_SECOND}   & Writes a secondary halo file based on normalised amplitude. \\
+    \texttt{WRITE\_AMPL}     & Writes checking files for amplitude, closed orbit. \\
+    \texttt{WRITE\_EFFIC}    & Writes the efficiency files. \\
+    \texttt{WRITE\_TRACKS}   & Writes secondary/tertiary halo files. \\
+    \texttt{WRITE\_CRYCOORD} & Writes crystal coordinate file(s).
 \end{tabular}
 
 % ================================================================================================================================ %
@@ -2054,6 +2055,10 @@ Crystal collimators require an additional set of parameters described in the fol
 \bigskip
 All the parameters default to zero.
 Additional details on the physics principles of crystal collimation and benchmark against experimental data can be found in~\cite{crystal:1,crystal:2,crystal:3,crystal:4,crystal:5,crystal:6}.
+
+The main output file is the \texttt{cry\_interaction.dat} file.\index{crystal interaction}
+This file is enabled with the \texttt{WRITE\_CRYCOORD} flag in \texttt{fort.3}.
+In addition, if the \texttt{DEBUG} flag is set in the \texttt{SETTINGS} block (see Section~\ref{STSett}), a \texttt{cry\_entrance.dat} and \texttt{cry\_exit.dat} file is written as well.\index{crystal dump}
 
 \bigskip
 \noindent\textit{Example}

--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1277,6 +1277,7 @@ subroutine coll_openFiles
   use mod_units
   use string_tools
   use mod_common, only : numl
+  use mod_settings
   use coll_common
 #ifdef HDF5
   use hdf5_output
@@ -1323,8 +1324,8 @@ subroutine coll_openFiles
   end if
 
   ! Crystal Files
-  if(coll_hasCrystal) then
-    if(dowrite_crycoord) then
+  if(coll_hasCrystal .and. dowrite_crycoord) then
+    if(st_debug) then
       call f_requestUnit(coll_cryEntFile,coll_cryEntUnit)
       call f_open(unit=coll_cryEntUnit,file=coll_cryEntFile,formatted=.true.,mode="w",status="replace")
       write(coll_cryEntUnit,"(a1,1x,a6,1x,a8,1x,a20,1x,a4,2(1x,a3),5(1x,a15))") &
@@ -1505,6 +1506,7 @@ subroutine coll_doCollimator(stracki)
   use mod_time
   use mod_common
   use coll_common
+  use mod_settings
   use mod_common_main
   use mod_common_track
   use coll_db
@@ -1747,8 +1749,8 @@ subroutine coll_doCollimator(stracki)
       part_abs_pos, part_abs_turn, part_impact, part_indiv, part_linteract,             &
       onesided, nhit_stage, 1, nabs_type, linside)
 
-    if(cdb_isCrystal(icoll)) then
-      if(dowrite_crycoord) then
+    if(cdb_isCrystal(icoll) .and. dowrite_crycoord) then
+      if(st_debug) then
         do j=1,napx
           isHit = part_hit_pos(j) == ie .and. part_hit_turn(j) == iturn
           isAbs = part_abs_pos(j) == ie .and. part_abs_turn(j) == iturn

--- a/test/collimation_cry_ge_am_hor_b2/fort.3
+++ b/test/collimation_cry_ge_am_hor_b2/fort.3
@@ -1,7 +1,7 @@
 GEOM
 
 SETTINGS----------------------------------------------------------------
-!  PRINT
+  DEBUG
   INITIALSTATE text
   FINALSTATE   text
 NEXT

--- a/test/collimation_cry_ge_vc_ver_b1/fort.3
+++ b/test/collimation_cry_ge_vc_ver_b1/fort.3
@@ -1,7 +1,7 @@
 GEOM
 
 SETTINGS----------------------------------------------------------------
-!  PRINT
+  DEBUG
   INITIALSTATE text
   FINALSTATE   text
 NEXT

--- a/test/collimation_cry_si_ch_hor_b1/fort.3
+++ b/test/collimation_cry_si_ch_hor_b1/fort.3
@@ -1,7 +1,7 @@
 GEOM
 
 SETTINGS----------------------------------------------------------------
-!  PRINT
+  DEBUG
   INITIALSTATE text
   FINALSTATE   text
 NEXT

--- a/test/collimation_cry_si_vr_ver_b2/fort.3
+++ b/test/collimation_cry_si_vr_ver_b2/fort.3
@@ -1,7 +1,7 @@
 GEOM
 
 SETTINGS----------------------------------------------------------------
-!  PRINT
+  DEBUG
   INITIALSTATE text
   FINALSTATE   text
 NEXT


### PR DESCRIPTION
This PR changes to logic of the writing of crystal collimation files so that the interaction file is only written when the `WRITE_CRYCOORD` flag is enabled, and the entrance and exit files are only written if, in addition, the global `DEBUG` flag is set.

Tests and documentation updated accordingly.