### PR TITLE
Reposition files routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * Fixed a type definition inconsistency introduced by #878 that affected the ROOT interface. PR #1026 (J. Molson)
 * Fixed the `CERNLIB` build system to support 64-bit. PR #1025 (F. Schmidt, J. Molson)
 * Fixed a faulty loop in the FFT routine in post-processing. PR #1025 (J. Molson, F. Schmidt)
-* Fixed a difference in sign in the thin combined function code. PR 1005 (T. Persson)
+* Fixed a difference in sign in the thin combined function code. PR #1005 (T. Persson)
 
 **User Side Changes**
 
@@ -26,6 +26,10 @@
 **BOINC Interface**
 
 * Extended the BOINC interface code to produce a new validation file for BOINC jobs. The new file supports a wider range of job types, especially jobs that do not produce a `fort.10` file. PR #878 (V.K. Berglyd Olsen, A. Mereghetti)
+
+**Code Improvements and Changes**
+
+* Cleaned up a number of unused variables throughout the SixTrack source code. PR #1037 (J. Molson)
 
 ### Version 5.4.2 [22.11.2019] - Release
 
@@ -44,10 +48,6 @@
 **Documentation**
 
 * Documentation section for collimation updated to include crystal collimators. PRs #1012 and #1019 (M. D'Andrea, V.K. Berglyd Olsen)
-
-**Code Improvements and Changes**
-
-* Cleaned up a number of unused variables throughout the SixTrack source code. PR #1037 (J. Molson)
 
 ### Version 5.4.1 [01.11.2019] - Release
 

--- a/source/dynk.f90
+++ b/source/dynk.f90
@@ -2921,59 +2921,14 @@ end subroutine dynk_crcheck_readdata
 ! ================================================================================================ !
 subroutine dynk_crcheck_positionFiles
 
-  use parpro
-  use crcoall
   use mod_units
-
-  logical isOpen, fErr
-  integer ierro
-  integer j
-  character(len=mInputLn) aRecord
 
   if(dynk_dynkSets .eqv. .false.) then
     ! No file to reposition
     return
   end if
 
-  inquire(unit=dynk_fileUnit, opened=isOpen)
-  if(isOpen) then
-    write(crlog,"(a)")      "CR_CHECK> ERROR Failed while repositioning '"//dynk_fileName//"'"
-    write(crlog,"(a,i0,a)") "CR_CHECK>       Unit ",dynk_fileUnit," already in use!"
-    flush(crlog)
-    write(lerr,"(a)") "CR_CHECK> ERROR Failed positioning '"//dynk_fileName//"'"
-    call prror
-  end if
-
-  if(dynk_filePosCR /= -1) then
-    call f_open(unit=dynk_fileUnit,file=dynk_fileName,formatted=.true.,mode="rw",status="old",err=fErr)
-    if(fErr) goto 110
-    dynk_filePos = 0     ! Start counting lines at 0, not -1
-    do j=1,dynk_filePosCR
-      read(dynk_fileUnit,"(a)",end=110,err=110,iostat=ierro) aRecord
-      dynk_filePos=dynk_filePos+1
-    end do
-
-    endfile(dynk_fileUnit,iostat=ierro)
-    call f_close(dynk_fileUnit)
-    call f_open(unit=dynk_fileUnit,file=dynk_fileName,formatted=.true.,mode="w+",status="old")
-
-    write(crlog,"(2(a,i0))") "CR_CHECK> Sucessfully repositioned '"//dynk_fileName//"', "// &
-      "dynk_filePos = ",dynk_filePos,", dynk_filePosCR = ",dynk_filePosCR
-    flush(crlog)
-  else
-    write(crlog,"(a,i0)") "CR_CHECK> Did not attempt repositioning of '"//dynk_fileName//"', dynk_filePosCR = ",dynk_filePosCR
-    write(crlog,"(a)")    "CR_CHECK> If anything was written to the file, it will be truncated in dynk_apply on the first turn."
-    flush(crlog)
-  end if
-
-  return
-
-110 continue
-  write(crlog,"(2(a,i0))") "CR_CHECK> ERROR While reading '"//dynk_fileName//"', "//&
-    "dynk_filePos = ",dynk_filePos,", dynk_filePosCR = ",dynk_filePosCR
-  flush(crlog)
-  write(lerr,"(a)") "CR_CHECK> ERROR CRCHECK failure positioning '"//dynk_fileName//"'"
-  call prror
+  call f_positionFile(dynk_fileName, dynk_fileUnit, dynk_filePos, dynk_filePosCR)
 
 end subroutine dynk_crcheck_positionFiles
 

--- a/source/mod_units.f90
+++ b/source/mod_units.f90
@@ -523,7 +523,7 @@ subroutine f_positionFile(fileName, fileUnit, filePos, newPos)
   inquire(unit=fileUnit,opened=isOpen)
   if(isOpen) then
 #ifdef CR
-    write(crlog,"(a,i0,a)") "UNITS> ERROR Failed while repsositioning '"//trim(fileName)//"', "//&
+    write(crlog,"(a,i0,a)") "UNITS> ERROR Failed while repositioning '"//trim(fileName)//"', "//&
       "unit ",fileUnit," already in use"
     flush(crlog)
 #endif
@@ -539,9 +539,11 @@ subroutine f_positionFile(fileName, fileUnit, filePos, newPos)
       read(fileUnit,"(a)",end=10,err=10,iostat=iError) aRecord
       filePos = filePos + 1
     end do
+    ! Truncate file at requested position
     endfile(fileUnit,iostat=iError)
     call f_close(fileUnit)
 
+    ! Re-open for appending
     call f_open(unit=fileUnit,file=fileName,formatted=.true.,mode="w+",err=fErr,status="old")
     if(fErr) goto 10
 #ifdef CR

--- a/source/scatter.f90
+++ b/source/scatter.f90
@@ -2221,76 +2221,13 @@ subroutine scatter_crcheck_positionFiles
   integer j
   character(len=mInputLn) aRecord
 
-  call scatter_positionFile(scatter_logFile, scatter_logUnit, scatter_logFilePos, scatter_logFilePos_CR)
-  call scatter_positionFile(scatter_sumFile, scatter_sumUnit, scatter_sumFilePos, scatter_sumFilePos_CR)
+  call f_positionFile(scatter_logFile, scatter_logUnit, scatter_logFilePos, scatter_logFilePos_CR)
+  call f_positionFile(scatter_sumFile, scatter_sumUnit, scatter_sumFilePos, scatter_sumFilePos_CR)
   if(scatter_writePLog) then
-    call scatter_positionFile(scatter_pVecFile, scatter_pVecUnit, scatter_pVecFilePos, scatter_pVecFilePos_CR)
+    call f_positionFile(scatter_pVecFile, scatter_pVecUnit, scatter_pVecFilePos, scatter_pVecFilePos_CR)
   end if
 
 end subroutine scatter_crcheck_positionFiles
-
-! =================================================================================================
-!  V.K. Berglyd Olsen, BE-ABP-HSS
-!  Created: 2019-07-24
-!  Updated: 2019-07-24
-! =================================================================================================
-subroutine scatter_positionFile(fileName, fileUnit, filePos, filePos_CR)
-
-  use parpro
-  use crcoall
-  use mod_units
-
-  character(len=*), intent(in)    :: fileName
-  integer,          intent(inout) :: fileUnit
-  integer,          intent(inout) :: filePos
-  integer,          intent(inout) :: filePos_CR
-
-  logical isOpen, fErr
-  integer iError
-  integer j
-  character(len=mInputLn) aRecord
-
-  call f_requestUnit(fileName,fileUnit)
-  inquire(unit=fileUnit, opened=isOpen)
-  if(isOpen) then
-    write(crlog,"(a,i0,a)") "CR_CHECK> ERROR Failed while repsositioning '"//fileName//"', unit ",fileUnit," already in use"
-    flush(crlog)
-    write(lerr,"(a)") "CR_CHECK> ERROR Failed positioning '"//fileName//"'"
-    call prror
-  end if
-
-  if(filePos_CR /= -1) then
-    call f_open(unit=fileUnit,file=fileName,formatted=.true.,mode="rw",err=fErr,status="old")
-    if(fErr) goto 10
-    filePos = 0
-    do j=1, filePos_CR
-      read(fileUnit,"(a)",end=10,err=10,iostat=iError) aRecord
-      filePos = filePos + 1
-    end do
-    endfile(fileUnit,iostat=iError)
-    call f_close(fileUnit)
-
-    call f_open(unit=fileUnit,file=fileName,formatted=.true.,mode="w+",err=fErr,status="old")
-    if(fErr) goto 10
-    write(97,"(2(a,i0))") "CR_CHECK> Sucessfully repositioned '"//fileName//"': "//&
-      "Position: ",filePos,", Position C/R: ",filePos_CR
-    flush(crlog)
-  else
-    write(crlog,"(a,i0)") "CR_CHECK> Did not attempt repositioning '"//fileName//"' at line ",filePos_CR
-    write(crlog,"(a)")    "CR_CHECK> If anything has been written to the file, it will be correctly truncated"
-    flush(crlog)
-  end if
-
-  return
-
-10 continue
-  write(crlog,"(a,i0)")    "CR_CHECK> ERROR While reading '"//fileName//"', iostat = ",iError
-  write(crlog,"(2(a,i0))") "CR_CHECK>       Position: ",filePos,", Position C/R: ",filePos_CR
-  flush(crlog)
-  write(lerr,"(a)")"CR_CHECK> ERROR CRCHECK failure positioning '"//fileName//"'"
-  call prror
-
-end subroutine scatter_positionFile
 
 ! =================================================================================================
 !  K. Sjobak, V.K. Berglyd Olsen, BE-ABP-HSS


### PR DESCRIPTION
This PR just moves the reposition files routine from the scatter module to mod_units, so it can be used by any module. This is especially useful for collimation.

The routine has been cleaned up a bit, made general (also should work outside of C/R) and more comments added.