### PR TITLE
fixing test of type 3 pencil beam

### DIFF
--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -2553,8 +2553,10 @@ subroutine coll_matchedHalo(c_tilt,c_offset,c_aperture,c_length)
   ! Assign amplitudes in x and y for the halo generation function
   if(cdist_ampX > zero .and. cdist_ampY == zero) then ! Horizontal halo
     c_nex2 = minAmpl
+    c_ney2 = zero 
   else if(cdist_ampX == zero .and. cdist_ampY > zero) then ! Vertical halo
     c_ney2 = minAmpl
+    c_nex2 = zero 
   end if ! Other cases taken care of above - in these cases, program has already stopped
 
   ! Assign optics parameters to use for the generation of the starting halo - at start or end of collimator


### PR DESCRIPTION
Apparently the test was failing because a variable was not properly initialised.

It has never been, actually, also when I set the test, but this was not caught by neither me preparing the test nor circleci catching it... But re-running the test with the master branch did fail...