### PR TITLE
Bug fix: update pairMap only in case of primary beam particles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix the root build PR # 1040 (J. Molson)
 * More robust detection of lxplus at compilation PR #1045 (J. Molson).
 * Fix pencil beam type 3 - the optics function at the entrance of the collimator were always used for beam sampling, even when those at the exit should have been used (e.g. because the beam is divergent on the cleaning plane). PR #1046 (A. Mereghetti).
+* Do not update the pair mapping for non-primary particlesPR #1050 (A. Mereghetti)
 
 ### Version 5.4.3 [19.12.2019] - Release
 

--- a/source/mainarrays.f90
+++ b/source/mainarrays.f90
@@ -292,7 +292,7 @@ end subroutine shuffleLostParticles
 ! ~~~~~~~~~~~~~~~~~~~~~~~~~
 !  V.K. Berglyd Olsen, BE-ABP-HSS
 !  Created: 2019-08-12
-!  Updated: 2019-08-12
+!  Updated: 2020-01-30, A. Mereghetti (BE-ABP-HSS)
 !
 !      This map allows for reverse lookup from a pairID to the index of its two particles in the
 !  main particle arrays. This is used for the distance calculation and for post-processing.
@@ -301,6 +301,10 @@ end subroutine shuffleLostParticles
 !      If, for some reason, each pair ID is not represented exactly twice in the array, the final
 !  map will contain zeros. Any routine using this map for lookup must therefore check for 0 values
 !  and trigger necessary error handling.
+!      In case of new particles added to the tracking arrays (e.g. secondary particles out of
+!  inelastic interactions), these must not enter the logics of couples, since the original particle
+!  died. Hence, keep the pairMap table of the length of the tracked particles (to keep particle
+!  reshuffling simple), but do not update the map for non-primary particles.
 ! ================================================================================================ !
 subroutine updatePairMap
 
@@ -311,6 +315,8 @@ subroutine updatePairMap
 
   pairMap(:,:) = 0
   do j=1,npart
+    ! do not update the map in case the particle is not a primary one
+    if (pairID(1,j).eq.0.and.pairID(2,j).eq.0 ) cycle
     pairMap(pairID(2,j),pairID(1,j)) = j
   end do
 

--- a/source/mainarrays.f90
+++ b/source/mainarrays.f90
@@ -316,7 +316,7 @@ subroutine updatePairMap
   pairMap(:,:) = 0
   do j=1,npart
     ! do not update the map in case the particle is not a primary one
-    if (pairID(1,j).eq.0.and.pairID(2,j).eq.0 ) cycle
+    if (pairID(1,j)==0.and.pairID(2,j)==0) cycle
     pairMap(pairID(2,j),pairID(1,j)) = j
   end do
 


### PR DESCRIPTION
In case secondary particles are injected in the tracking arrays, `pairID` and `pairMap` arrays are extended, with an initialisation to 0. This leads the `updatePairMap` subroutine to crash, as `pairMap(0,0)` would be updated for all secondary particles, out of bounds.

The fix is simple, i.e. to update the `pairMap` only for what concerns primary particles. The `pairMap` is anyway regularly expanded to keep the reshuffling algorithm smooth, without may exceptions.

Thanks to @JamesMolson for spotting the problem, in the context of the Fluka-SixTrack coupling.