### PR TITLE
Fix pair map (continued)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 * Do not update the pair mapping for non-primary particles. PR #1050 (A. Mereghetti)
 * Removed updating napxo variable in the context of the Fluka-SixTrack coupling. This allows not to screw-up pair mapping in the context of DA studies. PR # 1052 (A. Mereghetti)
 
+**User Side Changes**
+
+* When specifying `XP` and `YP` in the `FORMAT` statement of the `DIST` block, the units are parsed. Accepted values are [1], [1000], [MRAD], [RAD].
+
 ### Version 5.4.3 [19.12.2019] - Release
 
 **Bugfixes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 **Bugfixes**
 
-* Fix the root build PR # 1040 (J. Molson)
-* More robust detection of lxplus at compilation PR #1045 (J. Molson).
+* Fix the root build. PR # 1040 (J. Molson)
+* More robust detection of lxplus at compilation. PR #1045 (J. Molson).
 * Fix pencil beam type 3 - the optics function at the entrance of the collimator were always used for beam sampling, even when those at the exit should have been used (e.g. because the beam is divergent on the cleaning plane). PR #1046 (A. Mereghetti).
-* Do not update the pair mapping for non-primary particlesPR #1050 (A. Mereghetti)
+* Do not update the pair mapping for non-primary particles. PR #1050 (A. Mereghetti)
+* Removed updating napxo variable in the context of the Fluka-SixTrack coupling. This allows not to screw-up pair mapping in the context of DA studies. PR # 1052 (A. Mereghetti)
 
 ### Version 5.4.3 [19.12.2019] - Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 **User Side Changes**
 
-* When specifying `XP` and `YP` in the `FORMAT` statement of the `DIST` block, the units are parsed. Accepted values are [1], [1000], [MRAD], [RAD].
+* When specifying `XP` and `YP` in the `FORMAT` statement of the `DIST` block, the units are parsed. Accepted values are [1], [1000], [MRAD], [RAD]. PR # 1054 (A. Mereghetti)
 
 ### Version 5.4.3 [19.12.2019] - Release
 

--- a/source/include/lostpart.f90
+++ b/source/include/lostpart.f90
@@ -42,10 +42,6 @@
   !-----------------------------------------------------------------------
   ! closing stuff
 
-#ifdef FLUKA
-  napxo = napx
-#endif
-
   if(napx.eq.0) then
     write(lout,"(a)") ""
     write(lout,"(a)") "************************"

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1387,13 +1387,13 @@ program maincr
   ! print stable particles only
   write(lout,"(a)") ""
   write(lout,"(a)") str_divLine
-  if(napxo > 0) then
+  if(napx > 0) then
     write(lout,"(a)") ""
-    write(lout,10350) napxo
+    write(lout,10350) napx
     write(lout,"(a)") ""
     write(lout,10360) 'ID', 'GEN', 'WEIGHT', 'X [m]', 'XP []', 'Y [m]', 'YP[]', 'PC [GeV]', 'DE [eV]', 'DT [s]'
     write(lout,"(a)") ""
-    do ia=1,napxo
+    do ia=1,napx
       if(.not.pstop(ia)) then
         write(lout,10370) fluka_uid(ia),fluka_gen(ia),fluka_weight(ia), &
           xv1(ia)*c1m3, yv1(ia)*c1m3, xv2(ia)*c1m3, yv2(ia)*c1m3, &


### PR DESCRIPTION
This is a continuation of PR #1050.

Here we remove any update of `napxo` that was still done in the context of the Fluka-SixTrack coupling, presently useless as the concerned loop can be run on `napx`.

Continuing on the comment https://github.com/SixTrack/SixTrack/pull/1050#issuecomment-580291211 by @vkbo :
> My point was to assign them anyway to prevent out of bounds errors and garbage values from memory in the analysis.

I agree with you on this, that's good, and it stays like that with these PRs.

> I added checks to catch this to avoid exactly this. Running PostPR on secondaries will therefore hit my bug trap, as intended.

I agree with you also on this, that's good, and it stays like that with these PRs. The loop in post-processing goes with `napxo`, hence having removed its (useless) update has put the Fluka-SixTrack coupling in the position of running DA studies (if ever wanted...). Therefore, your check will actually trap no secondary particles, but only problems in the mapping :)

> A more sensible solution may be to just filter out secondaries of course and skip them in the loops.

Not sure this is a smart idea - we should have two integers for accessing the tracking arrays...

> Either way, one of these approaches need to be implemented.

I think we are there