### PR TITLE
Update geant4 based collimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Do not update the pair mapping for non-primary particles. PR #1050 (A. Mereghetti)
 * Increased number of digits for particle ID in FirstImpacts.dat and in collimator length in coll_summary.dat (to properly display crystal collimators which are usually a few mm long). First impacts on crystal collimators are now correctly flagged and a missing check on the `dowrite_impact` flag when writing Coll_Scatter.dat has been added. PR #1053 (M. D'Andrea)
 * When collimator settings are required to match those read from an old format CollDB, a separate subroutine reconstructs the family settings based on the most frequent setting in each family. PR #1053 (M. D'Andrea)
+* Do not perform the pair mapping when geant4 collimation is enabled.
 
 **User Side Changes**
 
@@ -35,6 +36,8 @@
 * Removed updating napxo variable in the context of the Fluka-SixTrack coupling. This allows not to screw-up pair mapping in the context of DA studies. PR # 1052 (A. Mereghetti)
 * Removed the un-used fluka_init_brhono function. PR # 1055 (J. Molson).
 * Print error codes from the fluka coupling. PR # 1055 (J. Molson)
+* Update FLUKAIO reference.
+* Add Si as a possible collimator material for G4.
 
 ### Version 5.4.3 [19.12.2019] - Release
 

--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -1782,6 +1782,7 @@ subroutine coll_doCollimator(stracki)
 
   end if
 
+#ifndef G4COLLIMATION
   ! Calculate average impact parameter and save info for all collimators.
   ! Copy information back and do negative drift.
 
@@ -1799,6 +1800,7 @@ subroutine coll_doCollimator(stracki)
       end if
     end do
   end if
+#endif
 
 #ifdef G4COLLIMATION
   do j=1,napx
@@ -2408,9 +2410,10 @@ subroutine coll_endTurn
         llostp(j) = .true.
       end if
     end do
-
+#ifndef G4COLLIMATION
     ! Move the lost particles to the end of the arrays
     call shuffleLostParticles
+#endif
   end if
 
   ! Write final distribution

--- a/source/g4collimation/CollimationMaterials.cpp
+++ b/source/g4collimation/CollimationMaterials.cpp
@@ -30,6 +30,7 @@ CollimationMaterials::CollimationMaterials()
 	G4Material* Mo = NManager->FindOrBuildMaterial("G4_Mo");
 	G4Material* W = NManager->FindOrBuildMaterial("G4_W");
 	G4Material* Pb = NManager->FindOrBuildMaterial("G4_Pb");
+	G4Material* Si = NManager->FindOrBuildMaterial("G4_Si");
 
 
 	//Only needed for pure elemental collimators
@@ -42,6 +43,8 @@ CollimationMaterials::CollimationMaterials()
 	AddMaterial("Mo", Mo);
 	AddMaterial("W", W);
 	AddMaterial("Pb", Pb);
+	AddMaterial("Si", Si);
+	AddMaterial("SI", Si);
 
 	AddMaterial("CU", Cu);
 

--- a/source/main_cr.f90
+++ b/source/main_cr.f90
@@ -1270,7 +1270,7 @@ program maincr
   numx = nnuml
   id   = 0
 
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATION)
   napxto = 0
 
 #ifdef CR
@@ -1382,8 +1382,9 @@ program maincr
         xv1(ie),yv1(ie),xv2(ie),yv2(ie),sigmv(ie),dpsv(ie),e0,ejv(ia),ejv(ie)
     end if
   end do
+#endif
 
-#else
+#ifdef FLUKA
   ! IFDEF FLUKA
   ! A.Mereghetti and D.Sinuela Pastor, for the FLUKA Team
   ! last modified: 17-07-2013

--- a/source/mod_particles.f90
+++ b/source/mod_particles.f90
@@ -49,8 +49,14 @@ subroutine part_setPairID
   use mod_common_main
   integer j
   do j=1,npart
+#ifndef G4COLLIMATION
     pairID(1,j) = (j+1)/2    ! The pairID of particle j
     pairID(2,j) = 2-mod(j,2) ! Either particle 1 or 2 of the pair
+#else
+!with g4, treat all particles as secondaries
+    pairID(1,j) = 0
+    pairID(2,j) = 0
+#endif
   end do
   call updatePairMap
 end subroutine part_setPairID

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -543,7 +543,7 @@ subroutine thck4d(nthinerr)
 
     if(nthinerr /= 0) return
     if(ntwin /= 2) call trackDistance
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATON)
     if(mod(n,nwr(4)) == 0) call trackPairReport(n)
 #else
     ! increase napxto, to get an estimation of particles*turns
@@ -1134,7 +1134,7 @@ subroutine thck6d(nthinerr)
 
     if(nthinerr /= 0) return
     if(ntwin /= 2) call trackDistance
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATON)
     if(mod(n,nwr(4)) == 0) call trackPairReport(n)
 #else
     ! increase napxto, to get an estimation of particles*turns

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -526,7 +526,7 @@ subroutine thin4d(nthinerr)
 
     if(nthinerr /= 0) return
     if(ntwin /= 2) call trackDistance
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATON)
     if(mod(n,nwr(4)) == 0) call trackPairReport(n)
 #else
     ! increase napxto, to get an estimation of particles*turns
@@ -1308,7 +1308,7 @@ subroutine thin6d(nthinerr)
     if(nthinerr /= 0) return
     if(do_coll .eqv. .false.) then
       if(ntwin /= 2) call trackDistance
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATON)
       if(mod(n,nwr(4)) == 0) call trackPairReport(n)
 #endif
     end if

--- a/source/tracking.f90
+++ b/source/tracking.f90
@@ -404,7 +404,7 @@ subroutine trackBeginTurn(n, nthinerr)
   meta_nPartTurn = meta_nPartTurn + napx
   numx = n-1
 
-#ifndef FLUKA
+#if !defined(FLUKA) && !defined(G4COLLIMATION)
   if(mod(numx,nwri) == 0) call writebin(nthinerr)
   if(nthinerr /= 0) return
 #endif


### PR DESCRIPTION
Missing #ifndefs as previously added for FLUKA (for pair map related topics).
Treat all particles as secondaries for the pair mapping with geant4 (i.e. just disable it).
Add Si as a material for geant4.