### PR TITLE
Fix CR build, elens test for BOINC, and SCATTER parsing bug

### DIFF
--- a/source/elens.f90
+++ b/source/elens.f90
@@ -1811,6 +1811,8 @@ end subroutine elens_kick_fox
 #ifdef CR
 subroutine elens_crcheck(fileUnit,readErr)
 
+  use crcoall
+
   integer, intent(in)  :: fileUnit
   logical, intent(out) :: readErr
 
@@ -1831,6 +1833,8 @@ subroutine elens_crcheck(fileUnit,readErr)
 end subroutine elens_crcheck
 
 subroutine elens_crpoint(fileUnit, writeErr)
+
+  use crcoall
 
   integer, intent(in)  :: fileUnit
   logical, intent(out) :: writeErr

--- a/source/scatter.f90
+++ b/source/scatter.f90
@@ -698,7 +698,7 @@ subroutine scatter_parseProfile(lnSplit, nSplit, iErr)
 
   case("FIXED")
     proType = scatter_proFixed
-    if(nSplit /= 3) then
+    if(nSplit /= 4) then
       write(lerr,"(a,i0)") "SCATTER> ERROR PROfile type FIXED expected 1 argument, got ",nSplit-3
       write(lerr,"(a)")    "SCATTER>       PRO name FIXED density[targets/m^2]"
       iErr = .true.

--- a/test/elensidealthin6d_FOX_uniform/extra_inputs.txt
+++ b/test/elensidealthin6d_FOX_uniform/extra_inputs.txt
@@ -1,1 +1,0 @@
-CHG1b_170523_8p75A_2-4-2kG_500V_75mA_hires_j-vs-r.txt


### PR DESCRIPTION
This PR fixes three bugs:

* The C/R build for the elens module (Issue #1064)
* One of the elens tests had a non-existent file in extra_inputs.txt, which is used to generate the Sixin.zip file. This broke BOINC build.
* The check of parameters for the FIXED target profile type in the SCATTER block was set to the wrong value.