### PR TITLE
Detect angular losses in exact drift

### DIFF
--- a/source/include/lostpart_exactDrift.f90
+++ b/source/include/lostpart_exactDrift.f90
@@ -1,0 +1,64 @@
+! start include/lostpart_exactDrift.f90
+  !-----------------------------------------------------------------------
+  ! initialise
+  llost=.false.
+  do j=1,napx
+    llostp(j)=.false.
+  end do
+
+  !-----------------------------------------------------------------------
+  ! check
+  if (do_coll) then
+    do j=1,napx
+      if(part_abs_turn(j).eq.0) then
+        llostp(j)=(yv1(j)**2 + yv2(j)**2).gt.c1e6
+        llost=llost.or.llostp(j)
+      end if
+    end do
+  else
+    do j=1,napx
+      llostp(j)=(yv1(j)**2 + yv2(j)**2).gt.c1e6
+      llost=llost.or.llostp(j)
+    end do
+  end if
+
+  !-----------------------------------------------------------------------
+  ! dump coordinates in case of losses
+  if(llost) then
+    ! report losses to user
+    call aperture_reportLoss(n,i,ix,.false.)
+    if(.not.apflag) call shuffleLostParticles
+    ! store old particle coordinates
+    ! necessary since aperture markers are downstream of lenses...
+    if ( lbacktracking ) call aperture_saveLastCoordinates(i,ix,-1)
+  end if
+
+  !-----------------------------------------------------------------------
+  ! closing stuff
+
+  if(napx.eq.0) then
+    write(lout,"(a)") ""
+    write(lout,"(a)") "************************"
+    write(lout,"(a)") "** ALL PARTICLES LOST **"
+    write(lout,"(a)") "**   PROGRAM STOPS    **"
+    write(lout,"(a)") "************************"
+    write(lout,"(a)") ""
+#ifdef FLUKA
+!skip postpr
+    nthinerr = 3000
+#else
+    nthinerr = 3001
+    nnuml = numl
+#endif
+    return
+  end if
+
+  ! stop tracking if no particle survives to this element
+  if(nthinerr.ne.0) return
+  ! A.Mereghetti and P.Garcia Ortega, for the FLUKA Team
+  ! last modified: 16-07-2018
+  if ( lbacktracking ) then
+     ! store infos of last aperture marker
+     if ( kape(ix).ne.0 ) call aperture_saveLastMarker(i,ix)
+  end if
+! end include/lostpart_exactDrift.f90

--- a/source/track_thick.f90
+++ b/source/track_thick.f90
@@ -593,7 +593,6 @@ subroutine thck6d(nthinerr)
   use mod_commons
   use mod_common_track
   use mod_common_da
-  use aperture
   use elens, only : elens_ktrack, elens_kick
   use cheby, only : cheby_ktrack, cheby_kick
   use mod_utils

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -140,6 +140,7 @@ subroutine thin4d(nthinerr)
       case (1)
         stracki=strack(i)
         if(iexact) then ! EXACT DRIFT
+#include "include/lostpart_exactDrift.f90"              
           do j=1,napx
             pz     = sqrt(c1e6 - (yv1(j)**2 + yv2(j)**2))*c1m3 ! pz/p0
             xv1(j) = xv1(j) + stracki*(yv1(j)/pz)
@@ -728,6 +729,7 @@ subroutine thin6d(nthinerr)
           call coll_doCollimator(stracki)
         else ! Normal SixTrack drifts
           if(iexact) then ! EXACT DRIFT
+#include "include/lostpart_exactDrift.f90"              
             do j=1,napx
               pz       = sqrt(c1e6 - (yv1(j)**2 + yv2(j)**2))*c1m3 ! pz/p0
               xv1(j)   = xv1(j)   + stracki*(yv1(j)/pz)

--- a/source/track_thin.f90
+++ b/source/track_thin.f90
@@ -39,7 +39,6 @@ subroutine thin4d(nthinerr)
   use mod_common_track
   use mod_common_da
   use bdex, only : bdex_enable
-  use aperture
   use elens, only : elens_ktrack, elens_kick
   use cheby, only : cheby_ktrack, cheby_kick
   use mod_utils
@@ -578,7 +577,6 @@ subroutine thin6d(nthinerr)
   use mod_commons
   use mod_common_track
   use mod_common_da
-  use aperture
   use elens, only : elens_ktrack, elens_kick
   use cheby, only : cheby_ktrack, cheby_kick
   use mod_utils


### PR DESCRIPTION
This PR aims at inserting a check on the integrity of the `sqrt` in the exact drift code, and it fixes #1067 .
If a particle has a transverse momentum which is too large (and hence the exact drift code would miserably fail), the particle is considered as lost.