### PR TITLE
Fix building with gcc >=10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ message(STATUS "Project Binary:   ${PROJECT_BINARY_DIR}")
 option(CRLIBM "Use correctly rounded libmath instead of system libmath" ON)
 option(SIXDA "Build differential algebra version (NOT dynamic aperture!)" ON)
 option(NAFF "Link to external NAFFlib for FMA" ON)
-option(DISTLIB "Link to external DISTlib for the beam distribution" ON)
+option(DISTLIB "Link to external DISTlib for the beam distribution" OFF)
 option(HASHLIB "Build the md5 hash library" ON)
 option(ZLIB "Build and link zlib. Needed for BOINC and ZIPF block" ON)
 
@@ -602,6 +602,14 @@ if(Fortran_COMPILER_NAME MATCHES "gfortran.*")
   set(CMAKE_Fortran_FLAGS "-frecord-marker=4 -fno-second-underscore -funroll-loops -std=f2008")
   set(PREPRO_EXEC  ${CMAKE_Fortran_COMPILER})
   set(PREPRO_FLAGS -cpp -E -P)
+
+  #get the compiler version
+  string(REGEX MATCH "^([0-9]*)" VERSION_TMP ${CMAKE_Fortran_COMPILER_VERSION})
+  set(GFORTRAN_VERSION "${CMAKE_MATCH_1}")
+  #fix for building with gfortran >= 10
+  if(${GFORTRAN_VERSION} GREATER_EQUAL 10)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-argument-mismatch")
+  endif(${GFORTRAN_VERSION} GREATER_EQUAL 10)
 
   if(${CMAKE_SYSTEM_PROCESSOR} MATCHES aarch64 )
     set (CMAKE_Fortran_FLAGS "-ffp-contract=off ${CMAKE_Fortran_FLAGS}")
@@ -1446,7 +1454,10 @@ endif()
 if(STATIC)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     get_filename_component(COMPILERDIR ${CMAKE_Fortran_COMPILER} DIRECTORY)
-    string(SUBSTRING ${CMAKE_Fortran_COMPILER_VERSION} 0 1 COMPILER_MAJOR_VERSION)
+    #Get the compiler version
+    string(REGEX MATCH "^([0-9]*)" VERSION_TMP ${CMAKE_Fortran_COMPILER_VERSION})
+    set(COMPILER_MAJOR_VERSION "${CMAKE_MATCH_1}")
+
     # search relative to the compiler executable
     find_library(lquadmath NAMES libquadmath.a PATHS "${COMPILERDIR}/../lib/gcc${COMPILER_MAJOR_VERSION}/" "${COMPILERDIR}/../lib/gcc/${COMPILER_MAJOR_VERSION}/")
     if (lquadmath)

--- a/source/constants.f90
+++ b/source/constants.f90
@@ -66,29 +66,29 @@ module numerical_constants
   ! Note: Transfer to real128 only works for GNU
 
 #ifdef SINGLE_MATH
-  real(kind=fPrec), parameter :: pi      = transfer(z'40490fdb',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2     = transfer(z'3fc90fdb',1.0_fPrec) ! 0.5_fPrec*pi
-  real(kind=fPrec), parameter :: twopi   = transfer(z'40c90fdb',1.0_fPrec) ! 2.0_fPrec*pi
-  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fe2dfc5',1.0_fPrec) ! sqrt(pi)
-  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fb8aa3b',1.0_fPrec) ! 1/log(2)
-  real(kind=fPrec), parameter :: rad     = transfer(z'3c8efa35',1.0_fPrec) ! pi/180.0_fPrec
+  real(kind=fPrec), parameter :: pi      = real(z'40490fdb',fPrec)
+  real(kind=fPrec), parameter :: pi2     = real(z'3fc90fdb',fPrec) ! 0.5_fPrec*pi
+  real(kind=fPrec), parameter :: twopi   = real(z'40c90fdb',fPrec) ! 2.0_fPrec*pi
+  real(kind=fPrec), parameter :: pisqrt  = real(z'3fe2dfc5',fPrec) ! sqrt(pi)
+  real(kind=fPrec), parameter :: inv_ln2 = real(z'3fb8aa3b',fPrec) ! 1/log(2)
+  real(kind=fPrec), parameter :: rad     = real(z'3c8efa35',fPrec) ! pi/180.0_fPrec
 #endif
 #ifdef DOUBLE_MATH
-  real(kind=fPrec), parameter :: pi      = transfer(z'400921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2     = transfer(z'3ff921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: twopi   = transfer(z'401921fb54442d18',1.0_fPrec)
-  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3ffc5bf891b4ef6a',1.0_fPrec)
-  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3ff71547652b82fe',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad     = transfer(z'3f91df46a2529d39',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi      = real(z'400921fb54442d18',fPrec)
+  real(kind=fPrec), parameter :: pi2     = real(z'3ff921fb54442d18',fPrec)
+  real(kind=fPrec), parameter :: twopi   = real(z'401921fb54442d18',fPrec)
+  real(kind=fPrec), parameter :: pisqrt  = real(z'3ffc5bf891b4ef6a',fPrec)
+  real(kind=fPrec), parameter :: inv_ln2 = real(z'3ff71547652b82fe',fPrec)
+  real(kind=fPrec), parameter :: rad     = real(z'3f91df46a2529d39',fPrec)
 #endif
 #ifdef QUAD_MATH
 #ifdef GFORTRAN
-  real(kind=fPrec), parameter :: pi      = transfer(z'4000921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: pi2     = transfer(z'3fff921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: twopi   = transfer(z'4001921fb54442d18469898cc51701b8',1.0_fPrec)
-  real(kind=fPrec), parameter :: pisqrt  = transfer(z'3fffc5bf891b4ef6aa79c3b0520d5db9',1.0_fPrec)
-  real(kind=fPrec), parameter :: inv_ln2 = transfer(z'3fff71547652b82fe1777d0ffda0d23a',1.0_fPrec)
-  real(kind=fPrec), parameter :: rad     = transfer(z'3ff91df46a2529d3915c1d8becdd290b',1.0_fPrec)
+  real(kind=fPrec), parameter :: pi      = real(z'4000921fb54442d18469898cc51701b8',fPrec)
+  real(kind=fPrec), parameter :: pi2     = real(z'3fff921fb54442d18469898cc51701b8',fPrec)
+  real(kind=fPrec), parameter :: twopi   = real(z'4001921fb54442d18469898cc51701b8',fPrec)
+  real(kind=fPrec), parameter :: pisqrt  = real(z'3fffc5bf891b4ef6aa79c3b0520d5db9',fPrec)
+  real(kind=fPrec), parameter :: inv_ln2 = real(z'3fff71547652b82fe1777d0ffda0d23a',fPrec)
+  real(kind=fPrec), parameter :: rad     = real(z'3ff91df46a2529d3915c1d8becdd290b',fPrec)
 #else
   real(kind=fPrec), parameter :: pi      = 3.141592653589793238462643383279502884197169399375105820974_fPrec
   real(kind=fPrec), parameter :: pi2     = 0.5_fPrec*pi

--- a/source/crlibm/crlibm_private.h
+++ b/source/crlibm/crlibm_private.h
@@ -42,7 +42,7 @@ development/debugging phase, until no type warning remains.
 /* setting the following variable adds variables and code for
    monitoring the performance.
    Note that sometimes only round to nearest is instrumented */
-#define EVAL_PERF  1
+#define EVAL_PERF 0
 
 
 #if EVAL_PERF==1


### PR DESCRIPTION
So I tried to build with gcc/gfortran 10, and it currently does not.

This pr should fix that.

I had to disable building with distlib since it fails to link. The problem there seems to be a lack of header guards so the same variables are now pulled in multiple times and you get the same symbols defined multiple times. That would need to be fixed by @tpersson since it is in a separate repo.


crlibm had a similar issue which came from some internal diagnostic code that we don't need, so I just disabled that. This also should speed things up a tiny bit.