### PR TITLE
Fix the time coordinate with geant4 collimation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 * Fix building with geant4 collimation with geant4 releases >= 10.06. PR #1060 (J. Molson)
 * Fix a mass miss-match with geant4 when entering non-ground state ions into geant4. PR #1062 (J. Molson)
 * Fix a crash with miss-matched format strings when writing the aperture losses file with geant4 enabled (and not FLUKA). PR #1062 (J. Molson)
+* Fix building with gcc >= 10. PR #1076 (J. Molson)
+* Fix 2 regressions in the K2 collimation cross section calculations from version 4 to 5. PR #1077 (J. Molson)
+* Fix the time coordinate when using geant4 based collimation. PR #1078 (J. Molson)
 
 **User Side Changes**
 
@@ -57,6 +60,7 @@
 * Always enable the EMD physics process in geant4. PR #1062 (J. Molson)
 * Use global id/parent/weight variables in the FLUKA coupling. PR #1062 (J. Molson)
 * Start to enable the ability to use collimation with thick lens lattices. PR #1062 (J. Molson)
+* Updated some physical constants to use their now fixed values. PR #1077 (J. Molson)
 
 ### Version 5.4.3 [19.12.2019] - Release
 

--- a/source/g4collimation/CollimationParticleGun.cpp
+++ b/source/g4collimation/CollimationParticleGun.cpp
@@ -24,7 +24,7 @@ void CollimationParticleGun::GeneratePrimaries(G4Event* anEvent)
 	anEvent->GetPrimaryVertex()->SetWeight(ThisWeight);
 }
 
-void CollimationParticleGun::SetParticleDetails(double x, double y, double px, double py, double pz, double e, double p, int pdgid, int q, double mass, double sx, double sy, double sz, double weight)
+void CollimationParticleGun::SetParticleDetails(double x, double y, double px, double py, double pz, double e, double p, double t, int pdgid, int q, double mass, double sx, double sy, double sz, double weight)
 {
 //UNITS MUST BE MeV, mm, rad!
 	if(do_debug)
@@ -130,11 +130,14 @@ void CollimationParticleGun::SetParticleDetails(double x, double y, double px, d
 	//The kinetic energy (Total energy - rest mass)
 	ParticleGun->SetParticleEnergy(e - mp);
 
-	//How to deal with longitudinal coordinate?
 	ParticleGun->SetParticlePosition(G4ThreeVector(x, y, 0));
 	ParticleGun->SetParticleMomentumDirection(G4ThreeVector(px,py,pz));
 //	ParticleGun->SetParticleMomentum(G4ThreeVector(px,py,pz));
 
+//	Internally g4 uses ns, so make sure to convert
+	ParticleGun->SetParticleTime(t*CLHEP::second);
+
+//	Set Spin polarisation
 	ParticleGun->SetParticlePolarization(G4ThreeVector(sx,sy,sz));
 
 	//Set weight

--- a/source/g4collimation/CollimationParticleGun.h
+++ b/source/g4collimation/CollimationParticleGun.h
@@ -13,7 +13,7 @@ public:
 	~CollimationParticleGun();
 
 	void GeneratePrimaries(G4Event*);
-	void SetParticleDetails(double x, double y, double xp, double yp, double zp, double e, double p, int pdgid, int q, double mass, double sx, double sy, double sz, double weight);
+	void SetParticleDetails(double x, double y, double xp, double yp, double zp, double e, double p, double t, int pdgid, int q, double mass, double sx, double sy, double sz, double weight);
 	void SetReferenceEnergy(double);
 	double GetReferenceEnergy();
 	void SetDebug(bool);

--- a/source/g4collimation/G4Interface.cpp
+++ b/source/g4collimation/G4Interface.cpp
@@ -306,6 +306,9 @@ extern "C" void g4_add_particle(double* x, double* y, double* xp, double* yp, do
 	in_particle.sy = *sy;
 	in_particle.sz = *sz;
 
+//  This should now be in seconds
+	in_particle.t = *sigmv;
+
 	input_particles.push_back(in_particle);
 
 	if(*partID > MaximumParticleID)
@@ -322,7 +325,7 @@ extern "C" void g4_collimate()
 	//Update the gun with this particle's details
 	for(size_t n=0; n < input_particles.size(); n++)
 	{
-		part->SetParticleDetails(input_particles.at(n).x, input_particles.at(n).y, input_particles.at(n).px, input_particles.at(n).py, input_particles.at(n).pz, input_particles.at(n).e, input_particles.at(n).p, input_particles.at(n).pdgid, input_particles.at(n).q, input_particles.at(n).m, input_particles.at(n).sx, input_particles.at(n).sy, input_particles.at(n).sz,input_particles.at(n).weight);
+		part->SetParticleDetails(input_particles.at(n).x, input_particles.at(n).y, input_particles.at(n).px, input_particles.at(n).py, input_particles.at(n).pz, input_particles.at(n).e, input_particles.at(n).p, input_particles.at(n).t, input_particles.at(n).pdgid, input_particles.at(n).q, input_particles.at(n).m, input_particles.at(n).sx, input_particles.at(n).sy, input_particles.at(n).sz,input_particles.at(n).weight);
 
 		//Tell the "tracking" about the parent particle ID for tracking secondaries
 		tracking->SetParticleID(input_particles.at(n).id);
@@ -376,7 +379,7 @@ double py = output_particles.at(*j).py;
 *sy = output_particles.at(*j).sy;
 *sz = output_particles.at(*j).sz;
 
-//time, must be converted for using with sigmv
+//time, must be converted for using with sigmv (done on the Sixtrack fortran side)
 *sigmv  = output_particles.at(*j).t;
 
 


### PR DESCRIPTION
I finally enable the conversion of sigmv to time inside geant4.

dumping out the longitudinal phase space for a test bunch over 1000 turns makes the same pattern as for normal tracking.