### PR TITLE
Move the nucleon/energy logging in k2 collimation to after the single sided collimator check

### DIFF
--- a/source/coll_k2.f90
+++ b/source/coll_k2.f90
@@ -180,11 +180,6 @@ subroutine k2coll_collimate(icoll, iturn, ie, c_length, c_rotation, c_aperture, 
     xp_flk = zero
     yp_flk = zero
 
-! Log input energy + nucleons as per the FLUKA coupling
-    nnuc0   = nnuc0 + naa(j)
-    ien0    = ien0 + rcp(j) * c1e3
-
-
     ! Transform particle coordinates to get into collimator coordinate  system
     ! First do rotation into collimator frame
     x  =  x_in(j)*cRot + sRot*y_in(j)
@@ -196,6 +191,11 @@ subroutine k2coll_collimate(icoll, iturn, ie, c_length, c_rotation, c_aperture, 
     if(onesided .and. x < zero .and. (icoll /= ipencil .or. iturn /= 1)) then
       cycle
     end if
+
+! Log input energy + nucleons as per the FLUKA coupling
+    nnuc0   = nnuc0 + naa(j)
+    ien0    = ien0 + rcp(j) * c1e3
+
 
     ! Now mirror at the horizontal axis for negative X offset
     if(x < zero) then


### PR DESCRIPTION
In the previous PR I had the saving of the incoming nucleon count + energy at the start of the particle loop. Following this is a check for 1 sided collimators, that if a particle fails, it skips to the next particle. It would then never balance out the outgoing energy at the end of the particle loop leading to crazy energy losses in the fort.208 file.

This fixes it by just moving the logging to after the single side check.