### PR TITLE
Add support for dealing with neutral particles in G4/FLUKA

### DIFF
--- a/source/collimation.f90
+++ b/source/collimation.f90
@@ -434,7 +434,7 @@ subroutine coll_init
   ! g4_physics = 0
 
   call g4_collimation_init(e0, rnd_seed, g4_recut, g4_aecut, g4_rcut, g4_rangecut_mm, g4_v0, trim(g4_phys_str), &
-    g4_debug, g4_keep_stable, g4_edep)
+    g4_debug, g4_keep_stable, g4_edep, g4_neutral)
 #endif
 
   write (lout,"(a)") ""
@@ -3356,6 +3356,12 @@ subroutine coll_doCollimator_Geant4(c_aperture,c_rotation,c_length,onesided)
       part_hit_flag, part_abs_flag, part_impact(j), part_indiv(j), part_linteract(j), spin_x(j), spin_y(j), spin_z(j))
 
     pstop (j) = .false.
+
+    if(nqq(j) .eq. 0) then
+      mtc (j) = zero
+    else
+      mtc (j) = (nqq(j)*nucm0)/(qq0*nucm(j))  ! hisix: mass to charge
+    endif
 
 !! Rotate back into the accelerator frame
     x_tmp   = rcx(j)

--- a/source/g4collimation/CollimationTrackingAction.cpp
+++ b/source/g4collimation/CollimationTrackingAction.cpp
@@ -55,7 +55,8 @@ void CollimationTrackingAction::PostUserTrackingAction(const G4Track* Track)
 	G4StepStatus Tstatus = Track->GetStep()->GetPostStepPoint()->GetStepStatus();
 
 //Extraction plane and charge cut
-    if (Tstatus == fWorldBoundary && Track->GetParticleDefinition()->GetPDGCharge() != 0)
+    //if (Tstatus == fWorldBoundary && Track->GetParticleDefinition()->GetPDGCharge() != 0)
+    if (Tstatus == fWorldBoundary)
 	{
 		bool keep_this = false;
 
@@ -196,6 +197,11 @@ void CollimationTrackingAction::SetParticlesToKeep(std::set<int>* iset)
 void CollimationTrackingAction::SetKeepStableParticles(bool flag)
 {
 	KeepOnlyStable = flag;
+}
+
+void CollimationTrackingAction::SetKeepNeutrals(bool flag)
+{
+	KeepNeutrals = flag;
 }
 
 void CollimationTrackingAction::SetParticleID(int32_t in)

--- a/source/g4collimation/CollimationTrackingAction.cpp
+++ b/source/g4collimation/CollimationTrackingAction.cpp
@@ -7,7 +7,7 @@
 
 #include "G4Proton.hh"
 
-CollimationTrackingAction::CollimationTrackingAction() : do_debug(false),KeepOnlyStable(false),parentID(0),partID_max(0)
+CollimationTrackingAction::CollimationTrackingAction() : do_debug(false),KeepNeutrals(false),KeepOnlyStable(false),parentID(0),partID_max(0)
 {}
 
 void CollimationTrackingAction::PreUserTrackingAction(const G4Track*)
@@ -92,6 +92,12 @@ void CollimationTrackingAction::PostUserTrackingAction(const G4Track* Track)
 			{
 				std::cout << "RETURN STABLE> Not returning particle: " << Track->GetParticleDefinition()->GetParticleName() << "\t" << Track->GetParticleDefinition()->GetPDGEncoding() << "\t" << !Track->GetParticleDefinition()->GetPDGStable() << std::endl;
 			}
+		}
+
+//Check if the particle is neutral and if we are keeping them or not
+		if(Track->GetParticleDefinition()->GetPDGCharge() != 0 && KeepNeutrals != true)
+		{
+			keep_this = false;
 		}
 
 //Energy cut

--- a/source/g4collimation/CollimationTrackingAction.h
+++ b/source/g4collimation/CollimationTrackingAction.h
@@ -21,8 +21,10 @@ public:
 	void SetDebug(bool flag);
 	void SetParticlesToKeep(std::set<int>*);
 	void SetKeepStableParticles(bool);
+	void SetKeepNeutrals(bool);
 
 	bool do_debug;
+	bool KeepNeutrals;
 	bool KeepOnlyStable;
 
 	CollimationEventAction* EventAction;

--- a/source/g4collimation/G4Interface.cpp
+++ b/source/g4collimation/G4Interface.cpp
@@ -54,7 +54,7 @@ These include:
 2: The Physics to use.
 3: A particle source.
 */
-extern "C" void g4_collimation_init(double* ReferenceE, int* seed, double* recut, double* aecut, double* rcut, double* rangecut_mm, double* v0, char* PhysicsSelect, bool* g4_debug, bool* g4_keep_stable, bool *DoEnergyDeposition)
+extern "C" void g4_collimation_init(double* ReferenceE, int* seed, double* recut, double* aecut, double* rcut, double* rangecut_mm, double* v0, char* PhysicsSelect, bool* g4_debug, bool* g4_keep_stable, bool *DoEnergyDeposition, bool *g4_neutral)
 {
 
 	std::cout << "GEANT4> Using seed " << *seed << " in geant4 C++" << std::endl;
@@ -173,9 +173,11 @@ extern "C" void g4_collimation_init(double* ReferenceE, int* seed, double* recut
 
 	if(*g4_debug)
 	{
-		std::cout << "GEANT4> keep stable particles: " << *g4_keep_stable << std::endl;
+		std::cout << "GEANT4> keep stable particles:  " << *g4_keep_stable << std::endl;
+		std::cout << "GEANT4> keep neutral particles: " << *g4_neutral     << std::endl;
 	}
 	tracking->SetKeepStableParticles(*g4_keep_stable);
+	tracking->SetKeepNeutrals(*g4_neutral);
 	tracking->SetDebug(*g4_debug);
 
 	stack = new CollimationStackingAction();

--- a/source/geant4.f90
+++ b/source/geant4.f90
@@ -21,6 +21,7 @@ module geant4
 
   logical(kind=C_BOOL) :: g4_enabled     = .false.
   logical(kind=C_BOOL) :: g4_debug       = .false.
+  logical(kind=C_BOOL) :: g4_neutral     = .false. !Keep neutral particles or not
   logical(kind=C_BOOL) :: g4_keep_stable = .false.
 
 
@@ -55,7 +56,7 @@ module geant4
 !void g4_collimation_init_(double* ReferenceE, int* seed, double* recut, double* aecut, double* rcut,
 !int* PhysicsSelect, bool* g4_debug, bool* g4_keep_stable)
   subroutine g4_collimation_init(ReferenceE, seed, recut, aecut, rcut, rangecut_mm, v0, PhysicsSelect, g4_debug, g4_keep_stable, &
-& g4_edep) &
+& g4_edep, g4_neutral) &
 & bind(C,name="g4_collimation_init")
     use, intrinsic :: iso_c_binding
     implicit none
@@ -71,6 +72,7 @@ module geant4
     logical(kind=C_BOOL),         intent(in) :: g4_debug
     logical(kind=C_BOOL),         intent(in) :: g4_keep_stable
     logical(kind=C_BOOL),         intent(in) :: g4_edep
+    logical(kind=C_BOOL),         intent(in) :: g4_neutral
   end subroutine g4_collimation_init
 
 !void g4_add_collimator_(char* name, char* material, double* length, double* aperture, double* rotation, double* offset)
@@ -298,6 +300,8 @@ subroutine geant4_parseInputLine(inLine,iErr)
       call g4_keep_id(g4_keep)
     end if
 
+  else if(lnSplit(1) == 'NEUTRAL') then
+    g4_neutral = .true.
 
 !Physics list to use string
   else if(lnSplit(1) == 'PHYSICS') then

--- a/source/mod_fluka.f90
+++ b/source/mod_fluka.f90
@@ -1081,7 +1081,11 @@ subroutine kernel_fluka_element( nturn, i, ix )
          dpsv  (j) = (ejfv(j)*(nucm0/nucm(j))-e0f)/e0f         ! hisix: new delta
          oidpsv(j) = one/(one+dpsv(j))
          dpsv1 (j) = (dpsv(j)*c1e3)*oidpsv(j)
-         mtc     (j) = (nqq(j)*nucm0)/(qq0*nucm(j))            ! hisix: mass to charge
+         if(nqq(j) .eq. 0) then
+           mtc (j) = zero
+         else
+           mtc (j) = (nqq(j)*nucm0)/(qq0*nucm(j))              ! hisix: mass to charge
+         endif
          moidpsv (j) = mtc(j)*oidpsv(j)                        ! hisix
          omoidpsv(j) = c1e3*((one-mtc(j))*oidpsv(j))           ! hisix
          nnuc1       = nnuc1 + naa(j)                          ! outcoming nucleons


### PR DESCRIPTION
Fairly simple...


We set mtc = 0 for neutrals.

This may have unintended outcomes if you don't know what you're doing, but you have to manually turn it on in both codes.

The fluka server code has already been updated to support this.